### PR TITLE
fix: skip inlining large container heights & add @connect localhost

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -39,6 +39,7 @@ const header = `// ==UserScript==
 // @match        *://*/*
 // @grant        GM_xmlhttpRequest
 // @grant        GM_cookie
+// @connect      localhost
 // @connect      *
 // @run-at       document-idle
 // ==/UserScript==

--- a/browser/src/style-inliner.ts
+++ b/browser/src/style-inliner.ts
@@ -166,6 +166,12 @@ export function inlineLayoutStyles(): string {
         if (px > 0) {
           const ref = prop === 'width' ? vw : vh;
           if (Math.abs(px - ref) / ref < 0.05) continue;
+
+          // 跳过远大于视口的 height（通常是内容驱动的容器，不应固化）
+          // 例如 GitHub 的 application-main、react-app 等容器
+          if (prop === 'height' && px > vh * 2) {
+            continue;
+          }
         }
         // 跳过 flex 子元素及其后代的 width/height（由 flex 布局动态计算，固化后失去弹性）
         // 向上遍历祖先，检查是否有任何祖先是弹性 flex 子元素


### PR DESCRIPTION
## 问题

1. 归档 GitHub 等页面时，style-inliner 将容器元素（如 `application-main`、`react-app`）的动态高度（8522px、8736px）固化为像素值，导致页面出现大块空白区域。

2. Tampermonkey 的 `@connect *` 在某些情况下不生效，导致请求被阻止，浏览器控制台卡在 "Sending to server..."。

## 修复

- **style-inliner**: 当元素 height 超过视口高度 2 倍时跳过内联，这些是内容驱动的容器高度，不应固化为像素值
- **build.js**: 在 `@connect *` 之外增加 `@connect localhost`，确保 Tampermonkey 不会阻止到本地服务器的请求