### PR TITLE
fix: use nonce-based script to fix header overlap with fixed/sticky elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tests/root/*.png
 tests/server/*.log
 tests/server/*.png
 tests/browser/*.log
+tests/browser/*.png
 
 # Data directories
 server/data/

--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -9,7 +9,7 @@ import (
 )
 
 // injectArchiveHeader 在页面顶部注入归档信息栏
-func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next *models.Page, snapshotTotal int) string {
+func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next *models.Page, snapshotTotal int, nonce string) string {
 	// 格式化时间
 	capturedTime := page.CapturedAt.Format("2006-01-02 15:04:05")
 
@@ -73,7 +73,25 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 	</div>
 </div>
 <style>
-	body { margin-top: 48px !important; }
+	:root {
+		--wayback-header-height: 48px;
+	}
+	body {
+		margin-top: var(--wayback-header-height) !important;
+		padding-top: 0 !important;
+	}
+	/* 将页面自身的 fixed/sticky 顶部元素下移，避免被归档 header 遮挡 */
+	/* 针对内联样式定义的 fixed/sticky 元素 */
+	[style*="position: fixed"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position:fixed"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position: fixed"][style*="top:0"]:not(#wayback-archive-header),
+	[style*="position:fixed"][style*="top:0"]:not(#wayback-archive-header),
+	[style*="position: sticky"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position:sticky"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position: sticky"][style*="top:0"]:not(#wayback-archive-header),
+	[style*="position:sticky"][style*="top:0"]:not(#wayback-archive-header) {
+		top: var(--wayback-header-height) !important;
+	}
 	/* SPA 框架常用 height:100%% 配合 JS 滚动，静态模式下会截断内容 */
 	html, body, #app, #root, #__next, #__nuxt {
 		height: auto !important;
@@ -95,7 +113,41 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		transform: none !important;
 	}
 </style>
-`, page.URL, escapeHTML(page.URL), escapeHTML(page.URL), capturedTime, navHTML)
+<script nonce="%s">
+(function() {
+	'use strict';
+	// 修复所有 fixed/sticky 定位的顶部元素，避免被归档 header 遮挡
+	function fixPositionedElements() {
+		const HEADER_HEIGHT = 48;
+		const elements = document.querySelectorAll('*:not(#wayback-archive-header):not(#wayback-archive-header *)');
+
+		elements.forEach(function(el) {
+			const style = window.getComputedStyle(el);
+			const position = style.position;
+			const top = style.top;
+
+			// 检查是否是 fixed 或 sticky 定位，且 top 为 0 或接近 0
+			if ((position === 'fixed' || position === 'sticky') &&
+			    (top === '0px' || top === '0' || parseInt(top) === 0)) {
+				// 设置新的 top 值，避免被归档 header 遮挡
+				el.style.setProperty('top', HEADER_HEIGHT + 'px', 'important');
+			}
+		});
+	}
+
+	// 页面加载完成后执行
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', fixPositionedElements);
+	} else {
+		fixPositionedElements();
+	}
+
+	// 延迟执行一次，确保动态加载的元素也被处理
+	setTimeout(fixPositionedElements, 100);
+	setTimeout(fixPositionedElements, 500);
+})();
+</script>
+`, page.URL, escapeHTML(page.URL), escapeHTML(page.URL), capturedTime, navHTML, nonce)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -87,13 +87,14 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	// 导致后续元素（如 <main>、<section>）被提升到错误的层级
 	modifiedHTML = fixNestedButtons(modifiedHTML)
 
-	// 注入归档信息栏
-	modifiedHTML = injectArchiveHeader(modifiedHTML, page, prev, next, snapshotTotal)
+	// 注入归档信息栏（传入 nonce 用于 CSP）
+	nonce := "wayback-fix-positioning"
+	modifiedHTML = injectArchiveHeader(modifiedHTML, page, prev, next, snapshotTotal, nonce)
 
-	// 设置安全响应头（禁用所有脚本）
+	// 设置安全响应头（允许带 nonce 的内联脚本，用于修复定位问题）
 	c.Header("X-Frame-Options", "SAMEORIGIN")
 	c.Header("Referrer-Policy", "no-referrer")
-	c.Header("Content-Security-Policy", "default-src 'self'; script-src 'none'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'none'; object-src 'none';")
+	c.Header("Content-Security-Policy", fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'none'; object-src 'none';", nonce))
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(modifiedHTML))
 }

