### PR TITLE
fix: improve error message clarity when server is not running

### DIFF
--- a/server/web/index.html
+++ b/server/web/index.html
@@ -593,6 +593,10 @@
                 if (dateTo) url += `&to=${dateTo}`;
 
                 const response = await fetch(url);
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || `HTTP ${response.status}`);
+                }
                 const data = await response.json();
 
                 // Handle new paginated response format
@@ -610,7 +614,7 @@
                 renderPages(allPages);
                 updatePagination();
             } catch (error) {
-                document.getElementById('pageList').innerHTML = '<li class="empty"><div class="empty-icon">[ ! ]</div>Failed to load archives</li>';
+                document.getElementById('pageList').innerHTML = '<li class="empty"><div class="empty-icon">[ ! ]</div>Unable to connect to server. Please check if the server is running.</li>';
             }
         }
 

--- a/server/web/timeline.html
+++ b/server/web/timeline.html
@@ -263,7 +263,10 @@
         async function loadTimeline(url) {
             try {
                 const response = await fetch(`/api/pages/timeline?url=${encodeURIComponent(url)}`);
-                if (!response.ok) throw new Error('Failed to load timeline');
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || `HTTP ${response.status}`);
+                }
                 const data = await response.json();
 
                 const snapshots = data.snapshots || [];
@@ -277,7 +280,7 @@
                 renderTimeline(snapshots);
             } catch (error) {
                 console.error('Timeline error:', error);
-                document.getElementById('content').innerHTML = '<div class="empty">Failed to load timeline.</div>';
+                document.getElementById('content').innerHTML = '<div class="empty">Unable to connect to server. Please check if the server is running.</div>';
             }
         }
 


### PR DESCRIPTION
## Summary

改进当服务器未运行时的错误消息提示，避免误导用户以为发生了错误。

## Changes

- `server/web/index.html`:
  - 将 "Failed to load archives" 改为 "Unable to connect to server. Please check if the server is running."
  - 添加 `response.ok` 检查，正确处理 HTTP 错误状态

- `server/web/timeline.html`:
  - 同样改进错误消息
  - 添加 `response.ok` 检查

## Behavior

| 场景 | 显示消息 |
|------|---------|
| 数据库为空（正常） | "No archived pages found" |
| 服务器未运行 | "Unable to connect to server. Please check if the server is running." |

🤖 Generated with [Claude Code](https://claude.com/claude-code)