### PR TITLE
fix: preserve -webkit-box display for line-clamp elements

### DIFF
--- a/browser/src/style-inliner.ts
+++ b/browser/src/style-inliner.ts
@@ -22,6 +22,8 @@ const LAYOUT_PROPS = [
   // Overflow & Transform
   'overflow-x', 'overflow-y', 'visibility', 'opacity',
   'transform',
+  // WebKit Line Clamp (用于多行文本截断)
+  '-webkit-line-clamp', '-webkit-box-orient',
 ];
 
 // 跳过不需要内联的标签
@@ -92,6 +94,9 @@ const DEFAULTS: Record<string, Set<string>> = {
   'visibility': new Set(['visible']),
   'opacity': new Set(['1']),
   'transform': new Set(['none']),
+  // WebKit Line Clamp
+  '-webkit-line-clamp': new Set(['none']),
+  '-webkit-box-orient': new Set(['horizontal']),
 };
 
 // display 的默认值取决于标签类型，需要按标签判断
@@ -150,7 +155,7 @@ export function inlineLayoutStyles(): string {
     const parts: string[] = [];
 
     for (const prop of LAYOUT_PROPS) {
-      const value = computed.getPropertyValue(prop);
+      let value = computed.getPropertyValue(prop);
       if (!value) continue;
       if (DEFAULTS[prop]?.has(value)) continue;
       if (prop === 'display') {
@@ -159,6 +164,20 @@ export function inlineLayoutStyles(): string {
         if (tag === LIST_ITEM_TAG && value === 'list-item') continue;
         if (INLINE_TAGS.has(tag) && value === 'inline') continue;
         if (!INLINE_TAGS.has(tag) && !TABLE_DISPLAY_TAGS[tag] && tag !== LIST_ITEM_TAG && value === 'block') continue;
+
+        // 特殊处理：如果元素使用了 -webkit-line-clamp，需要保留 -webkit-box
+        // getComputedStyle 会将 -webkit-box 标准化为 flow-root，但这会破坏 -webkit-line-clamp
+        const lineClamp = computed.getPropertyValue('-webkit-line-clamp');
+        if (lineClamp && lineClamp !== 'none') {
+          // 检查原始 style 属性或 CSS 类是否使用了 -webkit-box
+          const inlineStyle = (origEl as HTMLElement).style.display;
+          if (inlineStyle === '-webkit-box' || inlineStyle === '-webkit-inline-box') {
+            value = inlineStyle;
+          } else if (value === 'flow-root' || value === 'block') {
+            // computed 返回 flow-root，但元素有 -webkit-line-clamp，推断原始值为 -webkit-box
+            value = '-webkit-box';
+          }
+        }
       }
       // 跳过接近视口尺寸的 width/height（来自 100%/100vh，固化为像素值会截断内容）
       if (prop === 'width' || prop === 'height') {


### PR DESCRIPTION
## 问题描述

修复 X.com 等网站归档页面中文本错位的问题（如截图中的 "Discover more" 区域）。

### 根本原因

1. X.com 使用 `-webkit-line-clamp` 来截断多行文本
2. `-webkit-line-clamp` 只在 `display: -webkit-box` 时才生效
3. `getComputedStyle()` 会将 `-webkit-box` 标准化为 `flow-root`
4. style-inliner 内联 `display: flow-root` 后，`-webkit-line-clamp` 失效
5. 文本不再被截断，导致溢出和布局错位

### 修复方案

1. **检测 `-webkit-line-clamp` 使用**：在处理 `display` 属性时，检查元素是否使用了 `-webkit-line-clamp`
2. **保留 `-webkit-box`**：如果检测到，强制将 `display` 值设为 `-webkit-box`（不使用 computed 的 `flow-root`）
3. **内联相关属性**：添加 `-webkit-line-clamp` 和 `-webkit-box-orient` 到 LAYOUT_PROPS，确保它们被内联

### 影响范围

- 所有使用 `-webkit-line-clamp` 的网站（X.com、GitHub、新闻网站等）
- 修复后文本截断正常工作，布局不再错位
- 不影响其他页面的渲染

### 测试建议

1. 重新归档 https://x.com/coolish/status/2032754018200805839
2. 检查 "Discover more" 区域文字是否正确截断（3行）
3. 验证其他使用 line-clamp 的元素（推文内容、用户简介等）

### 技术细节

修改文件：`browser/src/style-inliner.ts`

- 添加 `-webkit-line-clamp` 和 `-webkit-box-orient` 到 LAYOUT_PROPS
- 在 display 属性处理中添加特殊逻辑，检测并保留 `-webkit-box`
- 添加默认值定义，避免内联冗余值