### PR TITLE
fix archived page resource loading with base tags

### DIFF
--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -36,6 +36,11 @@ func (h *Handler) ViewPage(c *gin.Context) {
 
 	modifiedHTML := string(htmlContent)
 
+	// 移除 <base> 标签 — 归档页面的资源路径已重写为本地路径，
+	// <base href="https://原始域名/"> 会导致浏览器将 /archive/... 解析到原始域名
+	baseTagRe := regexp.MustCompile(`(?i)<base\s[^>]*>`)
+	modifiedHTML = baseTagRe.ReplaceAllString(modifiedHTML, "")
+
 	// 移除所有 <script> 标签
 	modifiedHTML = scriptTagRe.ReplaceAllString(modifiedHTML, "")
 


### PR DESCRIPTION
## Summary
- remove `<base>` tags when rendering archived pages in `/view/:id`
- prevent rewritten local archive URLs like `/archive/...` from being resolved against the original site
- fix layout/resource loading issues on pages such as Google Translate

## Test plan
- [x] `cd server && go build ./...`
- [x] open `http://localhost:8080/view/519`
- [x] verify previously misaligned Google Translate page now renders correctly
- [x] capture a fresh screenshot with Puppeteer to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)