### PR TITLE
perf: HTML rewrite 性能优化 (46s → 4s)

### DIFF
--- a/browser/src/archiver.ts
+++ b/browser/src/archiver.ts
@@ -25,6 +25,7 @@ export function sendToServer(captureData: CaptureData): Promise<ArchiveResponse>
       url: CONFIG.SERVER_URL,
       headers,
       data: JSON.stringify(captureData),
+      timeout: CONFIG.REQUEST_TIMEOUT,
       onload: (response) => {
         if (response.status === 200) {
           const result: ArchiveResponse = JSON.parse(response.responseText);
@@ -38,6 +39,10 @@ export function sendToServer(captureData: CaptureData): Promise<ArchiveResponse>
       onerror: (error) => {
         console.error('[Wayback] ✗ Error:', error);
         reject(error);
+      },
+      ontimeout: () => {
+        console.error('[Wayback] ✗ Request timed out');
+        reject(new Error('Archive request timed out'));
       }
     });
   });
@@ -47,7 +52,9 @@ export function sendToServer(captureData: CaptureData): Promise<ArchiveResponse>
  * Sends an update request for an existing page.
  */
 export function updateOnServer(pageId: number, captureData: CaptureData): Promise<ArchiveResponse> {
-  console.log('[Wayback] >>> Updating page', pageId, 'on server...');
+  const dataSize = JSON.stringify(captureData).length;
+  console.log(`[Wayback] >>> Updating page ${pageId} on server (${dataSize} bytes)...`);
+  const startTime = Date.now();
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json'
@@ -65,19 +72,27 @@ export function updateOnServer(pageId: number, captureData: CaptureData): Promis
       url: `${CONFIG.SERVER_URL}/${pageId}`,
       headers,
       data: JSON.stringify(captureData),
+      timeout: CONFIG.REQUEST_TIMEOUT,
       onload: (response) => {
+        const elapsed = Date.now() - startTime;
         if (response.status === 200) {
           const result: ArchiveResponse = JSON.parse(response.responseText);
-          console.log('[Wayback] ✓ Updated:', result.action);
+          console.log(`[Wayback] ✓ Updated: ${result.action} (took ${elapsed}ms)`);
           resolve(result);
         } else {
-          console.error('[Wayback] ✗ Update failed:', response.status);
+          console.error(`[Wayback] ✗ Update failed: ${response.status} (took ${elapsed}ms)`);
           reject(new Error(`Update failed: ${response.status}`));
         }
       },
       onerror: (error) => {
-        console.error('[Wayback] ✗ Update error:', error);
+        const elapsed = Date.now() - startTime;
+        console.error(`[Wayback] ✗ Update error (took ${elapsed}ms):`, error);
         reject(error);
+      },
+      ontimeout: () => {
+        const elapsed = Date.now() - startTime;
+        console.error(`[Wayback] ✗ Update timed out after ${elapsed}ms`);
+        reject(new Error('Update request timed out'));
       }
     });
   });

--- a/browser/src/config.ts
+++ b/browser/src/config.ts
@@ -10,4 +10,5 @@ export const CONFIG = {
   UPDATE_DEBOUNCE_DELAY: 5000,      // ms of no DOM changes before triggering an update
   UPDATE_MIN_MUTATIONS: 10,         // minimum mutation count before triggering an update
   UPDATE_MONITOR_TIMEOUT: 30000,    // max ms to keep monitoring DOM changes
+  REQUEST_TIMEOUT: 300000,          // max ms to wait for server response (5 minutes)
 } as const;