--- a/tests/browser/test-header-fix.js
+++ b/tests/browser/test-header-fix.js
@@ -1,0 +1,124 @@
+const puppeteer = require('puppeteer');
+
+async function testHeaderOverlap() {
+  const browser = await puppeteer.launch({
+    headless: true,
+    executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 800 });
+
+    // 访问归档页面
+    console.log('访问归档页面: http://localhost:8080/view/855');
+    await page.goto('http://localhost:8080/view/855', {
+      waitUntil: 'networkidle2',
+      timeout: 30000
+    });
+
+    // 等待页面加载完成
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // 检查归档 header 是否存在
+    const archiveHeader = await page.$('#wayback-archive-header');
+    if (!archiveHeader) {
+      console.error('❌ 归档 header 未找到');
+      return false;
+    }
+    console.log('✓ 归档 header 存在');
+
+    // 获取归档 header 的高度和位置
+    const headerBox = await archiveHeader.boundingBox();
+    console.log(`归档 header 位置: top=${headerBox.y}, height=${headerBox.height}`);
+
+    // 查找所有 fixed/sticky 定位的元素
+    const positionedElements = await page.evaluate(() => {
+      const elements = [];
+      const allElements = document.querySelectorAll('*:not(#wayback-archive-header):not(#wayback-archive-header *)');
+
+      allElements.forEach(el => {
+        const style = window.getComputedStyle(el);
+        const position = style.position;
+        const top = style.top;
+        const zIndex = style.zIndex;
+
+        if ((position === 'fixed' || position === 'sticky') &&
+            (top === '0px' || parseInt(top) >= 0 && parseInt(top) <= 50)) {
+          const rect = el.getBoundingClientRect();
+          elements.push({
+            tag: el.tagName,
+            className: el.className,
+            id: el.id,
+            position: position,
+            top: top,
+            zIndex: zIndex,
+            rect: {
+              top: rect.top,
+              left: rect.left,
+              width: rect.width,
+              height: rect.height
+            }
+          });
+        }
+      });
+
+      return elements;
+    });
+
+    console.log(`\n找到 ${positionedElements.length} 个 fixed/sticky 定位的顶部元素:`);
+    positionedElements.forEach((el, index) => {
+      console.log(`\n元素 ${index + 1}:`);
+      console.log(`  标签: ${el.tag}`);
+      console.log(`  类名: ${el.className || '(无)'}`);
+      console.log(`  ID: ${el.id || '(无)'}`);
+      console.log(`  position: ${el.position}`);
+      console.log(`  top: ${el.top}`);
+      console.log(`  z-index: ${el.zIndex}`);
+      console.log(`  实际位置: top=${el.rect.top}, left=${el.rect.left}`);
+      console.log(`  尺寸: width=${el.rect.width}, height=${el.rect.height}`);
+
+      // 检查是否与归档 header 重叠
+      const headerBottom = headerBox.y + headerBox.height;
+      const isVisible = el.rect.width > 0 && el.rect.height > 0;
+      if (!isVisible) {
+        console.log(`  ⏭️  跳过: 不可见元素 (尺寸为 0)`);
+      } else if (el.rect.top < headerBottom) {
+        console.log(`  ⚠️  警告: 此元素与归档 header 重叠! (元素 top=${el.rect.top} < header bottom=${headerBottom})`);
+      } else {
+        console.log(`  ✓ 此元素未与归档 header 重叠`);
+      }
+    });
+
+    // 截图保存
+    await page.screenshot({ path: 'tests/browser/header-test-screenshot.png', fullPage: true });
+    console.log('\n✓ 截图已保存到 tests/browser/header-test-screenshot.png');
+
+    // 检查是否有可见元素重叠（忽略零尺寸的不可见元素）
+    const hasOverlap = positionedElements.some(el => {
+      const headerBottom = headerBox.y + headerBox.height;
+      const isVisible = el.rect.width > 0 && el.rect.height > 0;
+      return isVisible && el.rect.top < headerBottom;
+    });
+
+    if (hasOverlap) {
+      console.log('\n❌ 测试失败: 发现可见元素与归档 header 重叠');
+      return false;
+    } else {
+      console.log('\n✅ 测试通过: 所有可见的 fixed/sticky 元素都已正确下移，未与归档 header 重叠');
+      return true;
+    }
+
+  } catch (error) {
+    console.error('测试出错:', error);
+    return false;
+  } finally {
+    await browser.close();
+  }
+}
+
+// 运行测试
+testHeaderOverlap().then(success => {
+  process.exit(success ? 0 : 1);
+});


### PR DESCRIPTION
## 问题

归档页面顶部的搜索框等 fixed/sticky 定位元素会被归档 header 遮挡。之前的 CSS 方案只能匹配内联 style 属性中的 `position: fixed`，无法处理通过 CSS 类定义定位的元素。

## 方案

- 注入带 nonce 的内联脚本，使用 `getComputedStyle` 检测所有 fixed/sticky + top:0 的元素，将其 top 下移 48px
- CSP 从 `script-src 'none'` 改为 `script-src 'nonce-...'`，仅允许修复脚本执行
- 保留原有的 CSS 属性选择器作为 fallback

## 测试

Puppeteer 测试验证通过：所有可见的 fixed/sticky 元素均正确下移，未与归档 header 重叠。