### PR TITLE
fix: rewrite relative URLs with &amp; encoding and multi-value srcset

### DIFF
--- a/server/internal/storage/rewriter_fast.go
+++ b/server/internal/storage/rewriter_fast.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -101,10 +102,122 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 				`url('`+pathWithQuery+`')`, `url('`+localURL+`')`,
 				`url(`+pathWithQuery+`)`, `url(`+localURL+`)`,
 			)
+
+			// 5a. 绝对路径的 &amp; 编码变体（HTML 属性中 & 常被编码为 &amp;）
+			pathWithQueryEncoded := strings.ReplaceAll(pathWithQuery, "&", "&amp;")
+			if pathWithQueryEncoded != pathWithQuery {
+				pairs = append(pairs,
+					` src="`+pathWithQueryEncoded+`"`, ` src="`+localURL+`"`,
+					` href="`+pathWithQueryEncoded+`"`, ` href="`+localURL+`"`,
+					` poster="`+pathWithQueryEncoded+`"`, ` poster="`+localURL+`"`,
+					` srcset="`+pathWithQueryEncoded+`"`, ` srcset="`+localURL+`"`,
+					`url("`+pathWithQueryEncoded+`")`, `url("`+localURL+`")`,
+					`url('`+pathWithQueryEncoded+`')`, `url('`+localURL+`')`,
+					`url(`+pathWithQueryEncoded+`)`, `url(`+localURL+`)`,
+				)
+			}
 		}
 	}
 
 	// 使用 strings.NewReplacer 做单次遍历替换
 	replacer := strings.NewReplacer(pairs...)
-	return replacer.Replace(html)
+	html = replacer.Replace(html)
+
+	// 6. 处理多值 srcset/imagesrcset（如 srcset="url1 1x, url2 2x"）
+	// strings.NewReplacer 只能匹配 srcset="<单个URL>"，无法处理逗号分隔的多值
+	html = r.rewriteMultiValueSrcset(html)
+
+	return html
+}
+
+// rewriteMultiValueSrcset 重写 srcset 和 imagesrcset 属性中的多值 URL
+func (r *URLRewriter) rewriteMultiValueSrcset(html string) string {
+	// 构建 URL 查找表：各种 URL 变体 -> 本地 URL
+	urlMap := make(map[string]string)
+	for originalURL := range r.urlToLocalPath {
+		var localURL string
+		if r.pageID > 0 && r.timestamp != "" {
+			localURL = fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, originalURL)
+		} else {
+			localURL = "/archive/" + r.urlToLocalPath[originalURL]
+		}
+
+		// 绝对 URL
+		urlMap[originalURL] = localURL
+		// &amp; 编码
+		if enc := strings.ReplaceAll(originalURL, "&", "&amp;"); enc != originalURL {
+			urlMap[enc] = localURL
+		}
+		// 协议相对
+		pr := strings.TrimPrefix(strings.TrimPrefix(originalURL, "https:"), "http:")
+		if pr != originalURL && strings.HasPrefix(pr, "//") {
+			urlMap[pr] = localURL
+			if enc := strings.ReplaceAll(pr, "&", "&amp;"); enc != pr {
+				urlMap[enc] = localURL
+			}
+		}
+		// 绝对路径 + query
+		parsed, err := url.Parse(originalURL)
+		if err == nil && parsed.Path != "" {
+			pq := parsed.Path
+			if parsed.RawQuery != "" {
+				pq = parsed.Path + "?" + parsed.RawQuery
+			}
+			urlMap[pq] = localURL
+			if enc := strings.ReplaceAll(pq, "&", "&amp;"); enc != pq {
+				urlMap[enc] = localURL
+			}
+		}
+	}
+
+	// 匹配 srcset="..." 和 imagesrcset="..."
+	srcsetDQ := regexp.MustCompile(`(?i)((?:image)?srcset)="([^"]+)"`)
+	html = srcsetDQ.ReplaceAllStringFunc(html, func(match string) string {
+		sub := srcsetDQ.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		attrName := sub[1]
+		value := sub[2]
+		rewritten := rewriteSrcsetValue(value, urlMap)
+		if rewritten == value {
+			return match
+		}
+		return attrName + `="` + rewritten + `"`
+	})
+	srcsetSQ := regexp.MustCompile(`(?i)((?:image)?srcset)='([^']+)'`)
+	return srcsetSQ.ReplaceAllStringFunc(html, func(match string) string {
+		sub := srcsetSQ.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		attrName := sub[1]
+		value := sub[2]
+		rewritten := rewriteSrcsetValue(value, urlMap)
+		if rewritten == value {
+			return match
+		}
+		return attrName + `='` + rewritten + `'`
+	})
+}
+
+// rewriteSrcsetValue 重写 srcset 属性值中的各个 URL
+func rewriteSrcsetValue(value string, urlMap map[string]string) string {
+	changed := false
+	parts := strings.Split(value, ",")
+	for i, part := range parts {
+		fields := strings.Fields(strings.TrimSpace(part))
+		if len(fields) == 0 {
+			continue
+		}
+		if local, ok := urlMap[fields[0]]; ok {
+			fields[0] = local
+			parts[i] = " " + strings.Join(fields, " ")
+			changed = true
+		}
+	}
+	if !changed {
+		return value
+	}
+	return strings.TrimLeft(strings.Join(parts, ","), " ")
 }