--- a/browser/src/page-freezer.ts
+++ b/browser/src/page-freezer.ts
@@ -128,7 +128,15 @@ export function waitForDOMStable(
 ): Promise<void> {
   return new Promise((resolve) => {
     let timer: number | null = null;
+    let timeoutId: number | null = null;
     let lastMutation = Date.now();
+    let resolved = false;
+
+    const cleanup = () => {
+      if (timer) nativeClearTimeout(timer);
+      if (timeoutId) nativeClearTimeout(timeoutId);
+      observer.disconnect();
+    };
 
     const observer = new MutationObserver(() => {
       lastMutation = Date.now();
@@ -136,12 +144,13 @@ export function waitForDOMStable(
 
       timer = nativeSetTimeout(() => {
         const elapsed = Date.now() - lastMutation;
-        if (elapsed >= stableTime) {
-          observer.disconnect();
+        if (elapsed >= stableTime && !resolved) {
+          resolved = true;
+          cleanup();
           console.log('[Wayback] DOM stable after', elapsed, 'ms');
           resolve();
         }
-      }, stableTime);
+      }, stableTime) as unknown as number;
     });
 
     observer.observe(document.body, {
@@ -152,10 +161,13 @@ export function waitForDOMStable(
     });
 
     // Timeout protection
-    nativeSetTimeout(() => {
-      observer.disconnect();
-      console.log('[Wayback] DOM stability timeout reached');
-      resolve();
-    }, timeout);
+    timeoutId = nativeSetTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        console.log('[Wayback] DOM stability timeout reached');
+        resolve();
+      }
+    }, timeout) as unknown as number;
   });
 }

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -412,6 +412,9 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 
 // UpdateCapture 更新已存在页面的捕获内容
 func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (string, error) {
+	startTime := time.Now()
+	log.Printf("[Update] Starting update for page %d", pageID)
+
 	// 1. 获取现有页面信息
 	page, err := d.db.GetPageByID(fmt.Sprintf("%d", pageID))
 	if err != nil || page == nil {
@@ -427,6 +430,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		if err := d.db.UpdatePageLastVisited(pageID, time.Now()); err != nil {
 			return "", err
 		}
+		log.Printf("[Update] Content unchanged, took %v", time.Since(startTime))
 		return models.ArchiveActionUnchanged, nil
 	}
 
@@ -439,6 +443,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 	}
 
 	// 5. 处理新内容（复用 ProcessCapture 的资源处理逻辑）
+	extractStart := time.Now()
 	htmlResources := d.htmlExtractor.ExtractResources(req.HTML, req.URL)
 	allResources := make([]models.ResourceReference, 0, len(htmlResources))
 	for _, res := range htmlResources {
@@ -448,7 +453,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		})
 	}
 
-	log.Printf("[Update] Total resources to process: %d", len(allResources))
+	log.Printf("[Update] Extracted %d resources in %v", len(allResources), time.Since(extractStart))
 
 	// 保存新 HTML
 	tempHTMLPath, err := d.storage.SaveHTML(req.URL, req.HTML, capturedAt)
@@ -474,6 +479,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 
 	var resourceIDs []int64
 	cssURLMapping := make(map[string]string)
+	processStart := time.Now()
 
 	// 并行处理资源
 	type resourceResult struct {
@@ -549,6 +555,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 			})
 		}
 	}
+	log.Printf("[Update] Processed %d resources in %v", len(resourceIDs), time.Since(processStart))
 
 	// 处理 CSS 中引用的资源
 	type cssSubResource struct {
@@ -571,6 +578,8 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 	}
 
 	if len(allCSSSubResources) > 0 {
+		cssSubStart := time.Now()
+		log.Printf("[Update] Processing %d CSS sub-resources", len(allCSSSubResources))
 		type cssSubResult struct {
 			sub      cssSubResource
 			resID    int64
@@ -624,9 +633,11 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 			cssURLMapping[result.sub.absoluteURL] = result.filePath
 			rewriter.AddMapping(result.sub.absoluteURL, result.filePath)
 		}
+		log.Printf("[Update] CSS sub-resources processed in %v", time.Since(cssSubStart))
 	}
 
 	// 重写 CSS 文件中的 URL
+	cssRewriteStart := time.Now()
 	for _, cw := range cssWorkItems {
 		cssResources := d.cssParser.ExtractResources(cw.cssContent)
 		if len(cssResources) > 0 {
@@ -636,16 +647,22 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 			}
 		}
 	}
+	log.Printf("[Update] CSS rewrite: %v", time.Since(cssRewriteStart))
 
 	// 重写 HTML 中的资源 URL
+	htmlRewriteStart := time.Now()
 	rewrittenHTML := rewriter.RewriteHTML(req.HTML)
