### PR TITLE
fix: resolve resource URL mismatch caused by content-hash dedup

### DIFF
--- a/server/init_db.sql
+++ b/server/init_db.sql
@@ -28,7 +28,7 @@ CREATE INDEX idx_pages_title_trgm ON pages USING gin (title gin_trgm_ops);
 CREATE TABLE resources (
     id BIGSERIAL PRIMARY KEY,
     url TEXT NOT NULL,
-    content_hash CHAR(64) NOT NULL UNIQUE,
+    content_hash CHAR(64) NOT NULL,
     resource_type VARCHAR(20),
     file_path TEXT NOT NULL,
     file_size BIGINT,

--- a/server/internal/api/rewriter.go
+++ b/server/internal/api/rewriter.go
@@ -47,7 +47,6 @@ func rewriteResourcePathsWithResources(html string, pageID int64, timestamp stri
 		}
 
 		// 处理协议相对 URL（如 //example.com/path）
-		// 从完整 URL 中移除协议部分
 		protocolRelativeURL := strings.TrimPrefix(resource.URL, "https:")
 		protocolRelativeURL = strings.TrimPrefix(protocolRelativeURL, "http:")
 
@@ -75,14 +74,12 @@ func rewriteResourcePathsWithResources(html string, pageID int64, timestamp stri
 		}
 
 		// 处理相对路径
-		// 从资源 URL 中提取文件名
 		parsedURL, err := url.Parse(resource.URL)
 		if err != nil {
 			continue
 		}
 		filename := path.Base(parsedURL.Path)
 
-		// 替换 ./filename 和 filename 格式
 		relativePatterns := []string{
 			`src=["']\.?/?` + regexp.QuoteMeta(filename) + `["']`,
 			`href=["']\.?/?` + regexp.QuoteMeta(filename) + `["']`,
@@ -100,11 +97,9 @@ func rewriteResourcePathsWithResources(html string, pageID int64, timestamp stri
 			})
 		}
 
-		// 处理以 / 开头的绝对路径（如 /assets/style.css）
-		// 提取资源URL的路径部分
+		// 处理以 / 开头的绝对路径
 		resourcePath := parsedURL.Path
 		if resourcePath != "" {
-			// 构建带查询参数的完整路径（如果有的话）
 			pathWithQuery := resourcePath
 			if parsedURL.RawQuery != "" {
 				pathWithQuery = resourcePath + "?" + parsedURL.RawQuery
@@ -115,7 +110,6 @@ func rewriteResourcePathsWithResources(html string, pageID int64, timestamp stri
 				`src=["']` + escapedPath + `["']`,
 				`href=["']` + escapedPath + `["']`,
 				`url\(["']?` + escapedPath + `["']?\)`,
-				// 处理HTML实体编码的引号：url(&quot;/path&quot;)
 				`url\(&quot;` + escapedPath + `&quot;\)`,
 			}
 

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -100,35 +100,48 @@ func (d *Deduplicator) ProcessResource(url, resourceType, base64Content string, 
 		}
 	}
 
-	// 检查资源是否已存在
-	existing, err := d.db.GetResourceByHash(hash)
+	// 检查是否已有相同 URL 的资源记录
+	existingByURL, err := d.db.GetResourceByURL(url)
 	if err != nil {
-		return 0, nil, fmt.Errorf("db query failed: %w", err)
+		return 0, nil, fmt.Errorf("db query by url failed: %w", err)
 	}
 
-	if existing != nil {
-		// 资源已存在，更新最后见到时间
-		log.Printf("Resource exists (hash: %s), reusing: %s", hash[:16], url)
-		if err := d.db.UpdateResourceLastSeen(existing.ID); err != nil {
+	if existingByURL != nil {
+		// 同 URL 已存在，更新最后见到时间
+		log.Printf("Resource exists by URL (hash: %s), reusing: %s", hash[:16], url)
+		if err := d.db.UpdateResourceLastSeen(existingByURL.ID); err != nil {
 			return 0, nil, err
 		}
-		d.cache.Store(url, &resourceCacheEntry{resourceID: existing.ID, data: data, cachedAt: time.Now()})
-		return existing.ID, data, nil
+		d.cache.Store(url, &resourceCacheEntry{resourceID: existingByURL.ID, data: data, cachedAt: time.Now()})
+		return existingByURL.ID, data, nil
 	}
 
-	// 新资源，保存文件
-	filePath, err := d.storage.SaveResource(data, hash, resourceType)
+	// 检查是否有相同哈希的资源（不同 URL，内容相同）
+	existingByHash, err := d.db.GetResourceByHash(hash)
 	if err != nil {
-		return 0, nil, fmt.Errorf("save failed: %w", err)
+		return 0, nil, fmt.Errorf("db query by hash failed: %w", err)
 	}
 
-	// 创建数据库记录
+	var filePath string
+	if existingByHash != nil {
+		// 内容相同但 URL 不同，复用文件，创建新 DB 记录
+		filePath = existingByHash.FilePath
+		log.Printf("Same content (hash: %s) different URL, reusing file: %s", hash[:16], url)
+	} else {
+		// 全新资源，保存文件
+		filePath, err = d.storage.SaveResource(data, hash, resourceType)
+		if err != nil {
+			return 0, nil, fmt.Errorf("save failed: %w", err)
+		}
+	}
+
+	// 创建数据库记录（每个 URL 一条记录）
 	resourceID, err := d.db.CreateResource(url, hash, resourceType, filePath, int64(len(data)))
 	if err != nil {
 		return 0, nil, fmt.Errorf("db insert failed: %w", err)
 	}
 
-	log.Printf("New resource saved (hash: %s): %s", hash[:16], url)
+	log.Printf("New resource record (hash: %s): %s", hash[:16], url)
 	d.cache.Store(url, &resourceCacheEntry{resourceID: resourceID, data: data, cachedAt: time.Now()})
 	return resourceID, data, nil
 }

--- a/server/migrations/006_drop_content_hash_unique.sql
+++ b/server/migrations/006_drop_content_hash_unique.sql
@@ -1,0 +1,4 @@
+-- 去掉 content_hash 唯一约束
+-- 允许同一内容（相同哈希）对应多个 URL 的资源记录
+-- 文件层面仍按哈希去重，不重复存储
+ALTER TABLE resources DROP CONSTRAINT resources_content_hash_key;


### PR DESCRIPTION
## Problem

Archived pages were missing CSS/JS/images (404) when the same resource content was previously stored under a different URL.

Root cause: `resources.content_hash` had a UNIQUE constraint. When two different URLs (e.g. `v2ex.com/style.css` and `www.v2ex.com/style.css`) served identical content, only the first URL got a DB record. The HTML rewriter wrote proxy paths using the second URL, but the proxy couldn't find it in the DB.

## Fix

- Drop UNIQUE constraint on `resources.content_hash` — allow multiple URL records pointing to the same file
- `ProcessResource` now matches by URL first; when only the hash matches, it reuses the file on disk but creates a new DB record with the current URL
- Update `init_db.sql` to reflect the schema change
- Add migration `006_drop_content_hash_unique.sql`

## Migration

```sql
ALTER TABLE resources DROP CONSTRAINT resources_content_hash_key;
```

Existing pages are unaffected. New captures will create correct per-URL records.