### PR TITLE
fix: normalize URLs with ../ segments to ensure CSS path rewriting

### DIFF
--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -390,8 +390,9 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 		}
 	}
 
-	// 重写 HTML 中的资源 URL
-	rewrittenHTML := rewriter.RewriteHTML(req.HTML)
+	// 重写 HTML 中的资源 URL（先规范化 HTML 中的 ../ 路径）
+	normalizedHTML := NormalizeHTMLURLs(req.HTML)
+	rewrittenHTML := rewriter.RewriteHTML(normalizedHTML)
 
 	// 更新保存的 HTML 文件（用重写后的内容替换临时内容）
 	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
@@ -649,9 +650,10 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 	}
 	log.Printf("[Update] CSS rewrite: %v", time.Since(cssRewriteStart))
 
-	// 重写 HTML 中的资源 URL
+	// 重写 HTML 中的资源 URL（先规范化 HTML 中的 ../ 路径）
 	htmlRewriteStart := time.Now()
-	rewrittenHTML := rewriter.RewriteHTML(req.HTML)
+	normalizedHTML := NormalizeHTMLURLs(req.HTML)
+	rewrittenHTML := rewriter.RewriteHTML(normalizedHTML)
 	log.Printf("[Update] HTML rewrite: %v (html size: %d bytes)", time.Since(htmlRewriteStart), len(rewrittenHTML))
 
 	// 更新保存的 HTML 文件

--- a/server/internal/storage/html_extractor.go
+++ b/server/internal/storage/html_extractor.go
@@ -249,16 +249,23 @@ func (e *HTMLResourceExtractor) isExternalURL(url string) bool {
 	return true
 }
 
-// resolveURL 将相对URL转换为绝对URL
+// resolveURL 将相对URL转换为绝对URL，并规范化路径（处理 ../ 等）
 func (e *HTMLResourceExtractor) resolveURL(rawURL, baseURL string) string {
-	// 如果已经是完整URL，直接返回
-	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
-		return rawURL
-	}
-
 	// 跳过 data: URLs
 	if strings.HasPrefix(rawURL, "data:") {
 		return rawURL
+	}
+
+	// 如果已经是完整URL，解析并规范化路径
+	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			log.Printf("Failed to parse absolute URL %s: %v", rawURL, err)
+			return rawURL
+		}
+		// 使用 ResolveReference 规范化路径（处理 ../ 等）
+		normalized := parsed.ResolveReference(&url.URL{})
+		return normalized.String()
 	}
 
 	// 解析基础URL
@@ -275,7 +282,7 @@ func (e *HTMLResourceExtractor) resolveURL(rawURL, baseURL string) string {
 		return rawURL
 	}
 
-	// 合并URL
+	// 合并URL（自动规范化路径）
 	resolved := base.ResolveReference(ref)
 	return resolved.String()
 }

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -93,6 +93,41 @@ func TestExtractResources_HTMLEntityDecode(t *testing.T) {
 	}
 }
 
+func TestExtractResources_DotDotURLNormalized(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	// CSS link with ../ in absolute URL — should be normalized
+	html := `<html><head>
+		<link rel="stylesheet" href="https://example.com/assets/nav/header/../common/style.css">
+		<link rel="stylesheet" href="https://example.com/assets/normal/style.css">
+	</head></html>`
+
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	foundNormalized := false
+	foundNormal := false
+	for _, r := range resources {
+		if r.URL == "https://example.com/assets/nav/common/style.css" {
+			foundNormalized = true
+			if r.Type != "css" {
+				t.Errorf("Expected type 'css', got '%s'", r.Type)
+			}
+		}
+		if r.URL == "https://example.com/assets/nav/header/../common/style.css" {
+			t.Error("URL with ../ should be normalized, but got raw URL")
+		}
+		if r.URL == "https://example.com/assets/normal/style.css" {
+			foundNormal = true
+		}
+	}
+	if !foundNormalized {
+		t.Error("Should extract and normalize URL with ../ to 'https://example.com/assets/nav/common/style.css'")
+	}
+	if !foundNormal {
+		t.Error("Should extract normal URL 'https://example.com/assets/normal/style.css'")
+	}
+}
+
 func TestExtractResources_VideoPoster(t *testing.T) {
 	extractor := NewHTMLResourceExtractor()
 

--- a/server/internal/storage/rewriter.go
+++ b/server/internal/storage/rewriter.go
@@ -8,6 +8,46 @@ import (
 	"strings"
 )
 
+// NormalizeHTMLURLs 规范化 HTML 中所有包含 ../ 的绝对 URL
+// 例如：https://example.com/path/../file.css -> https://example.com/file.css
+func NormalizeHTMLURLs(html string) string {
+	// 匹配 src/href/poster 属性中的绝对 URL（双引号和单引号分别匹配）
+	urlRegexDQ := regexp.MustCompile(`((?:src|href|poster)=")(https?://[^"]+)"`)
+	urlRegexSQ := regexp.MustCompile(`((?:src|href|poster)=')(https?://[^']+)'`)
+
+	normalize := func(match string, re *regexp.Regexp, quote string) string {
+		parts := re.FindStringSubmatch(match)
+		if len(parts) < 3 {
+			return match
+		}
+
+		attrPrefix := parts[1] // 如 href="
+		rawURL := parts[2]
+
+		if !strings.Contains(rawURL, "..") {
+			return match
+		}
+
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			return match
+		}
+
+		normalized := parsed.ResolveReference(&url.URL{})
+		return attrPrefix + normalized.String() + quote
+	}
+
+	result := urlRegexDQ.ReplaceAllStringFunc(html, func(match string) string {
+		return normalize(match, urlRegexDQ, `"`)
+	})
+	result = urlRegexSQ.ReplaceAllStringFunc(result, func(match string) string {
+		return normalize(match, urlRegexSQ, `'`)
+	})
+
+	return result
+}
+
+
 // URLRewriter 负责重写 HTML 中的资源 URL
 type URLRewriter struct {
 	urlToLocalPath map[string]string

--- a/server/internal/storage/rewriter_test.go
+++ b/server/internal/storage/rewriter_test.go
@@ -87,6 +87,64 @@ func TestRewriteHTML_URLQuotEncoding(t *testing.T) {
 	}
 }
 
