### PR TITLE
security: fix critical vulnerabilities (CSP nonce, SSRF, cookie leakage, race condition)

### DIFF
--- a/SECURITY_FIXES.md
+++ b/SECURITY_FIXES.md
@@ -1,0 +1,135 @@
+# Security Fixes - 2026-03-14
+
+本文档记录了针对 Wayback Archiver 项目的安全漏洞修复。
+
+## 修复的漏洞
+
+### 1. 硬编码 CSP Nonce (High)
+
+**位置**: `server/internal/api/view_handler.go`
+
+**问题**: CSP nonce 是固定字符串 `"wayback-fix-positioning"`，归档的恶意页面可以在 HTML 中嵌入同样 nonce 的 `<script>` 标签绕过 CSP。
+
+**修复**:
+- 实现 `generateNonce()` 函数，使用 `crypto/rand` 生成 128 位随机 nonce
+- 每次请求生成新的 nonce，防止预测和重放攻击
+- 添加测试验证 nonce 的唯一性和随机性
+
+**测试**: `server/internal/api/security_test.go::TestGenerateNonce`
+
+---
+
+### 2. SSRF 漏洞 - 资源下载 (High)
+
+**位置**: `server/internal/storage/filesystem.go`
+
+**问题**: `DownloadResource` 对用户提供的 URL 没有限制内网地址。169.254.169.254（云元数据）、10.x、192.168.x 等私有地址都可以被请求到。
+
+**修复**:
+- 实现 `validateResourceURL()` 函数，验证 URL 协议和主机名
+- 实现 `isPrivateIP()` 函数，检测私有 IP 地址段（RFC1918、Loopback、Link-local）
+- 实现 `isCloudMetadataIP()` 函数，阻止访问云服务元数据 IP（169.254.169.254、fd00:ec2::254）
+- 只允许 http 和 https 协议
+- 正确处理 IPv4-mapped IPv6 地址（如 ::ffff:8.8.8.8）
+
+**阻止的地址**:
+- 私有 IPv4: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16
+- 私有 IPv6: ::1/128, fc00::/7, fe80::/10
+- 云元数据: 169.254.169.254/32, fd00:ec2::254/128
+
+**测试**: `server/internal/storage/security_test.go::TestValidateResourceURL`, `TestIsPrivateIP`, `TestIsCloudMetadataIP`
+
+---
+
+### 3. Cookie 同根域判断不准确 (Medium)
+
+**位置**: `server/internal/storage/filesystem.go`
+
+**问题**: `getRootDomain` 取最后两段，对 co.uk、com.au 等多段 TLD 会误判。evil.co.uk 和 bank.co.uk 都会被认为是同根域，导致 Cookie 泄露给不相关的域名。
+
+**修复**:
+- 更新 `getRootDomain()` 函数，支持常见的多段 TLD
+- 添加公共后缀列表（co.uk, co.jp, com.au, com.br, com.cn, com.hk, com.tw 等）
+- 正确提取根域名（如 example.co.uk 而不是 co.uk）
+
+**测试**: `server/internal/storage/security_test.go::TestGetRootDomain`, `TestIsSameRootDomain`
+
+**示例**:
+- `evil.co.uk` 和 `bank.co.uk` → 不同根域，不共享 Cookie ✓
+- `www.bank.co.uk` 和 `api.bank.co.uk` → 同根域，可共享 Cookie ✓
+
+---
+
+### 4. SPA 导航竞态条件 (Medium)
+
+**位置**: `browser/src/main.ts`
+
+**问题**: SPA 导航时 `sendCapture()` 是异步的但没有 await，紧接着就 `resetState()`，可能导致上一个页面的捕获数据被清空后才发送，造成数据丢失。
+
+**修复**:
+- 在 Navigation API 监听器中，等待 `sendCapture()` 完成后再调用 `resetState()`
+- 在 `onURLChange()` 函数中应用相同的修复
+- 使用 Promise chain 确保操作顺序
+
+**影响**: 防止 SPA 页面切换时丢失归档数据
+
+---
+
+## 测试覆盖
+
+所有修复都包含完整的单元测试：
+
+```bash
+# 运行所有安全测试
+cd server
+go test ./internal/api -v -run Security
+go test ./internal/storage -v -run Security
+
+# 运行所有测试
+go test ./... -v
+```
+
+测试结果: ✅ 所有测试通过
+
+---
+
+## 影响评估
+
+| 漏洞 | 严重性 | 影响范围 | 修复状态 |
+|------|--------|----------|----------|
+| 硬编码 CSP Nonce | High | 归档页面可执行恶意脚本 | ✅ 已修复 |
+| SSRF - 资源下载 | High | 可访问内网和云元数据 | ✅ 已修复 |
+| Cookie 同根域误判 | Medium | Cookie 泄露给不相关域名 | ✅ 已修复 |
+| SPA 导航竞态 | Medium | 数据丢失 | ✅ 已修复 |
+
+---
+
+## 部署建议
+
+1. 更新代码后重新编译服务端：
+   ```bash
+   cd server
+   go build -o wayback-server ./cmd/server
+   ```
+
+2. 重新构建浏览器脚本：
+   ```bash
+   cd browser
+   npm run build
+   ```
+
+3. 运行测试验证：
+   ```bash
+   cd server
+   go test ./... -v
+   ```
+
+4. 重启服务
+
+---
+
+## 参考
+
+- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
+- [CSP Nonce Best Practices](https://content-security-policy.com/nonce/)
+- [Public Suffix List](https://publicsuffix.org/)

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -267,15 +267,17 @@ function initializeArchiver(): void {
           return;
         }
         console.log('[Wayback] SPA navigate detected');
-        sendCapture();
-        resetState();
-        // Wait for new page to render, then capture
-        nativeSetTimeout(async () => {
-          await prepareCapture();
-          if (captureData) {
-            await sendCapture();
-          }
-        }, CONFIG.DOM_STABILITY_DELAY);
+        // 等待 sendCapture 完成后再重置状态，防止竞态条件
+        sendCapture().then(() => {
+          resetState();
+          // Wait for new page to render, then capture
+          nativeSetTimeout(async () => {
+            await prepareCapture();
+            if (captureData) {
+              await sendCapture();
+            }
+          }, CONFIG.DOM_STABILITY_DELAY);
+        });
       });
   }
 
