### PR TITLE
refactor: remove redundant created_at field from pages table

### DIFF
--- a/server/init_db.sql
+++ b/server/init_db.sql
@@ -13,8 +13,7 @@ CREATE TABLE pages (
     first_visited TIMESTAMP WITH TIME ZONE,
     last_visited TIMESTAMP WITH TIME ZONE,
     body_text TEXT,
-    domain TEXT DEFAULT '',
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    domain TEXT DEFAULT ''
 );
 
 CREATE INDEX idx_pages_url ON pages(url);

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -103,9 +103,9 @@ func (db *DB) UpdatePageBodyText(id int64, bodyText string) error {
 func (db *DB) GetPageByURLAndHash(url, contentHash string) (*models.Page, error) {
 	var p models.Page
 	err := db.conn.QueryRow(
-		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 AND content_hash = $2",
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE url = $1 AND content_hash = $2",
 		url, contentHash,
-	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt)
+	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -238,7 +238,7 @@ func (db *DB) GetResourceByURLLike(pattern string) (*models.Resource, error) {
 
 // ListPages 列出页面（分页，支持时间和域名过滤）
 func (db *DB) ListPages(limit, offset int, from, to *time.Time, domain string) ([]models.Page, error) {
-	query := "SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages"
+	query := "SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages"
 	args := []interface{}{}
 	argIndex := 1
 
@@ -281,7 +281,7 @@ func (db *DB) ListPages(limit, offset int, from, to *time.Time, domain string) (
 	var pages []models.Page
 	for rows.Next() {
 		var p models.Page
-		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
 			return nil, err
 		}
 		pages = append(pages, p)
@@ -331,9 +331,9 @@ func (db *DB) GetTotalPagesCount(from, to *time.Time, domain string) (int, error
 func (db *DB) GetPageByID(id string) (*models.Page, error) {
 	var p models.Page
 	err := db.conn.QueryRow(
-		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE id = $1",
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE id = $1",
 		id,
-	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt)
+	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -346,7 +346,7 @@ func (db *DB) GetPageByID(id string) (*models.Page, error) {
 
 // SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
 func (db *DB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
-	query := "SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE (url ILIKE $1 OR title ILIKE $1 OR body_text ILIKE $1)"
+	query := "SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE (url ILIKE $1 OR title ILIKE $1 OR body_text ILIKE $1)"
 	args := []interface{}{"%"+keyword+"%"}
 	argIndex := 2
 
@@ -380,7 +380,7 @@ func (db *DB) SearchPages(keyword string, from, to *time.Time, domain string) ([
 	var pages []models.Page
 	for rows.Next() {
 		var p models.Page
-		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
 			return nil, err
 		}
 		pages = append(pages, p)
@@ -391,7 +391,7 @@ func (db *DB) SearchPages(keyword string, from, to *time.Time, domain string) ([
 // GetPagesWithoutBodyText 获取所有没有 body_text 的页面（用于回填）
 func (db *DB) GetPagesWithoutBodyText() ([]models.Page, error) {
 	rows, err := db.conn.Query(
-		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE body_text IS NULL ORDER BY id",
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE body_text IS NULL ORDER BY id",
 	)
 	if err != nil {
 		return nil, err
@@ -401,7 +401,7 @@ func (db *DB) GetPagesWithoutBodyText() ([]models.Page, error) {
 	var pages []models.Page
 	for rows.Next() {
 		var p models.Page
-		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
 			return nil, err
 		}
 		pages = append(pages, p)
@@ -506,7 +506,7 @@ func (db *DB) UpdatePageContent(id int64, htmlPath, contentHash, title string) e
 // GetPagesByURL 获取同一 URL 的所有快照（按时间倒序）
 func (db *DB) GetPagesByURL(pageURL string) ([]models.Page, error) {
 	rows, err := db.conn.Query(
-		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 ORDER BY first_visited DESC",
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE url = $1 ORDER BY first_visited DESC",
 		pageURL,
 	)
 	if err != nil {
@@ -517,7 +517,7 @@ func (db *DB) GetPagesByURL(pageURL string) ([]models.Page, error) {
 	var pages []models.Page
 	for rows.Next() {
 		var p models.Page
-		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
 			return nil, err
 		}
 		pages = append(pages, p)
@@ -536,9 +536,9 @@ func (db *DB) GetSnapshotNeighbors(pageURL string, currentID int64) (prev *model
 	// 前一个快照（比当前更早）
 	var p models.Page
 	err = db.conn.QueryRow(
-		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 AND first_visited < (SELECT first_visited FROM pages WHERE id = $2) ORDER BY first_visited DESC LIMIT 1",
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE url = $1 AND first_visited < (SELECT first_visited FROM pages WHERE id = $2) ORDER BY first_visited DESC LIMIT 1",
 		pageURL, currentID,
-	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited, &p.CreatedAt)
+	).Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited)
 	if err == nil {
 		prev = &p
 	} else if err != sql.ErrNoRows {
@@ -549,9 +549,9 @@ func (db *DB) GetSnapshotNeighbors(pageURL string, currentID int64) (prev *model
 	// 后一个快照（比当前更新）
 	var n models.Page
 	err = db.conn.QueryRow(
-		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited, created_at FROM pages WHERE url = $1 AND first_visited > (SELECT first_visited FROM pages WHERE id = $2) ORDER BY first_visited ASC LIMIT 1",
+		"SELECT id, url, title, captured_at, html_path, content_hash, first_visited, last_visited FROM pages WHERE url = $1 AND first_visited > (SELECT first_visited FROM pages WHERE id = $2) ORDER BY first_visited ASC LIMIT 1",
 		pageURL, currentID,
-	).Scan(&n.ID, &n.URL, &n.Title, &n.CapturedAt, &n.HTMLPath, &n.ContentHash, &n.FirstVisited, &n.LastVisited, &n.CreatedAt)
+	).Scan(&n.ID, &n.URL, &n.Title, &n.CapturedAt, &n.HTMLPath, &n.ContentHash, &n.FirstVisited, &n.LastVisited)
 	if err == nil {
 		next = &n
 	} else if err != sql.ErrNoRows {

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -11,7 +11,6 @@ type Page struct {
 	ContentHash  string    `json:"content_hash"`
 	FirstVisited time.Time `json:"first_visited"`
 	LastVisited  time.Time `json:"last_visited"`
-	CreatedAt    time.Time `json:"created_at"`
 }
 
 type Resource struct {

--- a/server/migrations/007_drop_created_at.sql
+++ b/server/migrations/007_drop_created_at.sql
@@ -1,0 +1,2 @@
+-- Drop created_at column from pages table
+ALTER TABLE pages DROP COLUMN IF EXISTS created_at;


### PR DESCRIPTION
## 变更说明

删除 `pages` 表中冗余的 `created_at` 字段。

## 原因

- `created_at` 字段与 `captured_at` 功能重复
- `captured_at` 已经表示快照的捕获时间，`created_at` 是多余的
- 代码中基本不使用 `created_at` 做业务逻辑

## 修改内容

- 从 pages 表 schema 中移除 `created_at` 字段
- 从 Page 模型中移除 `CreatedAt` 字段  
- 更新所有 SQL 查询，移除对 `created_at` 的引用
- 添加数据库迁移脚本 `007_drop_created_at.sql`

## 向后兼容性

这是一个**向后兼容的修改**：
- 代码在旧 schema（有 `created_at`）和新 schema（无 `created_at`）上都能正常工作
- 所有 SELECT 语句都明确指定字段列表（不使用 `SELECT *`）
- 即使数据库中还有 `created_at` 字段，程序也能正常运行

## 测试

- ✅ 所有 Go 单元测试通过
- ✅ 数据库迁移已验证