+func TestNormalizeHTMLURLs_DotDotPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "href with ../ double quote",
+			input:    `<link rel="stylesheet" href="https://example.com/a/b/../c/style.css">`,
+			expected: `<link rel="stylesheet" href="https://example.com/a/c/style.css">`,
+		},
+		{
+			name:     "href with ../ single quote",
+			input:    `<link href='https://example.com/a/b/../c/style.css' rel="stylesheet">`,
+			expected: `<link href='https://example.com/a/c/style.css' rel="stylesheet">`,
+		},
+		{
+			name:     "src with ../",
+			input:    `<script src="https://example.com/js/lib/../common/app.js"></script>`,
+			expected: `<script src="https://example.com/js/common/app.js"></script>`,
+		},
+		{
+			name:     "multiple ../ segments",
+			input:    `<link href="https://example.com/a/b/c/../../d/style.css" rel="stylesheet">`,
+			expected: `<link href="https://example.com/a/d/style.css" rel="stylesheet">`,
+		},
+		{
+			name:     "preserves query params",
+			input:    `<script src="https://example.com/a/../b/app.js?v=123"></script>`,
+			expected: `<script src="https://example.com/b/app.js?v=123"></script>`,
+		},
+		{
+			name:     "no ../ unchanged",
+			input:    `<link href="https://example.com/normal/style.css" rel="stylesheet">`,
+			expected: `<link href="https://example.com/normal/style.css" rel="stylesheet">`,
+		},
+		{
+			name:     "multiple links mixed",
+			input:    `<link href="https://a.com/x/../y.css" rel="stylesheet"><link href="https://b.com/normal.css" rel="stylesheet">`,
+			expected: `<link href="https://a.com/y.css" rel="stylesheet"><link href="https://b.com/normal.css" rel="stylesheet">`,
+		},
+		{
+			name:     "real world okx pattern",
+			input:    `<link rel="stylesheet" type="text/css" href="https://www.okx.com/cdn/assets/okfe/okx-nav/header/../common/9214.466d2d42.css">`,
+			expected: `<link rel="stylesheet" type="text/css" href="https://www.okx.com/cdn/assets/okfe/okx-nav/common/9214.466d2d42.css">`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeHTMLURLs(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeHTMLURLs()\ngot:  %s\nwant: %s", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestRewriteHTML_NormalSrcHref(t *testing.T) {
 	r := newTestRewriter(1, "20260310", map[string]string{
 		"https://example.com/style.css": "resources/ab/cd/hash.css",


### PR DESCRIPTION
## Problem

Archived pages with dynamically injected CSS `<link>` tags containing `../` in their URLs (e.g. `https://example.com/a/b/../c/style.css`) were not being rewritten to local archive paths, causing broken styles.

**Root cause:** The resource extractor normalized URLs (removing `../`), but the HTML still contained the original URLs with `../`. The rewriter couldn't match them.

## Fix

1. **html_extractor.go** — `resolveURL` now normalizes `../` in absolute URLs via `url.ResolveReference`
2. **rewriter.go** — New `NormalizeHTMLURLs` function normalizes `../` in `src`/`href`/`poster` attributes before rewriting
3. **deduplicator.go** — Calls `NormalizeHTMLURLs` before `RewriteHTML` in both `ProcessCapture` and `UpdateCapture`

## Tested

- Unit tests added for both `NormalizeHTMLURLs` and `ExtractResources` with `../` URLs
- Verified on page 560 (okx.com) — all CSS now loads correctly
- All existing tests pass