+	log.Printf("[Update] HTML rewrite: %v (html size: %d bytes)", time.Since(htmlRewriteStart), len(rewrittenHTML))
 
 	// 更新保存的 HTML 文件
+	saveStart := time.Now()
 	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
 		return "", fmt.Errorf("update html failed: %w", err)
 	}
+	log.Printf("[Update] Save HTML: %v", time.Since(saveStart))
 
 	// 更新数据库记录
+	dbStart := time.Now()
 	if err := d.db.UpdatePageContent(pageID, tempHTMLPath, newContentHash, req.Title); err != nil {
 		return "", fmt.Errorf("update page content failed: %w", err)
 	}
@@ -656,6 +673,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 			log.Printf("[Update] Failed to link resource: %v", err)
 		}
 	}
+	log.Printf("[Update] DB operations: %v (%d resources linked)", time.Since(dbStart), len(resourceIDs))
 
 	// 删除旧 HTML 文件（DB 已指向新文件，此时删除安全）
 	if oldHTMLPath != tempHTMLPath {
@@ -664,7 +682,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		}
 	}
 
-	log.Printf("[Update] Page updated (ID: %d, new hash: %s)", pageID, newContentHash[:16])
+	log.Printf("[Update] Page updated (ID: %d, new hash: %s, total: %v)", pageID, newContentHash[:16], time.Since(startTime))
 	return models.ArchiveActionUpdated, nil
 }
 

--- a/server/internal/storage/rewriter.go
+++ b/server/internal/storage/rewriter.go
@@ -87,6 +87,11 @@ func replaceURLInHTML(html, escapedURL, localURL string) string {
 
 // RewriteHTML 重写 HTML 中的资源 URL
 func (r *URLRewriter) RewriteHTML(html string) string {
+	return r.RewriteHTMLFast(html)
+}
+
+// rewriteHTMLRegex 使用正则逐个替换（旧版本，保留用于对比测试）
+func (r *URLRewriter) rewriteHTMLRegex(html string) string {
 	result := html
 
 	// 替换所有已知的资源 URL

--- a/server/internal/storage/rewriter_bench_test.go
+++ b/server/internal/storage/rewriter_bench_test.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+// BenchmarkRewriteHTML_Fast 测试快速版本的性能
+func BenchmarkRewriteHTML_Fast(b *testing.B) {
+	// 模拟真实场景：100 个资源，1MB HTML
+	r := NewURLRewriter()
+	r.SetPageID(123)
+	r.SetTimestamp("20260311")
+
+	// 添加 100 个资源映射
+	for i := 0; i < 100; i++ {
+		url := "https://example.com/resource" + string(rune(i)) + ".jpg"
+		r.AddMapping(url, "resources/hash"+string(rune(i))+".img")
+	}
+
+	// 生成 1MB HTML（包含所有资源引用）
+	var htmlBuilder strings.Builder
+	htmlBuilder.WriteString("<html><head>")
+	for i := 0; i < 100; i++ {
+		url := "https://example.com/resource" + string(rune(i)) + ".jpg"
+		htmlBuilder.WriteString(`<link href="` + url + `">`)
+	}
+	htmlBuilder.WriteString("</head><body>")
+	// 填充到 1MB
+	for htmlBuilder.Len() < 1024*1024 {
+		htmlBuilder.WriteString("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>")
+	}
+	htmlBuilder.WriteString("</body></html>")
+	html := htmlBuilder.String()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.RewriteHTML(html)
+	}
+}
+
+// BenchmarkRewriteHTML_Regex 测试正则版本的性能（用于对比）
+func BenchmarkRewriteHTML_Regex(b *testing.B) {
+	r := NewURLRewriter()
+	r.SetPageID(123)
+	r.SetTimestamp("20260311")
+
+	for i := 0; i < 100; i++ {
+		url := "https://example.com/resource" + string(rune(i)) + ".jpg"
+		r.AddMapping(url, "resources/hash"+string(rune(i))+".img")
+	}
+
+	var htmlBuilder strings.Builder
+	htmlBuilder.WriteString("<html><head>")
+	for i := 0; i < 100; i++ {
+		url := "https://example.com/resource" + string(rune(i)) + ".jpg"
+		htmlBuilder.WriteString(`<link href="` + url + `">`)
+	}
+	htmlBuilder.WriteString("</head><body>")
+	for htmlBuilder.Len() < 1024*1024 {
+		htmlBuilder.WriteString("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>")
+	}
+	htmlBuilder.WriteString("</body></html>")
+	html := htmlBuilder.String()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.rewriteHTMLRegex(html)
+	}
+}

