### PR TITLE
fix: neutralize vue-recycle-scroller virtual scroll in static archive

### DIFF
--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -81,6 +81,14 @@ func injectArchiveHeader(html string, page *models.Page) string {
 		height: auto !important;
 		min-height: 100%% !important;
 	}
+	/* 修复 vue-recycle-scroller 虚拟滚动：移除 transform 定位，让 items 自然排列 */
+	.vue-recycle-scroller__item-wrapper {
+		min-height: 0 !important;
+	}
+	.vue-recycle-scroller__item-view {
+		position: static !important;
+		transform: none !important;
+	}
 </style>
 `, escapeHTML(page.URL), capturedTime)
 


### PR DESCRIPTION
## 问题

微博等使用 `vue-recycle-scroller` 虚拟滚动的页面，在 DOM update 后归档快照顶部出现大片空白。

## 原因

`vue-recycle-scroller` 通过 `transform: translateY()` 定位 items，用 `min-height` 撑开容器。静态归档模式下 JS 被禁用，回收的 items 停留在 `translateY(-9999px)`，可见 items 从 `translateY(7042px)` 开始，导致前 7000+ px 全是空白。

## 修复

在注入的通用样式中：
- `.vue-recycle-scroller__item-view`: `position: static` + `transform: none`，让 items 自然流式排列
- `.vue-recycle-scroller__item-wrapper`: `min-height: 0`，移除虚拟滚动容器的人为高度

通用修复，对所有使用该虚拟滚动库的归档页面生效。

## 验证

- page 425 (weibo.com) 修复前顶部 ~7000px 空白，修复后 items 紧密排列
- page 408 (weibo.com) 回归测试正常
- `go test ./...` 全部通过