### PR TITLE
feat: auto-detect system username as default database user

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Chrome + Tampermonkey ──HTTP POST──▶ Go Server ──▶ PostgreSQL (m
 ### 1. Database Setup
 
 ```bash
-createdb -U postgres wayback
-psql -U postgres wayback < server/init_db.sql
+# PostgreSQL 默认使用当前系统用户名作为数据库用户
+# 如果你的系统用户名是 alice，以下命令等同于 createdb -U alice wayback
+createdb wayback
+psql wayback < server/init_db.sql
 ```
 
 ### 2. Start the Server
@@ -103,7 +105,7 @@ Environment variables (or `.env` file in `server/`):
 |---|---|---|
 | `DB_HOST` | `localhost` | PostgreSQL host |
 | `DB_PORT` | `5432` | PostgreSQL port |
-| `DB_USER` | `postgres` | Database user |
+| `DB_USER` | `postgres` | Database user (PostgreSQL 默认使用系统用户名，建议不设置此变量) |
 | `DB_PASSWORD` | *(empty)* | Database password |
 | `DB_NAME` | `wayback` | Database name |
 | `DB_SSLMODE` | `disable` | SSL mode |

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,7 +3,7 @@
 # 数据库配置
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=postgres
+# DB_USER=postgres  # 可选，默认使用当前系统用户名（$USER 环境变量）
 DB_PASSWORD=
 DB_NAME=wayback
 DB_SSLMODE=disable

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -49,11 +49,17 @@ func (a *AuthConfig) Enabled() bool {
 
 // LoadFromEnv loads configuration from environment variables with sensible defaults
 func LoadFromEnv() (*Config, error) {
+	// 默认使用当前系统用户名作为数据库用户（PostgreSQL 默认行为）
+	defaultUser := os.Getenv("USER")
+	if defaultUser == "" {
+		defaultUser = "postgres" // fallback for systems without USER env var
+	}
+
 	cfg := &Config{
 		Database: DatabaseConfig{
 			Host:     getEnv("DB_HOST", "localhost"),
 			Port:     getEnvInt("DB_PORT", 5432),
-			User:     getEnv("DB_USER", "postgres"),
+			User:     getEnv("DB_USER", defaultUser),
 			Password: getEnv("DB_PASSWORD", ""),
 			DBName:   getEnv("DB_NAME", "wayback"),
 			SSLMode:  getEnv("DB_SSLMODE", "disable"),

--- a/skill.md
+++ b/skill.md
@@ -37,9 +37,9 @@ Before using this skill, ensure the Wayback Archiver server is running:
 git clone https://github.com/icodeface/wayback-archiver.git
 cd wayback-archiver
 
-# Create database
-createdb -U postgres wayback
-psql -U postgres wayback < server/init_db.sql
+# Create database (PostgreSQL 默认使用当前系统用户名)
+createdb wayback
+psql wayback < server/init_db.sql
 ```
 
 ### 2. Start Server
@@ -205,7 +205,7 @@ Create `.env` file in `server/` directory:
 # Database
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=postgres
+DB_USER=postgres  # 可选，PostgreSQL 默认使用系统用户名
 DB_PASSWORD=
 DB_NAME=wayback
 DB_SSLMODE=disable


### PR DESCRIPTION
## Problem

Currently, users must explicitly set `DB_USER=postgres` (or their username) in the environment variables. This doesn't match PostgreSQL's default behavior, which uses the current system username when no user is specified.

For example, if a user named `alice` runs `createdb wayback`, PostgreSQL creates the database owned by `alice`, but the server tries to connect as `postgres` by default, causing authentication failures.

## Solution

Automatically detect and use the current system username as the default database user, matching PostgreSQL's convention.

### Implementation

1. Read the `$USER` environment variable in `LoadFromEnv()`
2. Use it as the default value for `DB_USER`
3. Fallback to `"postgres"` if `$USER` is not set (rare edge case)
4. Users can still override via `DB_USER` environment variable

### Code Changes

**server/internal/config/config.go:**
```go
// 默认使用当前系统用户名作为数据库用户（PostgreSQL 默认行为）
defaultUser := os.Getenv("USER")
if defaultUser == "" {
    defaultUser = "postgres" // fallback for systems without USER env var
}

cfg := &Config{
    Database: DatabaseConfig{
        User: getEnv("DB_USER", defaultUser),
        // ...
    },
}
```

**server/.env.example:**
- Commented out `DB_USER=postgres` with explanation
- Added note: "可选，默认使用当前系统用户名（$USER 环境变量）"

**Documentation:**
- Updated README.md database setup instructions
- Updated skill.md quick start guide
- Clarified that `DB_USER` is optional in configuration tables

## Benefits

✅ **Better UX**: Users don't need to configure `DB_USER` in most cases  
✅ **Matches PostgreSQL defaults**: Aligns with standard PostgreSQL behavior  
✅ **Still flexible**: Can override via `DB_USER` environment variable  
✅ **Cross-platform**: Works on Unix/Linux/macOS (where `$USER` is standard)  
✅ **Safe fallback**: Falls back to `postgres` if `$USER` is not set

## Testing

1. Build: `cd server && go build -o wayback-server ./cmd/server`
2. Run without `DB_USER` set - should use current system username
3. Run with `DB_USER=custom` - should use `custom`
4. Verify database connection works in both cases

## Example

**Before:**
```bash
# User must explicitly set DB_USER
export DB_USER=alice
./wayback-server
```

**After:**
```bash
# Automatically uses current username (alice)
./wayback-server
```

Simplifies setup and matches PostgreSQL conventions.