### PR TITLE
fix: resolve OKX page blank space

### DIFF
--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -77,6 +77,11 @@ func (h *Handler) ViewPage(c *gin.Context) {
 		modifiedHTML = fixXcomLayout(modifiedHTML)
 	}
 
+	// 针对 OKX 网站的专项修复
+	if strings.Contains(page.URL, "okx.com") {
+		modifiedHTML = fixOKXLayout(modifiedHTML)
+	}
+
 	// 修复嵌套的 <button> 标签（HTML 规范不允许 button 嵌套 button）
 	// 浏览器遇到嵌套 button 时会隐式关闭外层 button，破坏 DOM 树结构，
 	// 导致后续元素（如 <main>、<section>）被提升到错误的层级
@@ -502,6 +507,21 @@ func fixXcomLayout(html string) string {
 	// 在 </head> 前注入
 	if idx := strings.Index(html, "</head>"); idx != -1 {
 		html = html[:idx] + xcomCSS + html[idx:]
+	}
+
+	return html
+}
+
+func fixOKXLayout(html string) string {
+	// .balance_okui-tabs 设置了 height:100%，在静态归档中会撑开大片空白
+	// .Balance_balanceBottom__vAGcz 设置了 min-height:640px，内容不足时也会产生空白
+	okxCSS := `<style>
+	.balance_okui-tabs { height: auto !important; }
+	[class*="Balance_balanceBottom"] { min-height: auto !important; }
+</style>`
+
+	if idx := strings.Index(html, "</head>"); idx != -1 {
+		html = html[:idx] + okxCSS + html[idx:]
 	}
 
 	return html

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -64,6 +64,28 @@ func TestFixNestedButtons_CaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestFixOKXLayout(t *testing.T) {
+	html := `<html><head><link rel="stylesheet" href="/archive/590/test.css"></head><body>
+<div class="balance_okui balance_okui-tabs-var balance_okui-tabs ">
+<div class="Balance_balanceBottom__vAGcz">content</div>
+</div></body></html>`
+
+	result := fixOKXLayout(html)
+
+	if !strings.Contains(result, ".balance_okui-tabs { height: auto !important; }") {
+		t.Error("Should inject CSS to fix .balance_okui-tabs height")
+	}
+	if !strings.Contains(result, `[class*="Balance_balanceBottom"] { min-height: auto !important; }`) {
+		t.Error("Should inject CSS to fix Balance_balanceBottom min-height")
+	}
+	// 确保注入在 </head> 之前
+	headIdx := strings.Index(result, "</head>")
+	styleIdx := strings.Index(result, ".balance_okui-tabs { height: auto")
+	if styleIdx > headIdx {
+		t.Error("CSS should be injected before </head>")
+	}
+}
+
 func TestFixNestedButtons_RealWorldPopover(t *testing.T) {
 	// Simulates the actual Vben Admin popover trigger pattern
 	html := `<header><button class="" id="reka-popover-trigger-v-3" type="button"><div class="flex-center"><button class="bell-button text-foreground"><svg>icon</svg></button></div></button></header>`


### PR DESCRIPTION
修复 OKX 页面（如 /view/590）大量空白的问题。

原因：
- `.balance_okui-tabs` 设置了 `height: 100%`，在静态归档中撑开大片空白
- `.Balance_balanceBottom__*` 设置了 `min-height: 640px`，内容不足时也产生空白

修复：在 view_handler 中为 OKX 页面注入覆盖 CSS，将 height 和 min-height 改为 auto。