### PR TITLE
feat: add .env file support with godotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ psql wayback < server/init_db.sql
 
 ```bash
 cd server
-cp .env.example .env   # edit as needed
+cp .env.example .env   # 复制配置文件（可选，也可以直接使用环境变量）
+# 编辑 .env 文件根据需要修改配置
 go build -o wayback-server ./cmd/server
 ./wayback-server
 ```
@@ -99,7 +100,9 @@ That's it. Pages are automatically archived as soon as they load. Open `http://l
 
 ## Configuration
 
-Environment variables (or `.env` file in `server/`):
+Environment variables (or `.env` file in `server/` directory):
+
+The server automatically loads `.env` file if it exists. You can also set environment variables directly.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,3 +13,6 @@ SERVER_PORT=8080
 
 # 数据存储目录
 DATA_DIR=./data
+
+# 认证配置（可选）
+# AUTH_PASSWORD=  # 设置后启用 HTTP Basic Auth（用户名: wayback）

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
 	"wayback/internal/api"
 	"wayback/internal/config"
 	"wayback/internal/database"
@@ -13,6 +14,10 @@ import (
 )
 
 func main() {
+	// 加载 .env 文件（如果存在）
+	// 忽略错误，因为 .env 文件是可选的（可以直接使用环境变量）
+	_ = godotenv.Load()
+
 	// 加载配置
 	cfg, err := config.LoadFromEnv()
 	if err != nil {

--- a/server/go.mod
+++ b/server/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -31,6 +31,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/skill.md
+++ b/skill.md
@@ -46,6 +46,7 @@ psql wayback < server/init_db.sql
 
 ```bash
 cd server
+cp .env.example .env   # 可选，也可以直接使用环境变量
 go build -o wayback-server ./cmd/server
 ./wayback-server
 ```
@@ -199,7 +200,9 @@ cd tests/server && node test_update_feature.js
 
 ## Configuration
 
-Create `.env` file in `server/` directory:
+Create `.env` file in `server/` directory (or set environment variables directly):
+
+The server automatically loads `.env` file if it exists.
 
 ```bash
 # Database


### PR DESCRIPTION
## Problem

Currently, the server only reads environment variables directly from the shell environment. While `.env.example` exists in the repository, the `.env` file is not actually loaded by the application. Users must manually export environment variables every time they start the server.

## Solution

Add automatic `.env` file loading using the `godotenv` library, making configuration more convenient while maintaining backward compatibility.

### Implementation

1. **Add dependency**: `github.com/joho/godotenv v1.5.1`
2. **Load .env file**: Call `godotenv.Load()` at the start of `main()`
3. **Graceful handling**: Ignore errors if `.env` file doesn't exist (optional)
4. **Update documentation**: Clarify that both `.env` file and environment variables work

### Code Changes

**server/cmd/server/main.go:**
```go
import (
    "github.com/joho/godotenv"
    // ...
)

func main() {
    // 加载 .env 文件（如果存在）
    // 忽略错误，因为 .env 文件是可选的（可以直接使用环境变量）
    _ = godotenv.Load()

    // 加载配置
    cfg, err := config.LoadFromEnv()
    // ...
}
```

**Documentation:**
- Updated README.md to mention `.env` file is optional
- Updated skill.md configuration section
- Clarified that environment variables still work

## Benefits

✅ **More convenient**: No need to export variables every time  
✅ **Optional**: `.env` file is not required - environment variables still work  
✅ **Standard practice**: Matches modern application configuration patterns  
✅ **Backward compatible**: Existing deployments using environment variables continue to work  
✅ **Flexible**: Environment variables override `.env` file values

## Usage

**Option 1: Use .env file (recommended for local development)**
```bash
cd server
cp .env.example .env
# Edit .env as needed
./wayback-server
```

**Option 2: Use environment variables (recommended for production)**
```bash
export DB_HOST=localhost
export DB_NAME=wayback
./wayback-server
```

**Option 3: Mix both**
```bash
# .env file has defaults
# Override specific values with environment variables
export DB_PASSWORD=secret
./wayback-server
```

## Testing

1. Build: `cd server && go build -o wayback-server ./cmd/server`
2. Test with `.env` file: Create `.env` and run server
3. Test without `.env` file: Remove `.env` and use environment variables
4. Verify both methods work correctly

Simplifies configuration management while maintaining full flexibility.