--- a/server/internal/storage/rewriter_fast.go
+++ b/server/internal/storage/rewriter_fast.go
@@ -1,0 +1,110 @@
+package storage
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// RewriteHTMLFast 使用 strings.NewReplacer 快速重写 HTML 中的资源 URL
+// 相比原版 RewriteHTML，这个版本做单次遍历替换，速度快 100 倍以上
+func (r *URLRewriter) RewriteHTMLFast(html string) string {
+	// 构建所有需要替换的 URL 变体
+	var pairs []string
+
+	for originalURL := range r.urlToLocalPath {
+		// 构建本地 URL
+		var localURL string
+		if r.pageID > 0 && r.timestamp != "" {
+			localURL = fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, originalURL)
+		} else {
+			localURL = "/archive/" + r.urlToLocalPath[originalURL]
+		}
+
+		// 1. 原始 URL 的各种属性形式
+		pairs = append(pairs,
+			` src="`+originalURL+`"`, ` src="`+localURL+`"`,
+			` href="`+originalURL+`"`, ` href="`+localURL+`"`,
+			` poster="`+originalURL+`"`, ` poster="`+localURL+`"`,
+			` srcset="`+originalURL+`"`, ` srcset="`+localURL+`"`,
+			`url("`+originalURL+`")`, `url("`+localURL+`")`,
+			`url('`+originalURL+`')`, `url('`+localURL+`')`,
+			`url(`+originalURL+`)`, `url(`+localURL+`)`,
+		)
+
+		// 2. 协议相对 URL（如 //example.com/path）
+		protocolRelativeURL := strings.TrimPrefix(originalURL, "https:")
+		protocolRelativeURL = strings.TrimPrefix(protocolRelativeURL, "http:")
+		if protocolRelativeURL != originalURL && strings.HasPrefix(protocolRelativeURL, "//") {
+			pairs = append(pairs,
+				` src="`+protocolRelativeURL+`"`, ` src="`+localURL+`"`,
+				` href="`+protocolRelativeURL+`"`, ` href="`+localURL+`"`,
+				` poster="`+protocolRelativeURL+`"`, ` poster="`+localURL+`"`,
+				` srcset="`+protocolRelativeURL+`"`, ` srcset="`+localURL+`"`,
+				`url("`+protocolRelativeURL+`")`, `url("`+localURL+`")`,
+				`url('`+protocolRelativeURL+`')`, `url('`+localURL+`')`,
+				`url(`+protocolRelativeURL+`)`, `url(`+localURL+`)`,
+			)
+		}
+
+		// 3. HTML 实体编码的 URL（& -> &amp;）
+		htmlEncodedURL := strings.ReplaceAll(originalURL, "&", "&amp;")
+		if htmlEncodedURL != originalURL {
+			pairs = append(pairs,
+				` src="`+htmlEncodedURL+`"`, ` src="`+localURL+`"`,
+				` href="`+htmlEncodedURL+`"`, ` href="`+localURL+`"`,
+				` poster="`+htmlEncodedURL+`"`, ` poster="`+localURL+`"`,
+				` srcset="`+htmlEncodedURL+`"`, ` srcset="`+localURL+`"`,
+				`url("`+htmlEncodedURL+`")`, `url("`+localURL+`")`,
+				`url('`+htmlEncodedURL+`')`, `url('`+localURL+`')`,
+				`url(`+htmlEncodedURL+`)`, `url(`+localURL+`)`,
+			)
+
+			// 协议相对 + &amp; 组合
+			if protocolRelativeURL != originalURL && strings.HasPrefix(protocolRelativeURL, "//") {
+				protoRelEncoded := strings.ReplaceAll(protocolRelativeURL, "&", "&amp;")
+				pairs = append(pairs,
+					` src="`+protoRelEncoded+`"`, ` src="`+localURL+`"`,
+					` href="`+protoRelEncoded+`"`, ` href="`+localURL+`"`,
+					` poster="`+protoRelEncoded+`"`, ` poster="`+localURL+`"`,
+					` srcset="`+protoRelEncoded+`"`, ` srcset="`+localURL+`"`,
+					`url("`+protoRelEncoded+`")`, `url("`+localURL+`")`,
+					`url('`+protoRelEncoded+`')`, `url('`+localURL+`')`,
+					`url(`+protoRelEncoded+`)`, `url(`+localURL+`)`,
+				)
+			}
+		}
+
+		// 4. url(&quot;...&quot;) 格式
+		pairs = append(pairs,
+			`url(&quot;`+originalURL+`&quot;)`, `url(&quot;`+localURL+`&quot;)`,
+		)
+		if htmlEncodedURL != originalURL {
+			pairs = append(pairs,
+				`url(&quot;`+htmlEncodedURL+`&quot;)`, `url(&quot;`+localURL+`&quot;)`,
+			)
+		}
+
+		// 5. 绝对路径（如 /assets/style.css）
+		parsed, err := url.Parse(originalURL)
+		if err == nil && parsed.Path != "" {
+			pathWithQuery := parsed.Path
+			if parsed.RawQuery != "" {
+				pathWithQuery = parsed.Path + "?" + parsed.RawQuery
+			}
+			pairs = append(pairs,
+				` src="`+pathWithQuery+`"`, ` src="`+localURL+`"`,
+				` href="`+pathWithQuery+`"`, ` href="`+localURL+`"`,
+				` poster="`+pathWithQuery+`"`, ` poster="`+localURL+`"`,
+				` srcset="`+pathWithQuery+`"`, ` srcset="`+localURL+`"`,
+				`url("`+pathWithQuery+`")`, `url("`+localURL+`")`,
+				`url('`+pathWithQuery+`')`, `url('`+localURL+`')`,
+				`url(`+pathWithQuery+`)`, `url(`+localURL+`)`,
+			)
+		}
+	}
+
+	// 使用 strings.NewReplacer 做单次遍历替换
+	replacer := strings.NewReplacer(pairs...)
+	return replacer.Replace(html)
+}


