### PR TITLE
feat: add SERVER_HOST config for server bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The server automatically loads `.env` file if it exists. You can also set enviro
 | `DB_PASSWORD` | *(empty)* | Database password |
 | `DB_NAME` | `wayback` | Database name |
 | `DB_SSLMODE` | `disable` | SSL mode |
+| `SERVER_HOST` | `127.0.0.1` | Server bind address (`0.0.0.0` = all interfaces, `127.0.0.1` = localhost only) |
 | `SERVER_PORT` | `8080` | HTTP server port |
 | `DATA_DIR` | `./data` | Storage directory for HTML and resources |
 | `LOG_DIR` | `./data/logs` | Log file directory |

--- a/server/.env.example
+++ b/server/.env.example
@@ -9,6 +9,7 @@ DB_NAME=wayback
 DB_SSLMODE=disable
 
 # 服务器配置
+SERVER_HOST=0.0.0.0  # 默认 127.0.0.1，设置 0.0.0.0 监听所有网卡
 SERVER_PORT=8080
 
 # 数据存储目录

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -61,8 +61,9 @@ func main() {
 	api.SetupRoutes(r, handler, &cfg.Auth)
 
 	// 启动服务器
-	log.Printf("Server starting on port %d", cfg.Server.Port)
-	if err := r.Run(fmt.Sprintf(":%d", cfg.Server.Port)); err != nil {
+	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
+	log.Printf("Server starting on %s", addr)
+	if err := r.Run(addr); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -26,6 +26,7 @@ type DatabaseConfig struct {
 
 // ServerConfig holds HTTP server settings
 type ServerConfig struct {
+	Host string
 	Port int
 }
 
@@ -65,6 +66,7 @@ func LoadFromEnv() (*Config, error) {
 			SSLMode:  getEnv("DB_SSLMODE", "disable"),
 		},
 		Server: ServerConfig{
+			Host: getEnv("SERVER_HOST", "127.0.0.1"),
 			Port: getEnvInt("SERVER_PORT", 8080),
 		},
 		Storage: StorageConfig{

--- a/skill.md
+++ b/skill.md
@@ -214,6 +214,7 @@ DB_NAME=wayback
 DB_SSLMODE=disable
 
 # Server
+SERVER_HOST=0.0.0.0  # 默认 127.0.0.1，设置 0.0.0.0 监听所有网卡
 SERVER_PORT=8080
 
 # Storage


### PR DESCRIPTION
## Summary

Add `SERVER_HOST` environment variable to configure the server's bind address.

## Changes

- Add `Host` field to `ServerConfig` struct
- Read `SERVER_HOST` env var, default `127.0.0.1` (localhost only, secure by default)
- Set `SERVER_HOST=0.0.0.0` in `.env` to listen on all interfaces for remote deployment
- Update `.env.example`, README, skill.md

## Usage

```bash
# Local development (default, no config needed)
./wayback-server  # binds to 127.0.0.1:8080

# Remote deployment
SERVER_HOST=0.0.0.0 ./wayback-server  # binds to 0.0.0.0:8080
```