@@ -289,14 +291,16 @@ function initializeArchiver(): void {
     if (newURL === lastURL) return;
     console.log('[Wayback] URL changed:', lastURL, '->', newURL);
     lastURL = newURL;
-    sendCapture();
-    resetState();
-    nativeSetTimeout(async () => {
-      await prepareCapture();
-      if (captureData) {
-        await sendCapture();
-      }
-    }, CONFIG.DOM_STABILITY_DELAY);
+    // 等待 sendCapture 完成后再重置状态，防止竞态条件
+    sendCapture().then(() => {
+      resetState();
+      nativeSetTimeout(async () => {
+        await prepareCapture();
+        if (captureData) {
+          await sendCapture();
+        }
+      }, CONFIG.DOM_STABILITY_DELAY);
+    });
   }
 
   if (!(window as unknown as Record<string, unknown>).navigation) {

--- a/server/internal/api/security_test.go
+++ b/server/internal/api/security_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"testing"
+)
+
+// TestGenerateNonce tests that nonce generation produces unique values
+func TestGenerateNonce(t *testing.T) {
+	nonce1 := generateNonce()
+	nonce2 := generateNonce()
+
+	if nonce1 == "" {
+		t.Error("generateNonce returned empty string")
+	}
+
+	if nonce2 == "" {
+		t.Error("generateNonce returned empty string")
+	}
+
+	if nonce1 == nonce2 {
+		t.Error("generateNonce produced duplicate nonces")
+	}
+
+	// Nonce should be base64 encoded (at least 16 chars for 128-bit)
+	if len(nonce1) < 16 {
+		t.Errorf("nonce too short: %d chars", len(nonce1))
+	}
+}
+
+// TestGenerateNonceNotHardcoded tests that nonce is not the old hardcoded value
+func TestGenerateNonceNotHardcoded(t *testing.T) {
+	nonce := generateNonce()
+	if nonce == "wayback-fix-positioning" {
+		t.Error("nonce is still hardcoded to 'wayback-fix-positioning'")
+	}
+}

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log"
@@ -10,10 +12,21 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"wayback/internal/models"
 )
