### PR TITLE
feat: add robots.txt to block common search engine and AI crawlers

### DIFF
--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -21,6 +21,50 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig) {
 		c.Next()
 	})
 
+	// robots.txt（在认证之前，确保爬虫和工具可以访问）
+	r.GET("/robots.txt", func(c *gin.Context) {
+		robotsTxt := `User-agent: Googlebot
+Disallow: /
+
+User-agent: Bingbot
+Disallow: /
+
+User-agent: Slurp
+Disallow: /
+
+User-agent: DuckDuckBot
+Disallow: /
+
+User-agent: Baiduspider
+Disallow: /
+
+User-agent: YandexBot
+Disallow: /
+
+User-agent: Sogou
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: *
+Allow: /
+`
+		c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(robotsTxt))
+	})
+
 	// Basic Auth 中间件（如果启用）
 	if authCfg.Enabled() {
 		accounts := gin.Accounts{


### PR DESCRIPTION
添加 robots.txt 端点，屏蔽常见搜索引擎和 AI 爬虫（Googlebot、Bingbot、Baidu、Yandex、GPTBot、ClaudeBot 等），允许其他 User-agent 访问。

路由注册在 Basic Auth 中间件之前，无需认证即可获取。