### PR TITLE
fix: auto-cancel log page auto-scroll on user scroll

### DIFF
--- a/server/web/logs.html
+++ b/server/web/logs.html
@@ -158,6 +158,7 @@
         let autoScroll = true;
         let filterText = '';
         let refreshTimer = null;
+        let userScrolling = false;
 
         async function loadFileList() {
             try {
@@ -236,7 +237,9 @@
             }).join('');
 
             if (autoScroll) {
+                userScrolling = true;
                 viewer.scrollTop = viewer.scrollHeight;
+                userScrolling = false;
             }
         }
 
@@ -245,7 +248,10 @@
             const btn = document.getElementById('autoScrollBtn');
             btn.classList.toggle('active', autoScroll);
             if (autoScroll) {
-                document.getElementById('logViewer').scrollTop = document.getElementById('logViewer').scrollHeight;
+                const viewer = document.getElementById('logViewer');
+                userScrolling = true;
+                viewer.scrollTop = viewer.scrollHeight;
+                userScrolling = false;
                 startAutoRefresh();
             } else {
                 stopAutoRefresh();
@@ -265,6 +271,22 @@
             loadFileList();
             loadLogContent();
         }
+
+        // Detect user scroll: disable auto-scroll when scrolling up, re-enable when at bottom
+        document.getElementById('logViewer').addEventListener('scroll', () => {
+            if (userScrolling) return; // ignore programmatic scrolls
+            const viewer = document.getElementById('logViewer');
+            const atBottom = viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight < 30;
+            if (atBottom && !autoScroll) {
+                autoScroll = true;
+                document.getElementById('autoScrollBtn').classList.add('active');
+                startAutoRefresh();
+            } else if (!atBottom && autoScroll) {
+                autoScroll = false;
+                document.getElementById('autoScrollBtn').classList.remove('active');
+                stopAutoRefresh();
+            }
+        });
 
         document.getElementById('filterInput').addEventListener('input', (e) => {
             filterText = e.target.value;


### PR DESCRIPTION
## 问题

日志页面开启 auto-scroll 时，用户向上滚动查看历史日志会被自动刷新强制拉回底部，体验很差。

## 改动

监听 `logViewer` 的 scroll 事件：
- 用户向上滚动 → 自动关闭 auto-scroll 和轮询刷新
- 用户滚回底部（30px 容差）→ 自动恢复 auto-scroll 和轮询刷新
- 用 `userScrolling` 标志位区分程序滚动和用户手动滚动，避免误触发