### PR TITLE
feat: add optional HTTP Basic Auth

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -104,6 +104,7 @@ npm run build
 | `DB_SSLMODE` | `disable` | SSL 模式 |
 | `SERVER_PORT` | `8080` | HTTP 服务端口 |
 | `DATA_DIR` | `./data` | HTML 和资源的存储目录 |
+| `AUTH_PASSWORD` | *（空）* | HTTP Basic Auth 密码（为空时关闭认证，用户名固定为 `wayback`） |
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Environment variables (or `.env` file in `server/`):
 | `DB_SSLMODE` | `disable` | SSL mode |
 | `SERVER_PORT` | `8080` | HTTP server port |
 | `DATA_DIR` | `./data` | Storage directory for HTML and resources |
+| `AUTH_PASSWORD` | *(empty)* | HTTP Basic Auth password (disabled when empty, username: `wayback`) |
 
 ## API
 

--- a/browser/src/archiver.ts
+++ b/browser/src/archiver.ts
@@ -9,13 +9,21 @@ import { CaptureData, ArchiveResponse } from './types';
 export function sendToServer(captureData: CaptureData): Promise<ArchiveResponse> {
   console.log('[Wayback] >>> Sending to server...');
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  };
+
+  // Add Basic Auth header if password is configured
+  if (CONFIG.AUTH_PASSWORD) {
+    const credentials = btoa(`wayback:${CONFIG.AUTH_PASSWORD}`);
+    headers['Authorization'] = `Basic ${credentials}`;
+  }
+
   return new Promise((resolve, reject) => {
     GM_xmlhttpRequest({
       method: 'POST',
       url: CONFIG.SERVER_URL,
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers,
       data: JSON.stringify(captureData),
       onload: (response) => {
         if (response.status === 200) {
@@ -41,13 +49,21 @@ export function sendToServer(captureData: CaptureData): Promise<ArchiveResponse>
 export function updateOnServer(pageId: number, captureData: CaptureData): Promise<ArchiveResponse> {
   console.log('[Wayback] >>> Updating page', pageId, 'on server...');
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  };
+
+  // Add Basic Auth header if password is configured
+  if (CONFIG.AUTH_PASSWORD) {
+    const credentials = btoa(`wayback:${CONFIG.AUTH_PASSWORD}`);
+    headers['Authorization'] = `Basic ${credentials}`;
+  }
+
   return new Promise((resolve, reject) => {
     GM_xmlhttpRequest({
       method: 'PUT',
       url: `${CONFIG.SERVER_URL}/${pageId}`,
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers,
       data: JSON.stringify(captureData),
       onload: (response) => {
         if (response.status === 200) {

--- a/browser/src/config.ts
+++ b/browser/src/config.ts
@@ -2,6 +2,7 @@
 
 export const CONFIG = {
   SERVER_URL: 'http://localhost:8080/api/archive',
+  AUTH_PASSWORD: '',                    // Set this to enable HTTP Basic Auth
   DOM_STABILITY_DELAY: 2000,        // ms to wait before starting capture
   MUTATION_OBSERVER_TIMEOUT: 10000, // max ms to wait for DOM stability
   DOM_STABLE_TIME: 1000,            // ms of no mutations to consider DOM stable

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,7 +5,6 @@
 data/
 # Build artifacts
 server/wayback-server
-server
 
 # Logs
 *.log

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gin-gonic/gin"
+	"wayback/internal/api"
+	"wayback/internal/config"
+	"wayback/internal/database"
+	"wayback/internal/storage"
+)
+
+func main() {
+	// 加载配置
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// 连接数据库
+	db, err := database.New(
+		cfg.Database.Host,
+		fmt.Sprintf("%d", cfg.Database.Port),
+		cfg.Database.User,
+		cfg.Database.Password,
+		cfg.Database.DBName,
+	)
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer db.Close()
+	log.Println("Database connected")
+
+	// 初始化存储
+	fileStorage := storage.NewFileStorage(cfg.Storage.DataDir)
+
+	// 初始化去重器
+	dedup := storage.NewDeduplicator(db, fileStorage)
+
+	// 初始化 API 处理器
+	handler := api.NewHandler(dedup, db, cfg.Storage.DataDir)
+
+	// 设置 Gin
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.Default()
+	api.SetupRoutes(r, handler, &cfg.Auth)
+
+	// 启动服务器
+	log.Printf("Server starting on port %d", cfg.Server.Port)
+	if err := r.Run(fmt.Sprintf(":%d", cfg.Server.Port)); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -4,21 +4,30 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"wayback/internal/config"
 )
 
 // SetupRoutes 设置路由
-func SetupRoutes(r *gin.Engine, handler *Handler) {
+func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig) {
 	// CORS 中间件
 	r.Use(func(c *gin.Context) {
 		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, PUT, GET, DELETE, OPTIONS")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(http.StatusNoContent)
 			return
 		}
 		c.Next()
 	})
+
+	// Basic Auth 中间件（如果启用）
+	if authCfg.Enabled() {
+		accounts := gin.Accounts{
+			config.AuthUsername: authCfg.Password,
+		}
+		r.Use(gin.BasicAuth(accounts))
+	}
 
 	// Web UI
 	r.StaticFile("/", "./web/index.html")

--- a/server/internal/api/routes_test.go
+++ b/server/internal/api/routes_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"wayback/internal/config"
+)
+
+func setupAuthRouter(authCfg *config.AuthConfig) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	handler := &Handler{} // minimal handler, routes not hit
+
+	SetupRoutes(r, handler, authCfg)
+	return r
+}
+
+func TestRoutes_NoAuth_AllowsAccess(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	// Should not be 401
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("expected no auth challenge, got 401")
+	}
+}
+
+func TestRoutes_WithAuth_RejectsNoCredentials(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: "secret"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without credentials, got %d", w.Code)
+	}
+}
+
+func TestRoutes_WithAuth_AcceptsValidCredentials(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: "secret"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.SetBasicAuth("wayback", "secret")
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("expected access with valid credentials, got 401")
+	}
+}
+
+func TestRoutes_WithAuth_RejectsWrongPassword(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: "secret"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.SetBasicAuth("wayback", "wrong")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong password, got %d", w.Code)
+	}
+}
+
+func TestRoutes_WithAuth_RejectsWrongUsername(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: "secret"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.SetBasicAuth("admin", "secret")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong username, got %d", w.Code)
+	}
+}
+
+func TestRoutes_CORS_IncludesAuthorizationHeader(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/api/archive", nil)
+	r.ServeHTTP(w, req)
+
+	allowHeaders := w.Header().Get("Access-Control-Allow-Headers")
+	if allowHeaders == "" {
+		t.Fatal("Access-Control-Allow-Headers not set")
+	}
+	if !containsSubstring(allowHeaders, "Authorization") {
+		t.Errorf("CORS Allow-Headers = %q, want it to include Authorization", allowHeaders)
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Database DatabaseConfig
 	Server   ServerConfig
 	Storage  StorageConfig
+	Auth     AuthConfig
 }
 
 // DatabaseConfig holds database connection settings
@@ -33,6 +34,18 @@ type StorageConfig struct {
 	DataDir string
 }
 
+// AuthConfig holds authentication settings
+type AuthConfig struct {
+	Password string
+}
+
+const AuthUsername = "wayback"
+
+// Enabled returns true if authentication is enabled
+func (a *AuthConfig) Enabled() bool {
+	return a.Password != ""
+}
+
 // LoadFromEnv loads configuration from environment variables with sensible defaults
 func LoadFromEnv() (*Config, error) {
 	cfg := &Config{
@@ -49,6 +62,9 @@ func LoadFromEnv() (*Config, error) {
 		},
 		Storage: StorageConfig{
 			DataDir: getEnv("DATA_DIR", "./data"),
+		},
+		Auth: AuthConfig{
+			Password: getEnv("AUTH_PASSWORD", ""),
 		},
 	}
 


### PR DESCRIPTION
## 概述

通过环境变量 `AUTH_PASSWORD` 为所有路由添加可选的 HTTP Basic Auth 认证。默认关闭，设置密码后启用。

## 改动

- **server/internal/config** — 新增 `AuthConfig`，从 `AUTH_PASSWORD` 读取密码，`Enabled()` 判断是否启用
- **server/internal/api/routes.go** — CORS 允许 `Authorization` header；启用时插入 `gin.BasicAuth` 中间件（用户名固定 `wayback`）
- **server/cmd/server/main.go** — 传递 auth 配置到路由
- **browser/src/config.ts** — 新增 `AUTH_PASSWORD` 配置项
- **browser/src/archiver.ts** — 密码非空时自动附加 `Authorization: Basic ...` header
- **server/internal/api/routes_test.go** — 6 个测试用例覆盖：无认证访问、拒绝无凭据、接受正确凭据、拒绝错误密码、拒绝错误用户名、CORS header 包含 Authorization

## 使用方式

```bash
# 启用认证
AUTH_PASSWORD=secret ./wayback-server

# 浏览器访问弹出认证对话框，输入 wayback / secret
# Tampermonkey 脚本在 config.ts 中设置 AUTH_PASSWORD 即可
```

不设置 `AUTH_PASSWORD` 时行为与之前完全一致。