### PR TITLE
fix: skip degraded DOM updates when tab is hidden or content shrinks

### DIFF
--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -38,6 +38,7 @@ function initializeArchiver(): void {
   let currentPageId: number | null = null;
   let updateCount = 0;
   const MAX_UPDATES = 1;
+  let initialHTMLSize = 0; // Track initial capture size for update quality guard
 
   // Collects nodes removed by virtual scrolling so we can merge them into the update snapshot
   let domCollector: DOMCollector | null = null;
@@ -91,6 +92,7 @@ function initializeArchiver(): void {
         headers,
       };
 
+      initialHTMLSize = html.length;
       console.log('[Wayback] ✓ Data prepared, size:', JSON.stringify(captureData).length, 'bytes');
     } catch (error) {
       console.error('[Wayback] Failed to prepare:', error);
@@ -157,6 +159,14 @@ function initializeArchiver(): void {
       debounceTimer = nativeSetTimeout(async () => {
         // Guard: only proceed if the page ID hasn't changed (SPA navigation resets it)
         if (mutationCount >= CONFIG.UPDATE_MIN_MUTATIONS && monitorPageId && monitorPageId === currentPageId && updateCount < MAX_UPDATES) {
+          // Guard: skip update when tab is hidden — sites like X.com aggressively strip DOM
+          // nodes when the tab loses focus, producing a degraded snapshot
+          if (document.visibilityState === 'hidden') {
+            console.log(`[Wayback] Skipping update: tab is hidden (DOM may be stripped)`);
+            mutationCount = 0;
+            return;
+          }
+
           console.log(`[Wayback] DOM changed (${mutationCount} mutations), triggering update...`);
           updateCount++;
           stopDOMChangeMonitor();
@@ -174,6 +184,13 @@ function initializeArchiver(): void {
             if (domCollector && domCollector.collectedCount > 0) {
               console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes...`);
               newHTML = domCollector.mergeInto(newHTML);
+            }
+
+            // Guard: reject update if HTML shrunk significantly (< 70% of initial capture)
+            // This catches DOM virtualization stripping content even when tab appears visible
+            if (initialHTMLSize > 0 && newHTML.length < initialHTMLSize * 0.7) {
+              console.log(`[Wayback] Skipping update: HTML shrunk too much (${newHTML.length} vs initial ${initialHTMLSize}, ${Math.round(newHTML.length / initialHTMLSize * 100)}%)`);
+              return;
             }
 
             const newCaptureData: CaptureData = {


### PR DESCRIPTION
## Problem

Sites like X.com aggressively strip DOM nodes when the tab loses focus (visibility change). The DOM monitor's MutationObserver detects these removals as changes, triggers an update, and captures a degraded snapshot that overwrites the original good one.

In the case of page 1054 (an X.com tweet), the initial capture had 7438 elements, but after the tab went hidden, X.com stripped the DOM down to 4470 elements. The DOMCollector only recovered 88 of ~3000 missing nodes, and the degraded update replaced the original.

## Fix

Two guards added to the update path in `browser/src/main.ts`:

1. **Visibility guard** — skip update when `document.visibilityState === 'hidden'`, since that's when DOM virtualization strips content
2. **Size guard** — reject update if HTML size drops below 70% of the initial capture, as a safety net against DOM stripping even when the tab appears visible

## Testing

- `cd browser && npm run build` — compiles cleanly
- Reinstall `wayback.user.js` in Tampermonkey, browse to X.com tweet, switch tabs → console shows `Skipping update: tab is hidden` instead of sending degraded update