### PR TITLE
fix: rewrite ./relative paths in RewriteHTMLFast

### DIFF
--- a/server/internal/storage/rewriter_fast.go
+++ b/server/internal/storage/rewriter_fast.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 )
@@ -115,6 +116,39 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 					`url('`+pathWithQueryEncoded+`')`, `url('`+localURL+`')`,
 					`url(`+pathWithQueryEncoded+`)`, `url(`+localURL+`)`,
 				)
+			}
+
+			// 5b. 相对路径变体（如 ./style.css）
+			// 从绝对路径中提取文件名部分，生成 ./ 前缀的相对路径
+			fileName := path.Base(parsed.Path)
+			if fileName != "" && fileName != "." && fileName != "/" {
+				relWithQuery := "./" + fileName
+				if parsed.RawQuery != "" {
+					relWithQuery = "./" + fileName + "?" + parsed.RawQuery
+				}
+				pairs = append(pairs,
+					` src="`+relWithQuery+`"`, ` src="`+localURL+`"`,
+					` href="`+relWithQuery+`"`, ` href="`+localURL+`"`,
+					` poster="`+relWithQuery+`"`, ` poster="`+localURL+`"`,
+					` srcset="`+relWithQuery+`"`, ` srcset="`+localURL+`"`,
+					`url("`+relWithQuery+`")`, `url("`+localURL+`")`,
+					`url('`+relWithQuery+`')`, `url('`+localURL+`')`,
+					`url(`+relWithQuery+`)`, `url(`+localURL+`)`,
+				)
+
+				// 5c. &amp; 编码变体
+				relEncoded := strings.ReplaceAll(relWithQuery, "&", "&amp;")
+				if relEncoded != relWithQuery {
+					pairs = append(pairs,
+						` src="`+relEncoded+`"`, ` src="`+localURL+`"`,
+						` href="`+relEncoded+`"`, ` href="`+localURL+`"`,
+						` poster="`+relEncoded+`"`, ` poster="`+localURL+`"`,
+						` srcset="`+relEncoded+`"`, ` srcset="`+localURL+`"`,
+						`url("`+relEncoded+`")`, `url("`+localURL+`")`,
+						`url('`+relEncoded+`')`, `url('`+localURL+`')`,
+						`url(`+relEncoded+`)`, `url(`+localURL+`)`,
+					)
+				}
 			}
 		}
 	}

--- a/server/internal/storage/rewriter_test.go
+++ b/server/internal/storage/rewriter_test.go
@@ -201,6 +201,30 @@ func TestRewriteHTML_MultiValueSrcset(t *testing.T) {
 	}
 }
 
+func TestRewriteHTML_DotSlashRelativePath(t *testing.T) {
+	r := newTestRewriter(990, "20260313", map[string]string{
+		"https://newshacker.me/style.css":  "resources/2c/09/hash.css",
+		"https://newshacker.me/favicon.png": "resources/f9/22/hash.img",
+		"https://newshacker.me/shared.js":   "resources/4d/ee/hash.js",
+	})
+
+	html := `<link rel="stylesheet" href="./style.css"><link rel="icon" href="./favicon.png"><script src="./shared.js"></script>`
+	result := r.RewriteHTML(html)
+
+	if strings.Contains(result, `"./style.css"`) {
+		t.Errorf("./style.css should be rewritten, got: %s", result)
+	}
+	if strings.Contains(result, `"./favicon.png"`) {
+		t.Errorf("./favicon.png should be rewritten, got: %s", result)
+	}
+	if strings.Contains(result, `"./shared.js"`) {
+		t.Errorf("./shared.js should be rewritten, got: %s", result)
+	}
+	if !strings.Contains(result, `/archive/990/20260313mp_/https://newshacker.me/style.css`) {
+		t.Errorf("Expected rewritten style.css URL, got: %s", result)
+	}
+}
+
 func TestRewriteHTML_MultiValueSrcsetOnImg(t *testing.T) {
 	r := newTestRewriter(631, "20260312101010", map[string]string{
 		"https://www.moltbook.com/_next/image?url=%2Flogo.png&w=32&q=75": "resources/ab/cd/hash1.img",


### PR DESCRIPTION
## Problem

`RewriteHTMLFast` only generated replacement pairs for absolute URLs, protocol-relative URLs, and absolute paths (e.g. `/style.css`). It missed `./` prefixed relative paths like `href="./style.css"`, causing CSS and other resources to not be replaced in archived HTML.

The old regex-based `rewriteHTMLRegex` handled this (lines 160-178), but the logic was lost when switching to the fast string replacer.

## Fix

Added section 5b/5c in `RewriteHTMLFast` to generate `./filename` replacement pairs (with `&amp;` encoding variants) for each resource URL.

## Testing

- Added `TestRewriteHTML_DotSlashRelativePath` covering `./style.css`, `./favicon.png`, `./shared.js`
- All existing rewriter tests pass
- Verified with new archive of https://newshacker.me/ (page 990 equivalent)