### PR TITLE
feat: URL 时间线视图 — 查看同一 URL 的不同时间快照

### DIFF
--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -2,15 +2,44 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 
 	"wayback/internal/models"
 )
 
 // injectArchiveHeader 在页面顶部注入归档信息栏
-func injectArchiveHeader(html string, page *models.Page) string {
+func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next *models.Page, snapshotTotal int) string {
 	// 格式化时间
 	capturedTime := page.CapturedAt.Format("2006-01-02 15:04:05")
+
+	// 构建快照导航 HTML
+	var navHTML string
+	if snapshotTotal > 1 {
+		prevLink := ""
+		if prev != nil {
+			prevLink = fmt.Sprintf(`<a href="/view/%d" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" title="%s">◀ %s</a>`,
+				prev.ID, prev.FirstVisited.Format("2006-01-02 15:04:05"), prev.FirstVisited.Format("01-02 15:04"))
+		} else {
+			prevLink = `<span style="padding:4px 10px;font-size:12px;opacity:0.3;">◀</span>`
+		}
+
+		nextLink := ""
+		if next != nil {
+			nextLink = fmt.Sprintf(`<a href="/view/%d" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" title="%s">%s ▶</a>`,
+				next.ID, next.FirstVisited.Format("2006-01-02 15:04:05"), next.FirstVisited.Format("01-02 15:04"))
+		} else {
+			nextLink = `<span style="padding:4px 10px;font-size:12px;opacity:0.3;">▶</span>`
+		}
+
+		timelineLink := fmt.Sprintf(`<a href="/timeline?url=%s" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" title="查看所有快照">%d snapshots</a>`,
+			url.QueryEscape(page.URL), snapshotTotal)
+
+		navHTML = fmt.Sprintf(`
+		<div style="display:flex;align-items:center;gap:6px;">
+			%s %s %s
+		</div>`, prevLink, timelineLink, nextLink)
+	}
 
 	// 归档信息栏 HTML
 	archiveHeader := fmt.Sprintf(`
@@ -52,18 +81,21 @@ func injectArchiveHeader(html string, page *models.Page) string {
 			</div>
 		</div>
 	</div>
-	<a href="/" style="
-		color: white;
-		text-decoration: none;
-		padding: 6px 16px;
-		border: 1px solid rgba(255,255,255,0.3);
-		border-radius: 4px;
-		transition: all 0.2s;
-		font-size: 13px;
-		background: rgba(255,255,255,0.1);
-	" onmouseover="this.style.background='rgba(255,255,255,0.2)'" onmouseout="this.style.background='rgba(255,255,255,0.1)'">
-		← Back to Archives
-	</a>
+	<div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+		%s
+		<a href="/" style="
+			color: white;
+			text-decoration: none;
+			padding: 6px 16px;
+			border: 1px solid rgba(255,255,255,0.3);
+			border-radius: 4px;
+			transition: all 0.2s;
+			font-size: 13px;
+			background: rgba(255,255,255,0.1);
+		">
+			← Back to Archives
+		</a>
+	</div>
 </div>
 <style>
 	body { margin-top: 80px !important; }
@@ -90,7 +122,7 @@ func injectArchiveHeader(html string, page *models.Page) string {
 		transform: none !important;
 	}
 </style>
-`, escapeHTML(page.URL), capturedTime)
+`, escapeHTML(page.URL), capturedTime, navHTML)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {

--- a/server/internal/api/pages_handler.go
+++ b/server/internal/api/pages_handler.go
@@ -107,6 +107,27 @@ func (h *Handler) SearchPages(c *gin.Context) {
 	c.JSON(http.StatusOK, pages)
 }
 
+// GetPageTimeline 获取同一 URL 的所有快照
+func (h *Handler) GetPageTimeline(c *gin.Context) {
+	pageURL := c.Query("url")
+	if pageURL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing url parameter"})
+		return
+	}
+
+	pages, err := h.db.GetPagesByURL(pageURL)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"url":       pageURL,
+		"snapshots": pages,
+		"total":     len(pages),
+	})
+}
+
 // DeletePage 删除页面
 func (h *Handler) DeletePage(c *gin.Context) {
 	id := c.Param("id")

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -33,6 +33,8 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig) {
 	r.StaticFile("/", "./web/index.html")
 	r.StaticFile("/index.html", "./web/index.html")
 	r.StaticFile("/test.html", "./web/test.html")
+	r.StaticFile("/timeline", "./web/timeline.html")
+	r.StaticFile("/timeline.html", "./web/timeline.html")
 
 	// favicon（避免 404）
 	r.GET("/favicon.ico", func(c *gin.Context) {
@@ -44,6 +46,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig) {
 		api.POST("/archive", handler.ArchivePage)
 		api.PUT("/archive/:id", handler.UpdatePage)
 		api.GET("/pages", handler.ListPages)
+		api.GET("/pages/timeline", handler.GetPageTimeline)
 		api.GET("/pages/:id", handler.GetPage)
 		api.DELETE("/pages/:id", handler.DeletePage)
 		api.GET("/search", handler.SearchPages)

--- a/server/internal/api/timeline_handler_test.go
+++ b/server/internal/api/timeline_handler_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"wayback/internal/models"
+)
+
+func setupTimelineRouter(handler *Handler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	api := r.Group("/api")
+	api.POST("/archive", handler.ArchivePage)
+	api.GET("/pages/timeline", handler.GetPageTimeline)
+	return r
+}
+
+func TestGetPageTimeline_MultipleSnapshots(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupTimelineRouter(handler)
+
+	testURL := "http://test-timeline-handler.example.com/page"
+
+	// Create first snapshot
+	req1 := models.CaptureRequest{
+		URL:   testURL,
+		Title: "Version 1",
+		HTML:  "<html><body>Content Version 1</body></html>",
+	}
+	body1, _ := json.Marshal(req1)
+	w1 := httptest.NewRecorder()
+	httpReq1, _ := http.NewRequest("POST", "/api/archive", bytes.NewReader(body1))
+	httpReq1.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w1, httpReq1)
+
+	var resp1 models.ArchiveResponse
+	json.Unmarshal(w1.Body.Bytes(), &resp1)
+	if resp1.PageID <= 0 {
+		t.Fatalf("failed to create first snapshot: %s", w1.Body.String())
+	}
+	defer handler.db.DeletePage(resp1.PageID)
+
+	// Create second snapshot (different content)
+	req2 := models.CaptureRequest{
+		URL:   testURL,
+		Title: "Version 2",
+		HTML:  "<html><body>Content Version 2 - Updated</body></html>",
+	}
+	body2, _ := json.Marshal(req2)
+	w2 := httptest.NewRecorder()
+	httpReq2, _ := http.NewRequest("POST", "/api/archive", bytes.NewReader(body2))
+	httpReq2.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w2, httpReq2)
+
+	var resp2 models.ArchiveResponse
+	json.Unmarshal(w2.Body.Bytes(), &resp2)
+	if resp2.PageID <= 0 {
+		t.Fatalf("failed to create second snapshot: %s", w2.Body.String())
+	}
+	defer handler.db.DeletePage(resp2.PageID)
+
+	// Query timeline
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("GET", "/api/pages/timeline?url="+testURL, nil)
+	router.ServeHTTP(w, httpReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var result struct {
+		URL       string        `json:"url"`
+		Snapshots []models.Page `json:"snapshots"`
+		Total     int           `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if result.URL != testURL {
+		t.Errorf("url = %q, want %q", result.URL, testURL)
+	}
+	if result.Total != 2 {
+		t.Errorf("total = %d, want 2", result.Total)
+	}
+	if len(result.Snapshots) != 2 {
+		t.Fatalf("snapshots count = %d, want 2", len(result.Snapshots))
+	}
+
+	// Newest first
+	if result.Snapshots[0].Title != "Version 2" {
+		t.Errorf("first snapshot title = %q, want %q", result.Snapshots[0].Title, "Version 2")
+	}
+	if result.Snapshots[1].Title != "Version 1" {
+		t.Errorf("second snapshot title = %q, want %q", result.Snapshots[1].Title, "Version 1")
+	}
+}
+
+func TestGetPageTimeline_MissingURL(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupTimelineRouter(handler)
+
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("GET", "/api/pages/timeline", nil)
+	router.ServeHTTP(w, httpReq)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing url, got %d", w.Code)
+	}
+}
+
+func TestGetPageTimeline_NoSnapshots(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupTimelineRouter(handler)
+
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("GET", "/api/pages/timeline?url=http://nonexistent-timeline-test.example.com", nil)
+	router.ServeHTTP(w, httpReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result struct {
+		Total int `json:"total"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &result)
+	if result.Total != 0 {
+		t.Errorf("total = %d, want 0", result.Total)
+	}
+}

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -23,6 +23,9 @@ func (h *Handler) ViewPage(c *gin.Context) {
 		return
 	}
 
+	// 获取快照邻居信息（用于导航）
+	prev, next, snapshotTotal, _ := h.db.GetSnapshotNeighbors(page.URL, page.ID)
+
 	// 读取 HTML 文件（已经包含重写后的资源路径）
 	htmlPath := filepath.Join(h.dataDir, page.HTMLPath)
 	htmlContent, err := os.ReadFile(htmlPath)
@@ -75,7 +78,7 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	modifiedHTML = fixNestedButtons(modifiedHTML)
 
 	// 注入归档信息栏
-	modifiedHTML = injectArchiveHeader(modifiedHTML, page)
+	modifiedHTML = injectArchiveHeader(modifiedHTML, page, prev, next, snapshotTotal)
 
 	// 设置安全响应头（禁用所有脚本）
 	c.Header("X-Frame-Options", "SAMEORIGIN")

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -428,6 +428,64 @@ func (db *DB) UpdatePageContent(id int64, htmlPath, contentHash, title string) e
 	return err
 }
 
+// GetPagesByURL 获取同一 URL 的所有快照（按时间倒序）
+func (db *DB) GetPagesByURL(pageURL string) ([]models.Page, error) {
+	rows, err := db.conn.Query(
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 ORDER BY first_visited DESC",
+		pageURL,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var pages []models.Page
+	for rows.Next() {
+		var p models.Page
+		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		pages = append(pages, p)
+	}
+	return pages, nil
+}
+
+// GetSnapshotNeighbors 获取某个快照的前后快照（用于导航）
+func (db *DB) GetSnapshotNeighbors(pageURL string, currentID int64) (prev *models.Page, next *models.Page, total int, err error) {
+	// 获取总数
+	err = db.conn.QueryRow("SELECT COUNT(*) FROM pages WHERE url = $1", pageURL).Scan(&total)
+	if err != nil {
+		return
+	}
+
+	// 前一个快照（比当前更早）
+	var p models.Page
+	err = db.conn.QueryRow(
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 AND first_visited < (SELECT first_visited FROM pages WHERE id = $2) ORDER BY first_visited DESC LIMIT 1",
+		pageURL, currentID,
+	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt)
+	if err == nil {
+		prev = &p
+	} else if err != sql.ErrNoRows {
+		return
+	}
+	err = nil
+
+	// 后一个快照（比当前更新）
+	var n models.Page
+	err = db.conn.QueryRow(
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 AND first_visited > (SELECT first_visited FROM pages WHERE id = $2) ORDER BY first_visited ASC LIMIT 1",
+		pageURL, currentID,
+	).Scan(&n.ID, &n.URL, &n.Title, &n.CapturedAt, &n.HTMLPath, &n.ContentHash, &n.FirstVisited, &n.LastVisited, &n.CreatedAt)
+	if err == nil {
+		next = &n
+	} else if err != sql.ErrNoRows {
+		return
+	}
+	err = nil
+	return
+}
+
 // DeletePageResources 删除页面资源关联（不删除资源本身）
 func (db *DB) DeletePageResources(pageID int64) error {
 	_, err := db.conn.Exec("DELETE FROM page_resources WHERE page_id = $1", pageID)

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -142,3 +142,139 @@ func TestDeletePageResources_NoLinks(t *testing.T) {
 		t.Fatalf("DeletePageResources on page with no links should not error, got: %v", err)
 	}
 }
+
+func TestGetPagesByURL(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	now := time.Now()
+	testURL := "http://test-get-pages-by-url.example.com"
+
+	// Create 3 snapshots with different content hashes
+	hash1 := "1111111111111111111111111111111111111111111111111111111111111111"
+	hash2 := "2222222222222222222222222222222222222222222222222222222222222222"
+	hash3 := "3333333333333333333333333333333333333333333333333333333333333333"
+
+	id1, err := db.CreatePage(testURL, "Snapshot 1", "html/test/snap1.html", hash1, now.Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("CreatePage 1 failed: %v", err)
+	}
+	defer db.DeletePage(id1)
+
+	id2, err := db.CreatePage(testURL, "Snapshot 2", "html/test/snap2.html", hash2, now.Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("CreatePage 2 failed: %v", err)
+	}
+	defer db.DeletePage(id2)
+
+	id3, err := db.CreatePage(testURL, "Snapshot 3", "html/test/snap3.html", hash3, now)
+	if err != nil {
+		t.Fatalf("CreatePage 3 failed: %v", err)
+	}
+	defer db.DeletePage(id3)
+
+	// Query all snapshots
+	pages, err := db.GetPagesByURL(testURL)
+	if err != nil {
+		t.Fatalf("GetPagesByURL failed: %v", err)
+	}
+	if len(pages) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(pages))
+	}
+
+	// Should be ordered by first_visited DESC (newest first)
+	if pages[0].ID != id3 {
+		t.Errorf("first snapshot should be id3 (%d), got %d", id3, pages[0].ID)
+	}
+	if pages[2].ID != id1 {
+		t.Errorf("last snapshot should be id1 (%d), got %d", id1, pages[2].ID)
+	}
+}
+
+func TestGetPagesByURL_NoResults(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	pages, err := db.GetPagesByURL("http://nonexistent-url-test-12345.example.com")
+	if err != nil {
+		t.Fatalf("GetPagesByURL should not error for missing URL: %v", err)
+	}
+	if len(pages) != 0 {
+		t.Errorf("expected 0 snapshots, got %d", len(pages))
+	}
+}
+
+func TestGetSnapshotNeighbors(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	now := time.Now()
+	testURL := "http://test-snapshot-neighbors.example.com"
+
+	hash1 := "aaaa111111111111111111111111111111111111111111111111111111111111"
+	hash2 := "aaaa222222222222222222222222222222222222222222222222222222222222"
+	hash3 := "aaaa333333333333333333333333333333333333333333333333333333333333"
+
+	id1, err := db.CreatePage(testURL, "Snap A", "html/test/a.html", hash1, now.Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("CreatePage 1 failed: %v", err)
+	}
+	defer db.DeletePage(id1)
+
+	id2, err := db.CreatePage(testURL, "Snap B", "html/test/b.html", hash2, now.Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("CreatePage 2 failed: %v", err)
+	}
+	defer db.DeletePage(id2)
+
+	id3, err := db.CreatePage(testURL, "Snap C", "html/test/c.html", hash3, now)
+	if err != nil {
+		t.Fatalf("CreatePage 3 failed: %v", err)
+	}
+	defer db.DeletePage(id3)
+
+	// Middle snapshot: should have both prev and next
+	prev, next, total, err := db.GetSnapshotNeighbors(testURL, id2)
+	if err != nil {
+		t.Fatalf("GetSnapshotNeighbors failed: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if prev == nil {
+		t.Fatal("prev should not be nil for middle snapshot")
+	}
+	if prev.ID != id1 {
+		t.Errorf("prev.ID = %d, want %d", prev.ID, id1)
+	}
+	if next == nil {
+		t.Fatal("next should not be nil for middle snapshot")
+	}
+	if next.ID != id3 {
+		t.Errorf("next.ID = %d, want %d", next.ID, id3)
+	}
+
+	// Oldest snapshot: no prev, has next
+	prev, next, _, err = db.GetSnapshotNeighbors(testURL, id1)
+	if err != nil {
+		t.Fatalf("GetSnapshotNeighbors for oldest failed: %v", err)
+	}
+	if prev != nil {
+		t.Errorf("oldest snapshot should have no prev, got ID %d", prev.ID)
+	}
+	if next == nil || next.ID != id2 {
+		t.Errorf("oldest snapshot next should be id2 (%d)", id2)
+	}
+
+	// Newest snapshot: has prev, no next
+	prev, next, _, err = db.GetSnapshotNeighbors(testURL, id3)
+	if err != nil {
+		t.Fatalf("GetSnapshotNeighbors for newest failed: %v", err)
+	}
+	if prev == nil || prev.ID != id2 {
+		t.Errorf("newest snapshot prev should be id2 (%d)", id2)
+	}
+	if next != nil {
+		t.Errorf("newest snapshot should have no next, got ID %d", next.ID)
+	}
+}

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -353,6 +353,24 @@
             gap: 8px;
         }
 
+        .timeline-btn {
+            background: transparent;
+            border: 1px solid var(--color-border);
+            color: var(--color-text-dim);
+            padding: 4px 12px;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            cursor: pointer;
+            transition: all 0.2s ease;
+            white-space: nowrap;
+        }
+
+        .timeline-btn:hover {
+            border-color: var(--color-cyan);
+            color: var(--color-cyan);
+            background: rgba(0, 217, 255, 0.1);
+        }
+
         .delete-btn {
             background: transparent;
             border: 1px solid var(--color-border);
@@ -656,6 +674,7 @@
                                 <span class="page-id">#${page.id}</span>
                             </div>
                             <div class="page-actions">
+                                <button class="timeline-btn" onclick="openTimeline(event, '${escapeHtml(page.url)}')">Timeline</button>
                                 <button class="delete-btn" data-page-id="${page.id}" onclick="deletePage(event, ${page.id})">Delete</button>
                             </div>
                         </div>
@@ -680,13 +699,18 @@
             document.querySelectorAll('.page-item').forEach(item => {
                 item.addEventListener('click', (e) => {
                     // Don't navigate if clicking on the original URL link or delete button
-                    if (e.target.closest('.page-url') || e.target.closest('.delete-btn')) {
+                    if (e.target.closest('.page-url') || e.target.closest('.delete-btn') || e.target.closest('.timeline-btn')) {
                         return;
                     }
                     const archiveId = item.getAttribute('data-archive-id');
                     window.open(`/view/${archiveId}`, '_blank');
                 });
             });
+        }
+
+        function openTimeline(event, pageUrl) {
+            event.stopPropagation();
+            window.open(`/timeline?url=${encodeURIComponent(pageUrl)}`, '_blank');
         }
 
         async function deletePage(event, pageId) {

--- a/server/web/timeline.html
+++ b/server/web/timeline.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WAYBACK // TIMELINE</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --color-bg: #000000;
+            --color-surface: #0a0a0a;
+            --color-border: #1a1a1a;
+            --color-text-primary: #e0e0e0;
+            --color-text-secondary: #808080;
+            --color-text-dim: #404040;
+            --color-accent: #00ff88;
+            --color-accent-dim: #00cc6a;
+            --color-cyan: #00d9ff;
+            --font-mono: 'JetBrains Mono', monospace;
+            --font-sans: 'Inter', sans-serif;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: var(--font-mono);
+            background: var(--color-bg);
+            color: var(--color-text-primary);
+            line-height: 1.5;
+            min-height: 100vh;
+        }
+
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background-image:
+                linear-gradient(90deg, transparent 0%, rgba(0, 255, 136, 0.02) 50%, transparent 100%),
+                repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 255, 136, 0.03) 2px, rgba(0, 255, 136, 0.03) 4px);
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 40px 24px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .header {
+            margin-bottom: 40px;
+        }
+
+        .header a {
+            color: var(--color-accent);
+            text-decoration: none;
+            font-size: 13px;
+            opacity: 0.7;
+        }
+        .header a:hover { opacity: 1; }
+
+        .header h1 {
+            font-size: 20px;
+            font-weight: 700;
+            color: var(--color-accent);
+            margin: 16px 0 8px;
+            letter-spacing: 2px;
+        }
+
+        .target-url {
+            font-size: 13px;
+            color: var(--color-cyan);
+            word-break: break-all;
+            padding: 12px 16px;
+            background: rgba(0, 217, 255, 0.05);
+            border: 1px solid rgba(0, 217, 255, 0.15);
+            border-radius: 4px;
+            margin-top: 12px;
+        }
+
+        .target-url a {
+            color: var(--color-cyan);
+            text-decoration: none;
+        }
+        .target-url a:hover { text-decoration: underline; }
+
+        .stats {
+            font-size: 12px;
+            color: var(--color-text-secondary);
+            margin-top: 12px;
+        }
+
+        .timeline {
+            position: relative;
+            padding-left: 32px;
+        }
+
+        .timeline::before {
+            content: '';
+            position: absolute;
+            left: 8px;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: linear-gradient(to bottom, var(--color-accent), var(--color-border));
+        }
+
+        .snapshot {
+            position: relative;
+            margin-bottom: 24px;
+            padding: 16px 20px;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            border-radius: 6px;
+            cursor: pointer;
+            transition: border-color 0.2s, background 0.2s;
+        }
+
+        .snapshot:hover {
+            border-color: var(--color-accent);
+            background: rgba(0, 255, 136, 0.03);
+        }
+
+        .snapshot::before {
+            content: '';
+            position: absolute;
+            left: -28px;
+            top: 22px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--color-accent);
+            border: 2px solid var(--color-bg);
+            z-index: 1;
+        }
+
+        .snapshot:first-child::before {
+            width: 14px;
+            height: 14px;
+            left: -29px;
+            top: 21px;
+            box-shadow: 0 0 8px rgba(0, 255, 136, 0.5);
+        }
+
+        .snapshot-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .snapshot-date {
+            font-size: 15px;
+            font-weight: 600;
+            color: var(--color-accent);
+        }
+
+        .snapshot-id {
+            font-size: 11px;
+            color: var(--color-text-dim);
+        }
+
+        .snapshot-title {
+            font-size: 13px;
+            color: var(--color-text-primary);
+            margin-top: 8px;
+            font-family: var(--font-sans);
+        }
+
+        .snapshot-meta {
+            display: flex;
+            gap: 16px;
+            margin-top: 8px;
+            font-size: 11px;
+            color: var(--color-text-secondary);
+            flex-wrap: wrap;
+        }
+
+        .snapshot-meta .label {
+            color: var(--color-text-dim);
+        }
+
+        .snapshot-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 3px;
+            font-size: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .badge-latest {
+            background: rgba(0, 255, 136, 0.15);
+            color: var(--color-accent);
+            border: 1px solid rgba(0, 255, 136, 0.3);
+        }
+
+        .badge-changed {
+            background: rgba(0, 217, 255, 0.15);
+            color: var(--color-cyan);
+            border: 1px solid rgba(0, 217, 255, 0.3);
+        }
+
+        .empty {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--color-text-dim);
+            font-size: 14px;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--color-text-secondary);
+            font-size: 13px;
+        }
+
+        .loading::after {
+            content: '...';
+            animation: dots 1.5s steps(4, end) infinite;
+        }
+
+        @keyframes dots {
+            0%, 20% { content: ''; }
+            40% { content: '.'; }
+            60% { content: '..'; }
+            80%, 100% { content: '...'; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <a href="/">← Back to Archives</a>
+            <h1>// TIMELINE</h1>
+            <div class="target-url" id="targetUrl"></div>
+            <div class="stats" id="stats"></div>
+        </div>
+        <div id="content">
+            <div class="loading">Loading snapshots</div>
+        </div>
+    </div>
+
+    <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        const targetUrl = urlParams.get('url');
+
+        if (!targetUrl) {
+            document.getElementById('content').innerHTML = '<div class="empty">No URL specified. Use ?url=... to view timeline.</div>';
+            document.getElementById('targetUrl').style.display = 'none';
+        } else {
+            document.getElementById('targetUrl').innerHTML = `<a href="${escapeHtml(targetUrl)}" target="_blank" rel="noopener">${escapeHtml(targetUrl)}</a>`;
+            document.title = `Timeline: ${targetUrl}`;
+            loadTimeline(targetUrl);
+        }
+
+        async function loadTimeline(url) {
+            try {
+                const response = await fetch(`/api/pages/timeline?url=${encodeURIComponent(url)}`);
+                if (!response.ok) throw new Error('Failed to load timeline');
+                const data = await response.json();
+
+                const snapshots = data.snapshots || [];
+                document.getElementById('stats').textContent = `${snapshots.length} snapshot${snapshots.length !== 1 ? 's' : ''} captured`;
+
+                if (snapshots.length === 0) {
+                    document.getElementById('content').innerHTML = '<div class="empty">No snapshots found for this URL.</div>';
+                    return;
+                }
+
+                renderTimeline(snapshots);
+            } catch (error) {
+                console.error('Timeline error:', error);
+                document.getElementById('content').innerHTML = '<div class="empty">Failed to load timeline.</div>';
+            }
+        }
+
+        function renderTimeline(snapshots) {
+            const container = document.getElementById('content');
+            let prevHash = null;
+
+            const html = '<div class="timeline">' + snapshots.map((snap, index) => {
+                const firstVisited = formatDate(snap.first_visited);
+                const lastVisited = formatDate(snap.last_visited);
+                const isMultipleVisits = snap.first_visited !== snap.last_visited;
+                const hashChanged = prevHash !== null && snap.content_hash !== prevHash;
+                prevHash = snap.content_hash;
+
+                const badges = [];
+                if (index === 0) badges.push('<span class="snapshot-badge badge-latest">Latest</span>');
+                if (hashChanged) badges.push('<span class="snapshot-badge badge-changed">Content Changed</span>');
+
+                return `
+                    <div class="snapshot" onclick="window.open('/view/${snap.id}', '_blank')">
+                        <div class="snapshot-header">
+                            <div>
+                                <span class="snapshot-date">${firstVisited}</span>
+                                ${badges.join(' ')}
+                            </div>
+                            <span class="snapshot-id">#${snap.id}</span>
+                        </div>
+                        <div class="snapshot-title">${escapeHtml(snap.title || 'Untitled')}</div>
+                        <div class="snapshot-meta">
+                            <span><span class="label">First seen:</span> ${firstVisited}</span>
+                            ${isMultipleVisits ? `<span><span class="label">Last seen:</span> ${lastVisited}</span>` : ''}
+                            <span><span class="label">Hash:</span> ${snap.content_hash.substring(0, 12)}...</span>
+                        </div>
+                    </div>
+                `;
+            }).join('') + '</div>';
+
+            container.innerHTML = html;
+        }
+
+        function formatDate(dateString) {
+            const date = new Date(dateString);
+            return date.toLocaleString('zh-CN', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+            });
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 功能

类似 web.archive.org 的时间线快照查看功能，支持针对某个 URL 查看不同时间节点的快照。

## 改动

### 后端
- `GET /api/pages/timeline?url=...` — 查询同一 URL 的所有快照
- `GetPagesByURL()` — 按 first_visited 倒序返回所有快照
- `GetSnapshotNeighbors()` — 获取当前快照的前后邻居（用于导航）

### 前端
- 新增 `timeline.html` 时间线页面，竖向时间轴展示所有快照
  - 标记 Latest（最新）和 Changed（内容变化）
  - 点击快照直接跳转查看
- 主页列表每条记录增加 **Timeline** 按钮
- 归档页面顶部 header 增加 ◀/▶ 快照导航和 "N snapshots" 链接

### 入口
1. 主页列表 → Timeline 按钮
2. 查看归档页面 → 顶部 header "N snapshots" 链接
3. 直接访问 `/timeline?url=...`

### 测试
- 6 个新测试用例全部通过
  - DB: GetPagesByURL、GetPagesByURL_NoResults、GetSnapshotNeighbors
  - API: GetPageTimeline_MultipleSnapshots、MissingURL、NoSnapshots
- 所有已有测试通过