+
+// generateNonce 生成随机 CSP nonce（128 位，base64 编码）
+func generateNonce() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// 降级到时间戳（不应该发生，但提供回退）
+		return fmt.Sprintf("nonce-%d", time.Now().UnixNano())
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
 
 // validateResourcePath 验证资源路径，防止目录穿越攻击
 // 返回清理后的安全路径，如果路径试图逃逸出 baseDir 则返回错误
@@ -123,7 +136,8 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	modifiedHTML = fixNestedButtons(modifiedHTML)
 
 	// 注入归档信息栏（传入 nonce 用于 CSP）
-	nonce := "wayback-fix-positioning"
+	// 生成随机 nonce，防止归档页面中的恶意脚本绕过 CSP
+	nonce := generateNonce()
 	modifiedHTML = injectArchiveHeader(modifiedHTML, page, prev, next, snapshotTotal, nonce)
 
 	// 设置安全响应头（允许带 nonce 的内联脚本，用于修复定位问题）

--- a/server/internal/storage/filesystem.go
+++ b/server/internal/storage/filesystem.go
@@ -3,8 +3,10 @@ package storage
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -44,6 +46,103 @@ func NewFileStorage(baseDir string) *FileStorage {
 	}
 }
 
+// validateResourceURL 验证资源 URL，防止 SSRF 攻击
+func validateResourceURL(resourceURL string) error {
+	parsed, err := url.Parse(resourceURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	// 只允许 http 和 https 协议
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("only http and https schemes are allowed")
+	}
+
+	// 解析主机名和端口
+	host := parsed.Hostname()
+	if host == "" {
+		return errors.New("missing hostname")
+	}
+
+	// 解析 IP 地址
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		// DNS 解析失败，允许继续（可能是临时网络问题）
+		return nil
+	}
+
+	// 检查是否为内网地址或云元数据服务
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("private IP address not allowed: %s", ip.String())
+		}
+		if isCloudMetadataIP(ip) {
+			return fmt.Errorf("cloud metadata service not allowed: %s", ip.String())
+		}
+	}
+
+	return nil
+}
+
+// isPrivateIP 检查是否为私有 IP 地址
+func isPrivateIP(ip net.IP) bool {
+	// 将 IPv4-mapped IPv6 地址转换为 IPv4（如 ::ffff:8.8.8.8 -> 8.8.8.8）
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+
+	// IPv4 私有地址段
+	privateIPv4Blocks := []string{
+		"10.0.0.0/8",     // RFC1918
+		"172.16.0.0/12",  // RFC1918
+		"192.168.0.0/16", // RFC1918
+		"127.0.0.0/8",    // Loopback
+		"169.254.0.0/16", // Link-local
+	}
+
+	// IPv6 私有地址段
+	privateIPv6Blocks := []string{
+		"::1/128",   // Loopback
+		"fc00::/7",  // Unique local address
+		"fe80::/10", // Link-local
+	}
+
+	allBlocks := append(privateIPv4Blocks, privateIPv6Blocks...)
+
+	for _, block := range allBlocks {
+		_, subnet, err := net.ParseCIDR(block)
+		if err != nil {
+			continue
+		}
+		if subnet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isCloudMetadataIP 检查是否为云服务元数据 IP
+func isCloudMetadataIP(ip net.IP) bool {
+	// AWS/Azure/GCP 元数据服务
+	metadataIPs := []string{
+		"169.254.169.254/32", // AWS, Azure, GCP
+		"fd00:ec2::254/128",  // AWS IPv6
+	}
+
+	for _, block := range metadataIPs {
+		_, subnet, err := net.ParseCIDR(block)
+		if err != nil {
+			continue
+		}
+		if subnet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // SaveHTML 保存 HTML 文件，按日期组织目录
 func (fs *FileStorage) SaveHTML(url, html string, timestamp time.Time) (string, error) {
 	// 创建日期目录：data/html/2026/03/09/
@@ -69,6 +168,11 @@ func (fs *FileStorage) SaveHTML(url, html string, timestamp time.Time) (string, 
 
 // DownloadResource 下载资源并计算哈希，支持可选的认证 headers
 func (fs *FileStorage) DownloadResource(resourceURL string, pageURL string, headers map[string]string) ([]byte, string, error) {
+	// 防止 SSRF 攻击：拒绝内网地址和云元数据服务
+	if err := validateResourceURL(resourceURL); err != nil {
+		return nil, "", fmt.Errorf("invalid resource URL: %w", err)
+	}
+
 	req, err := http.NewRequest("GET", resourceURL, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("create request failed: %w", err)
@@ -125,14 +229,37 @@ func isSameRootDomain(url1, url2 string) bool {
 	return getRootDomain(parsed1.Hostname()) == getRootDomain(parsed2.Hostname())
 }
 
-// getRootDomain extracts the root domain (last two segments) from a hostname
-// e.g. "kp.m-team.cc" -> "m-team.cc", "img.m-team.cc" -> "m-team.cc"
+// getRootDomain extracts the root domain using public suffix list logic
+// e.g. "kp.m-team.cc" -> "m-team.cc", "img.example.co.uk" -> "example.co.uk"
 func getRootDomain(hostname string) string {
+	// 使用简化的公共后缀列表（常见的多段 TLD）
+	multiSegmentTLDs := map[string]bool{
+		"co.uk": true, "co.jp": true, "co.kr": true, "co.nz": true, "co.za": true,
+		"com.au": true, "com.br": true, "com.cn": true, "com.hk": true, "com.tw": true,
+		"net.au": true, "org.uk": true, "gov.uk": true, "ac.uk": true,
+		"ne.jp": true, "or.jp": true, "go.jp": true,
+	}
+
 	parts := strings.Split(hostname, ".")
-	if len(parts) <= 2 {
+	if len(parts) <= 1 {
 		return hostname
 	}
-	return strings.Join(parts[len(parts)-2:], ".")
+
+	// 检查是否为多段 TLD（如 co.uk）
+	if len(parts) >= 3 {
+		twoSegmentSuffix := strings.Join(parts[len(parts)-2:], ".")
+		if multiSegmentTLDs[twoSegmentSuffix] {
+			// 返回 domain + TLD（如 example.co.uk）
+			return strings.Join(parts[len(parts)-3:], ".")
+		}
+	}
+
+	// 默认返回最后两段（如 example.com）
+	if len(parts) >= 2 {
+		return strings.Join(parts[len(parts)-2:], ".")
+	}
+
+	return hostname
 }
 
 // SaveResource 保存资源文件，按哈希组织目录

--- a/server/internal/storage/security_test.go
+++ b/server/internal/storage/security_test.go
@@ -1,0 +1,202 @@
+package storage
+
+import (
+	"net"
+	"testing"
+)
+
+func TestValidateResourceURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantError bool
+	}{
+		// Valid URLs
+		{
+			name:      "valid https URL",
+			url:       "https://example.com/image.png",
+			wantError: false,
+		},
+		{
+			name:      "valid http URL",
+			url:       "http://example.com/style.css",
+			wantError: false,
+		},
+		// Invalid schemes
+		{
+			name:      "file scheme not allowed",
+			url:       "file:///etc/passwd",
+			wantError: true,
+		},
+		{
+			name:      "ftp scheme not allowed",
+			url:       "ftp://example.com/file.txt",
+			wantError: true,
+		},
+		// Private IPs (these will be blocked by DNS lookup + IP check)
+		{
+			name:      "localhost not allowed",
+			url:       "http://localhost/api",
+			wantError: true, // DNS resolves to 127.0.0.1, which is private
+		},
+		{
+			name:      "127.0.0.1 not allowed",
+			url:       "http://127.0.0.1/api",
+			wantError: true, // Private IP
+		},
+		// Invalid URLs
+		{
+			name:      "invalid URL",
+			url:       "not a url",
+			wantError: true,
+		},
+		{
+			name:      "missing hostname",
+			url:       "http:///path",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateResourceURL(tt.url)
+			if (err != nil) != tt.wantError {
+				t.Errorf("validateResourceURL() error = %v, wantError %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		isPriv  bool
+	}{
+		// Private IPv4
+		{"10.0.0.1", "10.0.0.1", true},
+		{"172.16.0.1", "172.16.0.1", true},
+		{"192.168.1.1", "192.168.1.1", true},
+		{"127.0.0.1", "127.0.0.1", true},
+		{"169.254.1.1", "169.254.1.1", true},
+		// Public IPv4
+		{"8.8.8.8", "8.8.8.8", false},
+		{"1.1.1.1", "1.1.1.1", false},
+		// Private IPv6
+		{"::1", "::1", true},
+		{"fc00::1", "fc00::1", true},
+		{"fe80::1", "fe80::1", true},
+		// Public IPv6
+		{"2001:4860:4860::8888", "2001:4860:4860::8888", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP: %s", tt.ip)
+			}
+			got := isPrivateIP(ip)
+			if got != tt.isPriv {
+				t.Errorf("isPrivateIP(%s) = %v, want %v", tt.ip, got, tt.isPriv)
+			}
+		})
+	}
+}
+
+func TestIsCloudMetadataIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		ip         string
+		isMetadata bool
+	}{
+		// Cloud metadata IPs
+		{"AWS metadata", "169.254.169.254", true},
+		{"AWS IPv6 metadata", "fd00:ec2::254", true},
+		// Non-metadata IPs
+		{"regular private IP", "192.168.1.1", false},
+		{"public IP", "8.8.8.8", false},
+		{"other link-local", "169.254.1.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP: %s", tt.ip)
+			}
+			got := isCloudMetadataIP(ip)
+			if got != tt.isMetadata {
+				t.Errorf("isCloudMetadataIP(%s) = %v, want %v", tt.ip, got, tt.isMetadata)
+			}
+		})
+	}
+}
+
+func TestGetRootDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		// Standard TLDs
+		{"simple domain", "example.com", "example.com"},
+		{"subdomain", "www.example.com", "example.com"},
+		{"deep subdomain", "api.v2.example.com", "example.com"},
+		// Multi-segment TLDs
+		{"co.uk domain", "example.co.uk", "example.co.uk"},
+		{"co.uk subdomain", "www.example.co.uk", "example.co.uk"},
+		{"com.au domain", "example.com.au", "example.com.au"},
+		{"co.jp domain", "example.co.jp", "example.co.jp"},
+		// Edge cases
+		{"single segment", "localhost", "localhost"},
+		{"two segments", "example.com", "example.com"},
+		// Real-world examples from the issue
+		{"m-team subdomain", "kp.m-team.cc", "m-team.cc"},
+		{"m-team img subdomain", "img.m-team.cc", "m-team.cc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getRootDomain(tt.hostname)
+			if got != tt.want {
+				t.Errorf("getRootDomain(%s) = %s, want %s", tt.hostname, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSameRootDomain(t *testing.T) {
+	tests := []struct {
+		name string
+		url1 string
+		url2 string
+		want bool
+	}{
+		// Same root domain
+		{"same domain", "https://example.com/page", "https://example.com/api", true},
+		{"different subdomains", "https://www.example.com/page", "https://api.example.com/data", true},
+		{"with and without subdomain", "https://example.com/page", "https://www.example.com/api", true},
+		// Different root domains
+		{"different domains", "https://example.com/page", "https://other.com/api", false},
+		{"different TLDs", "https://example.com/page", "https://example.org/api", false},
+		// Multi-segment TLD cases (the security issue)
+		{"co.uk same root", "https://www.bank.co.uk/login", "https://api.bank.co.uk/auth", true},
+		{"co.uk different root", "https://evil.co.uk/page", "https://bank.co.uk/login", false},
+		{"com.au same root", "https://www.example.com.au/page", "https://cdn.example.com.au/img", true},
+		{"com.au different root", "https://evil.com.au/page", "https://bank.com.au/login", false},
+		// Edge cases
+		{"empty URLs", "", "", false},
+		{"one empty", "https://example.com", "", false},
+		{"invalid URL", "not-a-url", "https://example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSameRootDomain(tt.url1, tt.url2)
+			if got != tt.want {
+				t.Errorf("isSameRootDomain(%s, %s) = %v, want %v", tt.url1, tt.url2, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概述

修复了 4 个安全漏洞，包括 2 个高危漏洞和 2 个中危漏洞。

## 修复的漏洞

### 1. 硬编码 CSP Nonce (High) 🔴

**问题**: CSP nonce 是固定字符串 `"wayback-fix-positioning"`，归档的恶意页面可以在 HTML 中嵌入同样 nonce 的 `<script>` 标签绕过 CSP。

**修复**:
- 实现 `generateNonce()` 函数，使用 `crypto/rand` 生成 128 位随机 nonce
- 每次请求生成新的 nonce，防止预测和重放攻击
- 添加测试验证 nonce 的唯一性和随机性

**文件**: `server/internal/api/view_handler.go`

---

### 2. SSRF 漏洞 - 资源下载 (High) 🔴

**问题**: `DownloadResource` 对用户提供的 URL 没有限制内网地址。169.254.169.254（云元数据）、10.x、192.168.x 等私有地址都可以被请求到。

**修复**:
- 实现 `validateResourceURL()` 函数，验证 URL 协议和主机名
- 实现 `isPrivateIP()` 函数，检测私有 IP 地址段（RFC1918、Loopback、Link-local）
- 实现 `isCloudMetadataIP()` 函数，阻止访问云服务元数据 IP
- 只允许 http 和 https 协议
- 正确处理 IPv4-mapped IPv6 地址

**阻止的地址**:
- 私有 IPv4: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`
- 私有 IPv6: `::1/128`, `fc00::/7`, `fe80::/10`
- 云元数据: `169.254.169.254/32`, `fd00:ec2::254/128`

**文件**: `server/internal/storage/filesystem.go`

---

### 3. Cookie 同根域判断不准确 (Medium) 🟡

**问题**: `getRootDomain` 取最后两段，对 co.uk、com.au 等多段 TLD 会误判。evil.co.uk 和 bank.co.uk 都会被认为是同根域，导致 Cookie 泄露给不相关的域名。

**修复**:
- 更新 `getRootDomain()` 函数，支持常见的多段 TLD
- 添加公共后缀列表（co.uk, co.jp, com.au, com.br, com.cn, com.hk, com.tw 等）
- 正确提取根域名（如 example.co.uk 而不是 co.uk）

**示例**:
- ❌ 修复前: `evil.co.uk` 和 `bank.co.uk` → 同根域（错误）
- ✅ 修复后: `evil.co.uk` 和 `bank.co.uk` → 不同根域（正确）

**文件**: `server/internal/storage/filesystem.go`

---

### 4. SPA 导航竞态条件 (Medium) 🟡

**问题**: SPA 导航时 `sendCapture()` 是异步的但没有 await，紧接着就 `resetState()`，可能导致上一个页面的捕获数据被清空后才发送，造成数据丢失。

**修复**:
- 在 Navigation API 监听器中，等待 `sendCapture()` 完成后再调用 `resetState()`
- 在 `onURLChange()` 函数中应用相同的修复
- 使用 Promise chain 确保操作顺序

**文件**: `browser/src/main.ts`

---

## 测试覆盖

新增 2 个测试文件，包含完整的单元测试：

- ✅ `server/internal/api/security_test.go` - CSP nonce 测试
- ✅ `server/internal/storage/security_test.go` - SSRF、Cookie、IP 检测测试

所有测试通过：
```bash
cd server
go test ./... -v
```

---

## 影响评估

| 漏洞 | 严重性 | 影响范围 | 修复状态 |
|------|--------|----------|----------|
| 硬编码 CSP Nonce | High | 归档页面可执行恶意脚本 | ✅ 已修复 |
| SSRF - 资源下载 | High | 可访问内网和云元数据 | ✅ 已修复 |
| Cookie 同根域误判 | Medium | Cookie 泄露给不相关域名 | ✅ 已修复 |
| SPA 导航竞态 | Medium | 数据丢失 | ✅ 已修复 |

---

## 部署建议

1. 更新代码后重新编译服务端：
   ```bash
   cd server
   go build -o wayback-server ./cmd/server
   ```

2. 重新构建浏览器脚本：
   ```bash
   cd browser
   npm run build
   ```

3. 运行测试验证：
   ```bash
   cd server
   go test ./... -v
   ```

4. 重启服务

---

## 参考

- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
- [CSP Nonce Best Practices](https://content-security-policy.com/nonce/)
- [Public Suffix List](https://publicsuffix.org/)

详细信息见 [SECURITY_FIXES.md](./SECURITY_FIXES.md)