### PR DESCRIPTION
## 问题

页面更新 (PUT /api/archive/:id) 非常慢，浏览器控制台长时间卡在 "Updating page on server..."。

通过添加分阶段计时日志定位到瓶颈：

| 阶段 | 耗时 |
|---|---|
| 资源提取 | 15ms |
| 资源处理 (124个) | 1.6s |
| **HTML 重写** | **44.3s** |
| 总计 | **46s** |

## 根因

`RewriteHTML` 对每个资源 URL 编译 ~20 个正则表达式，并在整个 HTML 上执行替换。124 个资源 × 20 个正则 × 1.2MB HTML = ~2500 次正则编译+全文扫描。

## 修复

用 `strings.NewReplacer` 替代正则逐个替换。NewReplacer 内部构建 trie，对 HTML 做单次遍历即可完成所有 URL 替换。

### Benchmark 结果

```
BenchmarkRewriteHTML_Fast-10      1426    2,350,248 ns/op   (2.3ms)
BenchmarkRewriteHTML_Regex-10        1   26,352,033,625 ns/op  (26.3s)
```

**提速 11,213 倍**

### 实际效果

| 指标 | 优化前 | 优化后 |
|---|---|---|
| HTML 重写 | 44.3s | 13.4ms |
| 更新总耗时 | 46s | 4.2s |

## 其他改进

- **修复 waitForDOMStable 竞态条件**：DOM 稳定后超时定时器未取消，导致延迟打印 "DOM stability timeout reached" 误导用户
- **添加请求超时**：GM_xmlhttpRequest 增加 5 分钟超时，防止浏览器无限等待
- **添加性能诊断日志**：UpdateCapture 各阶段计时，便于后续定位瓶颈

## 测试

- 所有现有单元测试通过
- 新增 benchmark 测试对比新旧实现性能
- data-src 保护、协议相对 URL、HTML 实体编码、url(&quot;) 等边界情况均覆盖