--- a/server/internal/storage/rewriter_test.go
+++ b/server/internal/storage/rewriter_test.go
@@ -161,3 +161,65 @@ func TestRewriteHTML_NormalSrcHref(t *testing.T) {
 		t.Errorf("src should be rewritten, got: %s", result)
 	}
 }
+
+func TestRewriteHTML_RelativePathWithAmpEncoding(t *testing.T) {
+	// Next.js image optimization URLs: relative path with &amp; in HTML
+	r := newTestRewriter(631, "20260312101010", map[string]string{
+		"https://www.moltbook.com/_next/image?url=%2Fmoltbook-transparent.png&w=384&q=75": "resources/ab/cd/hash.img",
+		"https://www.moltbook.com/_next/image?url=%2Fmoltbook-transparent.png&w=64&q=75":  "resources/ab/cd/hash2.img",
+	})
+
+	// HTML has relative path with &amp; encoding
+	html := `<img src="/_next/image?url=%2Fmoltbook-transparent.png&amp;w=384&amp;q=75">`
+	result := r.RewriteHTML(html)
+
+	expected := `src="/archive/631/20260312101010mp_/https://www.moltbook.com/_next/image?url=%2Fmoltbook-transparent.png&w=384&q=75"`
+	if !strings.Contains(result, expected) {
+		t.Errorf("relative path with &amp; should be rewritten to archive path, got: %s", result)
+	}
+}
+
+func TestRewriteHTML_MultiValueSrcset(t *testing.T) {
+	r := newTestRewriter(631, "20260312101010", map[string]string{
+		"https://www.moltbook.com/_next/image?url=%2Fmoltbook-transparent.png&w=256&q=75": "resources/ab/cd/hash1.img",
+		"https://www.moltbook.com/_next/image?url=%2Fmoltbook-transparent.png&w=384&q=75": "resources/ab/cd/hash2.img",
+	})
+
+	// Multi-value srcset with &amp; encoding and descriptors
+	html := `<link rel="preload" as="image" imagesrcset="/_next/image?url=%2Fmoltbook-transparent.png&amp;w=256&amp;q=75 1x, /_next/image?url=%2Fmoltbook-transparent.png&amp;w=384&amp;q=75 2x">`
+	result := r.RewriteHTML(html)
+
+	if !strings.Contains(result, `/archive/631/20260312101010mp_/https://www.moltbook.com/_next/image`) {
+		t.Errorf("multi-value srcset URLs should be rewritten to archive paths, got: %s", result)
+	}
+	if !strings.Contains(result, `1x`) || !strings.Contains(result, `2x`) {
+		t.Errorf("srcset descriptors should be preserved, got: %s", result)
+	}
+	// Should not contain unrewritten relative paths
+	if strings.Contains(result, `"/_next/image`) {
+		t.Errorf("should not contain unrewritten relative paths, got: %s", result)
+	}
+}
+
+func TestRewriteHTML_MultiValueSrcsetOnImg(t *testing.T) {
+	r := newTestRewriter(631, "20260312101010", map[string]string{
+		"https://www.moltbook.com/_next/image?url=%2Flogo.png&w=32&q=75": "resources/ab/cd/hash1.img",
+		"https://www.moltbook.com/_next/image?url=%2Flogo.png&w=64&q=75": "resources/ab/cd/hash2.img",
+	})
+
+	html := `<img srcset="/_next/image?url=%2Flogo.png&amp;w=32&amp;q=75 1x, /_next/image?url=%2Flogo.png&amp;w=64&amp;q=75 2x" src="/_next/image?url=%2Flogo.png&amp;w=64&amp;q=75">`
+	result := r.RewriteHTML(html)
+
+	// src should be rewritten
+	if !strings.Contains(result, `src="/archive/631/20260312101010mp_/`) {
+		t.Errorf("src should be rewritten to archive path, got: %s", result)
+	}
+	// srcset should be rewritten
+	if !strings.Contains(result, `srcset="/archive/631/20260312101010mp_/`) {
+		t.Errorf("srcset should be rewritten to archive path, got: %s", result)
+	}
+	// Should not contain unrewritten relative paths
+	if strings.Contains(result, `"/_next/image`) || strings.Contains(result, ` /_next/image`) {
+		t.Errorf("should not contain unrewritten relative paths, got: %s", result)
+	}
+}


### PR DESCRIPTION
## Problem

Archived pages with Next.js `/_next/image?url=...&w=...&q=...` URLs were not being rewritten to local archive paths. Two root causes:

1. **`&amp;` encoding in relative paths**: The HTML contains `&amp;`-encoded query params (e.g. `/_next/image?url=%2Flogo.png&amp;w=384&amp;q=75`), but the rewriter's step 5 (absolute path matching) only generated unencoded variants.

2. **Multi-value `srcset`/`imagesrcset`**: Attributes like `srcset="url1 1x, url2 2x"` contain comma-separated URLs. The `strings.NewReplacer` approach only matched single-URL srcset values.

## Fix

- **Step 5a**: Generate `&amp;`-encoded variants for path+query replacement pairs
- **Step 6**: Add `rewriteMultiValueSrcset()` post-processing that parses comma-separated srcset values and rewrites each URL individually
- Handles both `srcset` and `imagesrcset` attributes, double and single quotes

## Tests

Added 3 new test cases:
- `TestRewriteHTML_RelativePathWithAmpEncoding`
- `TestRewriteHTML_MultiValueSrcset`
- `TestRewriteHTML_MultiValueSrcsetOnImg`

Reported on page 631 (`https://www.moltbook.com/`).