### PR TITLE
fix: skip HTML/BODY inlining and preserve margin:auto centering in style-inliner

### DIFF
--- a/browser/src/style-inliner.ts
+++ b/browser/src/style-inliner.ts
@@ -28,6 +28,7 @@ const LAYOUT_PROPS = [
 const SKIP_TAGS = new Set([
   'SCRIPT', 'STYLE', 'LINK', 'META', 'TITLE', 'HEAD', 'BR', 'HR', 'NOSCRIPT',
   'BASE', 'COL', 'COLGROUP', 'PARAM', 'SOURCE', 'TRACK', 'WBR',
+  'HTML', 'BODY',  // 跳过顶层容器，避免固化视口相关的尺寸（如 min-width）
 ]);
 
 // 默认值 — computed 值等于默认值时跳过，减少 HTML 体积
@@ -166,6 +167,22 @@ export function inlineLayoutStyles(): string {
           const ref = prop === 'width' ? vw : vh;
           if (Math.abs(px - ref) / ref < 0.05) continue;
         }
+      }
+      // 跳过与 max-width/max-height 相等的 width/height（冗余，且会破坏响应式布局）
+      if (prop === 'width') {
+        const maxWidth = computed.getPropertyValue('max-width');
+        if (maxWidth && maxWidth !== 'none' && value === maxWidth) continue;
+      }
+      if (prop === 'height') {
+        const maxHeight = computed.getPropertyValue('max-height');
+        if (maxHeight && maxHeight !== 'none' && value === maxHeight) continue;
+      }
+      // 跳过 margin: auto 居中布局（computed 会把 auto 解析为像素值，固化后破坏居中）
+      if (prop === 'margin-left' || prop === 'margin-right') {
+        const ml = computed.getPropertyValue('margin-left');
+        const mr = computed.getPropertyValue('margin-right');
+        const mw = computed.getPropertyValue('max-width');
+        if (ml === mr && parseFloat(ml) > 0 && mw && mw !== 'none') continue;
       }
       parts.push(`${prop}:${value}`);
     }


### PR DESCRIPTION
## 问题

V2EX 快照页面 (view/1163) 右侧出现大片空白区域，真实网页没有此问题。

## 原因

style-inliner 将 computed style 内联到元素时存在三个问题：

1. **body 标签被内联 `min-width:820px`**，强制页面最小宽度
2. **width 与 max-width 相等时仍被内联**，冗余且破坏响应式布局
3. **`margin: auto` 被解析为固定像素值内联**（如 `margin-left:28.4px`），破坏居中布局

## 修复

- 跳过 HTML/BODY 标签的样式内联
- 当 `width == max-width` 时跳过 width 内联
- 当 `margin-left == margin-right` 且存在 max-width 时跳过 margin 内联（保留 `margin: auto` 居中）