### PR TITLE
fix: rewrite bare relative paths in HTML resource URLs

### DIFF
--- a/server/internal/storage/rewriter_fast.go
+++ b/server/internal/storage/rewriter_fast.go
@@ -118,13 +118,17 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 				)
 			}
 
-			// 5b. 相对路径变体（如 ./style.css）
-			// 从绝对路径中提取文件名部分，生成 ./ 前缀的相对路径
+			// 5b. 相对路径变体（如 ./style.css 和 style.css）
+			// 从绝对路径中提取文件名部分，生成相对路径变体
 			fileName := path.Base(parsed.Path)
 			if fileName != "" && fileName != "." && fileName != "/" {
+				// 带 ./ 前缀的相对路径
 				relWithQuery := "./" + fileName
+				// 裸文件名（不带 ./ 前缀）
+				bareWithQuery := fileName
 				if parsed.RawQuery != "" {
 					relWithQuery = "./" + fileName + "?" + parsed.RawQuery
+					bareWithQuery = fileName + "?" + parsed.RawQuery
 				}
 				pairs = append(pairs,
 					` src="`+relWithQuery+`"`, ` src="`+localURL+`"`,
@@ -135,6 +139,19 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 					`url('`+relWithQuery+`')`, `url('`+localURL+`')`,
 					`url(`+relWithQuery+`)`, `url(`+localURL+`)`,
 				)
+
+				// 裸文件名变体（如 style.css，不带 ./ 前缀）
+				if bareWithQuery != pathWithQuery {
+					pairs = append(pairs,
+						` src="`+bareWithQuery+`"`, ` src="`+localURL+`"`,
+						` href="`+bareWithQuery+`"`, ` href="`+localURL+`"`,
+						` poster="`+bareWithQuery+`"`, ` poster="`+localURL+`"`,
+						` srcset="`+bareWithQuery+`"`, ` srcset="`+localURL+`"`,
+						`url("`+bareWithQuery+`")`, `url("`+localURL+`")`,
+						`url('`+bareWithQuery+`')`, `url('`+localURL+`')`,
+						`url(`+bareWithQuery+`)`, `url(`+localURL+`)`,
+					)
+				}
 
 				// 5c. &amp; 编码变体
 				relEncoded := strings.ReplaceAll(relWithQuery, "&", "&amp;")
@@ -147,6 +164,18 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 						`url("`+relEncoded+`")`, `url("`+localURL+`")`,
 						`url('`+relEncoded+`')`, `url('`+localURL+`')`,
 						`url(`+relEncoded+`)`, `url(`+localURL+`)`,
+					)
+				}
+				bareEncoded := strings.ReplaceAll(bareWithQuery, "&", "&amp;")
+				if bareEncoded != bareWithQuery {
+					pairs = append(pairs,
+						` src="`+bareEncoded+`"`, ` src="`+localURL+`"`,
+						` href="`+bareEncoded+`"`, ` href="`+localURL+`"`,
+						` poster="`+bareEncoded+`"`, ` poster="`+localURL+`"`,
+						` srcset="`+bareEncoded+`"`, ` srcset="`+localURL+`"`,
+						`url("`+bareEncoded+`")`, `url("`+localURL+`")`,
+						`url('`+bareEncoded+`')`, `url('`+localURL+`')`,
+						`url(`+bareEncoded+`)`, `url(`+localURL+`)`,
 					)
 				}
 			}

--- a/server/internal/storage/rewriter_test.go
+++ b/server/internal/storage/rewriter_test.go
@@ -225,6 +225,34 @@ func TestRewriteHTML_DotSlashRelativePath(t *testing.T) {
 	}
 }
 
+func TestRewriteHTML_BareRelativePath(t *testing.T) {
+	// Bare relative paths without ./ prefix (e.g., SPA apps like Angular)
+	r := newTestRewriter(1104, "20260313144244", map[string]string{
+		"https://dash.3ue.co/zh-Hans/styles-V46MLXWF.css": "resources/74/33/hash.css",
+		"https://dash.3ue.co/zh-Hans/main-QVKUS6BA.js":    "resources/87/4b/hash.js",
+		"https://dash.3ue.co/zh-Hans/polyfills-TR5YYZNL.js": "resources/32/bc/hash.js",
+	})
+
+	html := `<link rel="stylesheet" href="styles-V46MLXWF.css" media="all"><script src="main-QVKUS6BA.js" type="module"></script><link rel="modulepreload" href="polyfills-TR5YYZNL.js">`
+	result := r.RewriteHTML(html)
+
+	if strings.Contains(result, `"styles-V46MLXWF.css"`) {
+		t.Errorf("bare relative CSS should be rewritten, got: %s", result)
+	}
+	if strings.Contains(result, `"main-QVKUS6BA.js"`) {
+		t.Errorf("bare relative JS should be rewritten, got: %s", result)
+	}
+	if strings.Contains(result, `"polyfills-TR5YYZNL.js"`) {
+		t.Errorf("bare relative modulepreload should be rewritten, got: %s", result)
+	}
+	if !strings.Contains(result, `/archive/1104/20260313144244mp_/https://dash.3ue.co/zh-Hans/styles-V46MLXWF.css`) {
+		t.Errorf("Expected rewritten CSS URL, got: %s", result)
+	}
+	if !strings.Contains(result, `/archive/1104/20260313144244mp_/https://dash.3ue.co/zh-Hans/main-QVKUS6BA.js`) {
+		t.Errorf("Expected rewritten JS URL, got: %s", result)
+	}
+}
+
 func TestRewriteHTML_MultiValueSrcsetOnImg(t *testing.T) {
 	r := newTestRewriter(631, "20260312101010", map[string]string{
 		"https://www.moltbook.com/_next/image?url=%2Flogo.png&w=32&q=75": "resources/ab/cd/hash1.img",


### PR DESCRIPTION
## Problem

`RewriteHTMLFast` only generated replacement pairs for relative paths with `./` prefix (e.g., `./styles.css`), but not for bare filenames (e.g., `styles.css`). This caused SPA apps (like Angular) that use bare relative paths to fail loading CSS/JS resources in archived pages.

Example: `https://dash.3ue.co/zh-Hans/#/page/m/home` had `<link href="styles-V46MLXWF.css">` which was never rewritten to the archive path.

## Fix

Add bare filename variants (without `./` prefix) to the replacement pairs in `RewriteHTMLFast`, alongside the existing `./`-prefixed variants. Also handles `&amp;` encoded forms.

## Test

- Added `TestRewriteHTML_BareRelativePath` covering CSS, JS, and modulepreload with bare relative paths
- All existing rewriter tests pass