### PR TITLE
fix: remove opacity:0 from scroll animation elements in archived pages

### DIFF
--- a/browser/src/style-inliner.ts
+++ b/browser/src/style-inliner.ts
@@ -33,6 +33,26 @@ const SKIP_TAGS = new Set([
   'HTML', 'BODY',  // 跳过顶层容器，避免固化视口相关的尺寸（如 min-width）
 ]);
 
+// SVG 图形元素标签集合
+const SVG_GRAPHIC_TAGS = new Set([
+  'path', 'circle', 'line', 'polyline', 'polygon', 'rect', 'ellipse',
+  'PATH', 'CIRCLE', 'LINE', 'POLYLINE', 'POLYGON', 'RECT', 'ELLIPSE',
+]);
+
+// 预编译正则 — 避免在循环中重复创建
+const GSAP_ANIM_RE = /translate:\s*none|rotate:\s*none|scale:\s*none/;
+const ANIM_STYLE_CLEANUP_RE = /\b(?:opacity:\s*0|transform:\s*[^;]+|translate:\s*[^;]+|rotate:\s*[^;]+|scale:\s*[^;]+|stroke-dashoffset:\s*[^;]+)\s*;?/g;
+const MULTI_SEMI_RE = /;\s*;+/g;
+
+// 检测元素是否有 data-animate* 属性（避免 getAttributeNames() 分配数组）
+function hasDataAnimateAttr(el: Element): boolean {
+  const attrs = el.attributes;
+  for (let i = 0; i < attrs.length; i++) {
+    if (attrs[i].name.startsWith('data-animate')) return true;
+  }
+  return false;
+}
+
 // 默认值 — computed 值等于默认值时跳过，减少 HTML 体积
 const DEFAULTS: Record<string, Set<string>> = {
   // Box Model
@@ -154,10 +174,32 @@ export function inlineLayoutStyles(): string {
     const existing = cloneEl.getAttribute('style') || '';
     const parts: string[] = [];
 
+    // 检测滚动/JS 动画元素：opacity: 0 + 动画相关特征
+    // 这些元素在未触发动画时 opacity 为 0，不应固化这个状态
+    // 特征：data-animate* 属性、GSAP 动画属性（translate/rotate/scale: none）、SVG 图形元素
+    const isHiddenByAnimation = computed.opacity === '0' && (
+      SVG_GRAPHIC_TAGS.has(origEl.tagName) ||
+      GSAP_ANIM_RE.test(existing) ||
+      hasDataAnimateAttr(origEl)
+    );
+
+    // 清理克隆元素内联样式中的动画属性
+    if (isHiddenByAnimation && existing) {
+      ANIM_STYLE_CLEANUP_RE.lastIndex = 0;
+      const cleaned = existing
+        .replace(ANIM_STYLE_CLEANUP_RE, '')
+        .replace(MULTI_SEMI_RE, ';')
+        .replace(/^;\s*/, '')
+        .replace(/;\s*$/, '');
+      cloneEl.setAttribute('style', cleaned);
+    }
+
     for (const prop of LAYOUT_PROPS) {
       let value = computed.getPropertyValue(prop);
       if (!value) continue;
       if (DEFAULTS[prop]?.has(value)) continue;
+      // 跳过滚动动画元素的 opacity 和 transform，避免固化未触发的动画状态（opacity: 0）
+      if (isHiddenByAnimation && (prop === 'opacity' || prop === 'transform')) continue;
       if (prop === 'display') {
         const tag = origEl.tagName;
         if (TABLE_DISPLAY_TAGS[tag] === value) continue;

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -139,6 +139,9 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	// 导致后续元素（如 <main>、<section>）被提升到错误的层级
 	modifiedHTML = fixNestedButtons(modifiedHTML)
 
+	// 修复滚动动画元素的 opacity: 0（归档页面没有 JS，动画永远不会触发）
+	modifiedHTML = fixScrollAnimationOpacity(modifiedHTML)
+
 	// 注入归档信息栏（传入 nonce 用于 CSP）
 	// 生成随机 nonce，防止归档页面中的恶意脚本绕过 CSP
 	nonce := generateNonce()
@@ -613,3 +616,62 @@ func removeLoadingOverlays(html string) string {
 	}
 	return html
 }
+
+// fixScrollAnimationOpacity 修复 JS 动画元素的 opacity: 0
+// 许多网站使用 IntersectionObserver 或 JS 库实现动画，元素初始 opacity: 0，
+// 动画触发后才变为 opacity: 1。归档页面没有 JS，这些元素永远不可见。
+// 匹配两类元素：
+// 1. 带有 data-animate* 属性且 style 中包含 opacity: 0 的元素
+// 2. style 中同时包含 opacity: 0 和 stroke-dashoffset 的 SVG 元素（线条绘制动画）
+var (
+	scrollAnimRe = regexp.MustCompile(
+		`(<[^>]*\bdata-animate(?:-\w+)?\b[^>]*\bstyle=")((?:[^"]*)opacity:\s*0[^"]*)(")`,
+	)
+	svgAnimRe = regexp.MustCompile(
+		`(?i)(<(?:path|circle|line|polyline|polygon|rect|ellipse)[\s>][^>]*\bstyle=")((?:[^"]*)opacity:\s*0[^"]*)(")`,
+	)
+)
+
+func fixScrollAnimationOpacity(html string) string {
+	html = scrollAnimRe.ReplaceAllStringFunc(html, func(match string) string {
+		return cleanAnimationStyle(scrollAnimRe, match)
+	})
+	html = svgAnimRe.ReplaceAllStringFunc(html, func(match string) string {
+		return cleanAnimationStyle(svgAnimRe, match)
+	})
+	return html
+}
+
+func cleanAnimationStyle(re *regexp.Regexp, match string) string {
+	sub := re.FindStringSubmatch(match)
+	if len(sub) < 4 {
+		return match
+	}
+	prefix := sub[1]  // <tag ... style="
+	style := sub[2]   // style content
+	closing := sub[3] // "
+
+	// 移除动画相关的内联样式属性
+	cleaned := animOpacityRe.ReplaceAllString(style, "")
+	cleaned = animTransformRe.ReplaceAllString(cleaned, "")
+	cleaned = animTranslateRe.ReplaceAllString(cleaned, "")
+	cleaned = animRotateRe.ReplaceAllString(cleaned, "")
+	cleaned = animScaleRe.ReplaceAllString(cleaned, "")
+	cleaned = animStrokeDashoffsetRe.ReplaceAllString(cleaned, "")
+	// 清理多余的分号和空格
+	cleaned = multiSemiRe.ReplaceAllString(cleaned, ";")
+	cleaned = strings.TrimLeft(cleaned, "; ")
+	cleaned = strings.TrimRight(cleaned, "; ")
+
+	return prefix + cleaned + closing
+}
+
+var (
+	animOpacityRe          = regexp.MustCompile(`\bopacity:\s*0\s*;?`)
+	animTransformRe        = regexp.MustCompile(`\btransform:\s*[^;]+;?`)
+	animTranslateRe        = regexp.MustCompile(`\btranslate:\s*[^;]+;?`)
+	animRotateRe           = regexp.MustCompile(`\brotate:\s*[^;]+;?`)
+	animScaleRe            = regexp.MustCompile(`\bscale:\s*[^;]+;?`)
+	animStrokeDashoffsetRe = regexp.MustCompile(`\bstroke-dashoffset:\s*[^;]+;?`)
+	multiSemiRe            = regexp.MustCompile(`;\s*;+`)
+)

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -167,3 +167,148 @@ func TestFixNestedButtons_RealWorldPopover(t *testing.T) {
 		t.Errorf("Outer popover button should be preserved, got: %s", result)
 	}
 }
+
+// --- 滚动动画 opacity 修复测试 ---
+
+func TestFixScrollAnimationOpacity_Basic(t *testing.T) {
+	html := `<div data-animate-item="" style="opacity: 0; transform: translate(0px, 50px);">content</div>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed, got: %s", result)
+	}
+	if strings.Contains(result, "transform:") {
+		t.Errorf("transform should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, "content") {
+		t.Errorf("content should be preserved, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_AnimateChild(t *testing.T) {
+	html := `<h3 data-animate-child="" style="translate: none; rotate: none; scale: none; transform: translate(0px, 20px); opacity: 0;">Title</h3>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed, got: %s", result)
+	}
+	if strings.Contains(result, "translate:") || strings.Contains(result, "rotate:") || strings.Contains(result, "scale:") {
+		t.Errorf("animation properties should be removed, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_NoAnimateAttr(t *testing.T) {
+	// 没有 data-animate-* 属性的元素不应被修改
+	html := `<div style="opacity: 0; transform: translate(0px, 50px);">hidden</div>`
+	result := fixScrollAnimationOpacity(html)
+	if result != html {
+		t.Errorf("Should not modify elements without data-animate-*, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_VisibleElement(t *testing.T) {
+	// opacity: 1 的动画元素不应被修改
+	html := `<div data-animate-item="" style="opacity: 1;">visible</div>`
+	result := fixScrollAnimationOpacity(html)
+	if result != html {
+		t.Errorf("Should not modify visible elements, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_PreservesOtherStyles(t *testing.T) {
+	html := `<div data-animate-item="" style="padding-top:20px;opacity: 0;display:flex;transform:matrix(1, 0, 0, 1, 0, 50)">text</div>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity") {
+		t.Errorf("opacity should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, "padding-top:20px") {
+		t.Errorf("padding-top should be preserved, got: %s", result)
+	}
+	if !strings.Contains(result, "display:flex") {
+		t.Errorf("display:flex should be preserved, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_DataAnimateNoSuffix(t *testing.T) {
+	html := `<div data-animate="" class="w-full flex" style="translate: none; rotate: none; scale: none; transform: translate(0px, 50px); opacity: 0;;margin-top:24px">text</div>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed, got: %s", result)
+	}
+	if strings.Contains(result, "transform:") {
+		t.Errorf("transform should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, "margin-top:24px") {
+		t.Errorf("margin-top should be preserved, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_DataAnimateGroup(t *testing.T) {
+	html := `<div data-animate-group="" style="opacity: 0; transform: translate(0px, 30px);">group</div>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_SVGChartLine(t *testing.T) {
+	html := `<path class="chart-line" d="M49.0 397.3" stroke="#74C375" stroke-width="1.5" style="opacity: 0; stroke-dashoffset: 1100px; stroke-dasharray: 1099.62;;box-sizing:border-box"></path>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed from SVG chart line, got: %s", result)
+	}
+	if strings.Contains(result, "stroke-dashoffset") {
+		t.Errorf("stroke-dashoffset should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, "stroke-dasharray") {
+		t.Errorf("stroke-dasharray should be preserved, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_SVGChartLegend(t *testing.T) {
+	html := `<circle class="chart-legend" cx="205.5" cy="165" r="2.5" fill="#F1F1F1" style="opacity: 0; stroke-dashoffset: 0;;box-sizing:border-box"></circle>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed from SVG chart legend, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_SVGNoStrokeDash(t *testing.T) {
+	// SVG element with opacity: 0 but no stroke-dashoffset — should also be fixed
+	// SVG graphic elements rarely use inline opacity: 0 intentionally
+	html := `<path d="M0 0" style="opacity: 0; fill: red;"></path>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed from SVG element, got: %s", result)
+	}
+	if !strings.Contains(result, "fill: red") {
+		t.Errorf("fill should be preserved, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_SVGCustomElement(t *testing.T) {
+	// 自定义元素名以 SVG 标签开头（如 path-component）不应被匹配
+	html := `<path-component style="opacity: 0; display: none;">hidden</path-component>`
+	result := fixScrollAnimationOpacity(html)
+	if result != html {
+		t.Errorf("Custom element should not be modified, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_SVGUpperCase(t *testing.T) {
+	// 大写 SVG 标签也应被匹配
+	html := `<PATH d="M0 0" style="opacity: 0; fill: red;"></PATH>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 should be removed from uppercase SVG element, got: %s", result)
+	}
+}
+
+func TestFixScrollAnimationOpacity_LeadingWhitespace(t *testing.T) {
+	html := `<div data-animate-item="" style="  opacity: 0; color: red;">text</div>`
+	result := fixScrollAnimationOpacity(html)
+	if strings.Contains(result, "opacity: 0") {
+		t.Errorf("opacity: 0 with leading whitespace should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, "color: red") {
+		t.Errorf("color should be preserved, got: %s", result)
+	}
+}


### PR DESCRIPTION
## 问题

许多现代网站使用 IntersectionObserver 或 JS 动画库实现滚动动画，元素初始状态为 `opacity: 0`，滚动到视口时才变为 `opacity: 1`。归档页面没有 JS 运行，这些元素永远不可见。

例如 page 1609（seeklab.io）有 95 个元素的 `opacity: 0`，导致大量内容（OUR SERVICES、WHY SEEKLAB、统计数据等）完全不可见。

## 解决方案

### 浏览器端（style-inliner.ts）
- 检测动画元素：`data-animate*` 属性、GSAP 内联样式（translate/rotate/scale: none）、SVG 图形元素
- 跳过固化这些元素的 `opacity` 和 `transform`
- 清理克隆 DOM 上已有的动画内联样式
- 性能优化：预编译正则、Set 查找、避免数组分配

### 服务端（view_handler.go）
- `fixScrollAnimationOpacity()` 在渲染归档页面时移除动画相关的 `opacity:0` 及 `transform/translate/rotate/scale` 属性
- 同时修复已归档的页面（如 page 1609）
- SVG 大小写不敏感匹配，防止误匹配自定义元素（如 `path-component`）

## 测试
- 13 个单元测试覆盖所有变体
- `go test ./...` 全部通过