### PR TITLE
fix: resolve top whitespace on view 538 by refining SPA container selector

### DIFF
--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -108,8 +108,9 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		min-height: 100%% !important;
 		overflow: visible !important;
 	}
-	/* 修复 flex 容器 height:100%% 截断内容 */
-	#app > div, #root > div, #__next > div, #__nuxt > div {
+	/* 修复 flex 容器 height:100%% 截断内容（:has 排除空容器，避免撑开广告占位） */
+	#app > div:has(> *:not(a):not(br):not(hr)), #root > div:has(> *:not(a):not(br):not(hr)),
+	#__next > div:has(> *:not(a):not(br):not(hr)), #__nuxt > div:has(> *:not(a):not(br):not(hr)) {
 		height: auto !important;
 		min-height: 100%% !important;
 	}


### PR DESCRIPTION
## Problem

View 538 页面顶部出现大片空白区域。

根因：SPA 容器修复规则 `#app > div, #root > div` 过于宽泛，将空的广告占位 div 也撑开了（`height: auto`），导致页面顶部出现不必要的空白。

## Fix

使用 `:has()` 伪类精确匹配包含实际内容的 SPA 容器：

```css
/* Before */
#app > div, #root > div, #__next > div, #__nuxt > div {
    height: auto !important;
    min-height: 100% !important;
}

/* After */
#app > div:has(> *:not(a):not(br):not(hr)),
#root > div:has(> *:not(a):not(br):not(hr)),
#__next > div:has(> *:not(a):not(br):not(hr)),
#__nuxt > div:has(> *:not(a):not(br):not(hr)) {
    height: auto !important;
    min-height: 100% !important;
}
```

## Impact

- 通用方案，应用于所有归档页面
- 不影响正常页面：`:has()` 选择器只匹配有实际内容子元素的容器，空容器不会被命中
- 向后兼容：`:has()` 在所有现代浏览器中已广泛支持（Chrome 105+, Firefox 121+, Safari 15.4+）