### PR TITLE
fix: resolve relative URLs before rewriting to fix unloaded resources

### DIFF
--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -393,8 +393,9 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 		}
 	}
 
-	// 重写 HTML 中的资源 URL（先规范化 HTML 中的 ../ 路径）
-	normalizedHTML := NormalizeHTMLURLs(req.HTML)
+	// 重写 HTML 中的资源 URL
+	// 1. 规范化 ../ 路径  2. 解析相对路径为绝对 URL  3. 替换为归档路径
+	normalizedHTML := ResolveRelativeURLs(NormalizeHTMLURLs(req.HTML), req.URL)
 	rewrittenHTML := rewriter.RewriteHTML(normalizedHTML)
 
 	// 更新保存的 HTML 文件（用重写后的内容替换临时内容）
@@ -651,8 +652,8 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		}
 	}
 
-	// 重写 HTML 中的资源 URL（先规范化 HTML 中的 ../ 路径）
-	normalizedHTML := NormalizeHTMLURLs(req.HTML)
+	// 重写 HTML 中的资源 URL
+	normalizedHTML := ResolveRelativeURLs(NormalizeHTMLURLs(req.HTML), req.URL)
 	rewrittenHTML := rewriter.RewriteHTML(normalizedHTML)
 
 	// 更新保存的 HTML 文件

--- a/server/internal/storage/rewriter_fast.go
+++ b/server/internal/storage/rewriter_fast.go
@@ -3,19 +3,130 @@ package storage
 import (
 	"fmt"
 	"net/url"
-	"path"
 	"regexp"
 	"strings"
 )
 
+// appendURLPairs 为给定的 URL 字符串生成所有属性形式的替换对
+// 覆盖 src/href/poster/srcset 属性（双引号）和 url() 的三种引号形式
+func appendURLPairs(pairs []string, urlStr, localURL string) []string {
+	return append(pairs,
+		` src="`+urlStr+`"`, ` src="`+localURL+`"`,
+		` href="`+urlStr+`"`, ` href="`+localURL+`"`,
+		` poster="`+urlStr+`"`, ` poster="`+localURL+`"`,
+		` srcset="`+urlStr+`"`, ` srcset="`+localURL+`"`,
+		`url("`+urlStr+`")`, `url("`+localURL+`")`,
+		`url('`+urlStr+`')`, `url('`+localURL+`')`,
+		`url(`+urlStr+`)`, `url(`+localURL+`)`,
+	)
+}
+
+// ResolveRelativeURLs 将 HTML 中的相对路径解析为绝对 URL
+// 这是 RewriteHTMLFast 的预处理步骤，确保所有 URL 都是绝对形式，
+// 从而让 rewriter 只需匹配绝对 URL 变体即可覆盖所有情况。
+// 处理 ./path、../path、bare/path 等所有相对路径形式。
+func ResolveRelativeURLs(html, baseURL string) string {
+	base, err := url.Parse(baseURL)
+	if err != nil || base.Host == "" {
+		return html
+	}
+
+	resolve := func(val string) string {
+		// 跳过已经是绝对的、特殊协议的、空的
+		if val == "" || strings.HasPrefix(val, "http://") || strings.HasPrefix(val, "https://") ||
+			strings.HasPrefix(val, "//") || strings.HasPrefix(val, "/") ||
+			strings.HasPrefix(val, "data:") || strings.HasPrefix(val, "javascript:") ||
+			strings.HasPrefix(val, "#") || strings.HasPrefix(val, "mailto:") ||
+			strings.HasPrefix(val, "tel:") || strings.HasPrefix(val, "blob:") {
+			return ""
+		}
+		// 解码 &amp; 以便正确解析 URL
+		decoded := strings.ReplaceAll(val, "&amp;", "&")
+		ref, err := url.Parse(decoded)
+		if err != nil {
+			return ""
+		}
+		return base.ResolveReference(ref).String()
+	}
+
+	// 1. src/href/poster 属性（双引号）
+	attrDQ := regexp.MustCompile(`(\s(?:src|href|poster))="([^"]*)"`)
+	html = attrDQ.ReplaceAllStringFunc(html, func(match string) string {
+		sub := attrDQ.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		resolved := resolve(sub[2])
+		if resolved == "" {
+			return match
+		}
+		return sub[1] + `="` + resolved + `"`
+	})
+
+	// 2. src/href/poster 属性（单引号）
+	attrSQ := regexp.MustCompile(`(\s(?:src|href|poster))='([^']*)'`)
+	html = attrSQ.ReplaceAllStringFunc(html, func(match string) string {
+		sub := attrSQ.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		resolved := resolve(sub[2])
+		if resolved == "" {
+			return match
+		}
+		return sub[1] + `='` + resolved + `'`
+	})
+
+	// 3. url() 中的相对路径
+	urlRe := regexp.MustCompile(`url\(["']?([^"')]+)["']?\)`)
+	html = urlRe.ReplaceAllStringFunc(html, func(match string) string {
+		sub := urlRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		resolved := resolve(sub[1])
+		if resolved == "" {
+			return match
+		}
+		return `url("` + resolved + `")`
+	})
+
+	// 4. srcset 中的相对路径（多值，逗号分隔）
+	srcsetRe := regexp.MustCompile(`(?i)(\s(?:image)?srcset)="([^"]+)"`)
+	html = srcsetRe.ReplaceAllStringFunc(html, func(match string) string {
+		sub := srcsetRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		attr, value := sub[1], sub[2]
+		changed := false
+		parts := strings.Split(value, ",")
+		for i, part := range parts {
+			fields := strings.Fields(strings.TrimSpace(part))
+			if len(fields) == 0 {
+				continue
+			}
+			if resolved := resolve(fields[0]); resolved != "" {
+				fields[0] = resolved
+				parts[i] = " " + strings.Join(fields, " ")
+				changed = true
+			}
+		}
+		if !changed {
+			return match
+		}
+		return attr + `="` + strings.TrimLeft(strings.Join(parts, ","), " ") + `"`
+	})
+
+	return html
+}
+
 // RewriteHTMLFast 使用 strings.NewReplacer 快速重写 HTML 中的资源 URL
-// 相比原版 RewriteHTML，这个版本做单次遍历替换，速度快 100 倍以上
+// 前置条件：HTML 应先经过 ResolveRelativeURLs 预处理，将相对路径转为绝对 URL
 func (r *URLRewriter) RewriteHTMLFast(html string) string {
-	// 构建所有需要替换的 URL 变体
 	var pairs []string
 
 	for originalURL := range r.urlToLocalPath {
-		// 构建本地 URL
 		var localURL string
 		if r.pageID > 0 && r.timestamp != "" {
 			localURL = fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, originalURL)
@@ -23,57 +134,24 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 			localURL = "/archive/" + r.urlToLocalPath[originalURL]
 		}
 
-		// 1. 原始 URL 的各种属性形式
-		pairs = append(pairs,
-			` src="`+originalURL+`"`, ` src="`+localURL+`"`,
-			` href="`+originalURL+`"`, ` href="`+localURL+`"`,
-			` poster="`+originalURL+`"`, ` poster="`+localURL+`"`,
-			` srcset="`+originalURL+`"`, ` srcset="`+localURL+`"`,
-			`url("`+originalURL+`")`, `url("`+localURL+`")`,
-			`url('`+originalURL+`')`, `url('`+localURL+`')`,
-			`url(`+originalURL+`)`, `url(`+localURL+`)`,
-		)
+		// 1. 绝对 URL
+		pairs = appendURLPairs(pairs, originalURL, localURL)
 
-		// 2. 协议相对 URL（如 //example.com/path）
+		// 2. 协议相对 URL（//example.com/path）
 		protocolRelativeURL := strings.TrimPrefix(originalURL, "https:")
 		protocolRelativeURL = strings.TrimPrefix(protocolRelativeURL, "http:")
 		if protocolRelativeURL != originalURL && strings.HasPrefix(protocolRelativeURL, "//") {
-			pairs = append(pairs,
-				` src="`+protocolRelativeURL+`"`, ` src="`+localURL+`"`,
-				` href="`+protocolRelativeURL+`"`, ` href="`+localURL+`"`,
-				` poster="`+protocolRelativeURL+`"`, ` poster="`+localURL+`"`,
-				` srcset="`+protocolRelativeURL+`"`, ` srcset="`+localURL+`"`,
-				`url("`+protocolRelativeURL+`")`, `url("`+localURL+`")`,
-				`url('`+protocolRelativeURL+`')`, `url('`+localURL+`')`,
-				`url(`+protocolRelativeURL+`)`, `url(`+localURL+`)`,
-			)
+			pairs = appendURLPairs(pairs, protocolRelativeURL, localURL)
 		}
 
-		// 3. HTML 实体编码的 URL（& -> &amp;）
+		// 3. &amp; 编码变体
 		htmlEncodedURL := strings.ReplaceAll(originalURL, "&", "&amp;")
 		if htmlEncodedURL != originalURL {
-			pairs = append(pairs,
-				` src="`+htmlEncodedURL+`"`, ` src="`+localURL+`"`,
-				` href="`+htmlEncodedURL+`"`, ` href="`+localURL+`"`,
-				` poster="`+htmlEncodedURL+`"`, ` poster="`+localURL+`"`,
-				` srcset="`+htmlEncodedURL+`"`, ` srcset="`+localURL+`"`,
-				`url("`+htmlEncodedURL+`")`, `url("`+localURL+`")`,
-				`url('`+htmlEncodedURL+`')`, `url('`+localURL+`')`,
-				`url(`+htmlEncodedURL+`)`, `url(`+localURL+`)`,
-			)
+			pairs = appendURLPairs(pairs, htmlEncodedURL, localURL)
 
-			// 协议相对 + &amp; 组合
 			if protocolRelativeURL != originalURL && strings.HasPrefix(protocolRelativeURL, "//") {
 				protoRelEncoded := strings.ReplaceAll(protocolRelativeURL, "&", "&amp;")
-				pairs = append(pairs,
-					` src="`+protoRelEncoded+`"`, ` src="`+localURL+`"`,
-					` href="`+protoRelEncoded+`"`, ` href="`+localURL+`"`,
-					` poster="`+protoRelEncoded+`"`, ` poster="`+localURL+`"`,
-					` srcset="`+protoRelEncoded+`"`, ` srcset="`+localURL+`"`,
-					`url("`+protoRelEncoded+`")`, `url("`+localURL+`")`,
-					`url('`+protoRelEncoded+`')`, `url('`+localURL+`')`,
-					`url(`+protoRelEncoded+`)`, `url(`+localURL+`)`,
-				)
+				pairs = appendURLPairs(pairs, protoRelEncoded, localURL)
 			}
 		}
 
@@ -87,112 +165,30 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 			)
 		}
 
-		// 5. 绝对路径（如 /assets/style.css）
+		// 5. 绝对路径（/assets/style.css）
 		parsed, err := url.Parse(originalURL)
 		if err == nil && parsed.Path != "" {
 			pathWithQuery := parsed.Path
 			if parsed.RawQuery != "" {
 				pathWithQuery = parsed.Path + "?" + parsed.RawQuery
 			}
-			pairs = append(pairs,
-				` src="`+pathWithQuery+`"`, ` src="`+localURL+`"`,
-				` href="`+pathWithQuery+`"`, ` href="`+localURL+`"`,
-				` poster="`+pathWithQuery+`"`, ` poster="`+localURL+`"`,
-				` srcset="`+pathWithQuery+`"`, ` srcset="`+localURL+`"`,
-				`url("`+pathWithQuery+`")`, `url("`+localURL+`")`,
-				`url('`+pathWithQuery+`')`, `url('`+localURL+`')`,
-				`url(`+pathWithQuery+`)`, `url(`+localURL+`)`,
-			)
+			pairs = appendURLPairs(pairs, pathWithQuery, localURL)
 
-			// 5a. 绝对路径的 &amp; 编码变体（HTML 属性中 & 常被编码为 &amp;）
-			pathWithQueryEncoded := strings.ReplaceAll(pathWithQuery, "&", "&amp;")
-			if pathWithQueryEncoded != pathWithQuery {
-				pairs = append(pairs,
-					` src="`+pathWithQueryEncoded+`"`, ` src="`+localURL+`"`,
-					` href="`+pathWithQueryEncoded+`"`, ` href="`+localURL+`"`,
-					` poster="`+pathWithQueryEncoded+`"`, ` poster="`+localURL+`"`,
-					` srcset="`+pathWithQueryEncoded+`"`, ` srcset="`+localURL+`"`,
-					`url("`+pathWithQueryEncoded+`")`, `url("`+localURL+`")`,
-					`url('`+pathWithQueryEncoded+`')`, `url('`+localURL+`')`,
-					`url(`+pathWithQueryEncoded+`)`, `url(`+localURL+`)`,
-				)
-			}
-
-			// 5b. 相对路径变体（如 ./style.css 和 style.css）
-			// 从绝对路径中提取文件名部分，生成相对路径变体
-			fileName := path.Base(parsed.Path)
-			if fileName != "" && fileName != "." && fileName != "/" {
-				// 带 ./ 前缀的相对路径
-				relWithQuery := "./" + fileName
-				// 裸文件名（不带 ./ 前缀）
-				bareWithQuery := fileName
-				if parsed.RawQuery != "" {
-					relWithQuery = "./" + fileName + "?" + parsed.RawQuery
-					bareWithQuery = fileName + "?" + parsed.RawQuery
-				}
-				pairs = append(pairs,
-					` src="`+relWithQuery+`"`, ` src="`+localURL+`"`,
-					` href="`+relWithQuery+`"`, ` href="`+localURL+`"`,
-					` poster="`+relWithQuery+`"`, ` poster="`+localURL+`"`,
-					` srcset="`+relWithQuery+`"`, ` srcset="`+localURL+`"`,
-					`url("`+relWithQuery+`")`, `url("`+localURL+`")`,
-					`url('`+relWithQuery+`')`, `url('`+localURL+`')`,
-					`url(`+relWithQuery+`)`, `url(`+localURL+`)`,
-				)
-
-				// 裸文件名变体（如 style.css，不带 ./ 前缀）
-				if bareWithQuery != pathWithQuery {
-					pairs = append(pairs,
-						` src="`+bareWithQuery+`"`, ` src="`+localURL+`"`,
-						` href="`+bareWithQuery+`"`, ` href="`+localURL+`"`,
-						` poster="`+bareWithQuery+`"`, ` poster="`+localURL+`"`,
-						` srcset="`+bareWithQuery+`"`, ` srcset="`+localURL+`"`,
-						`url("`+bareWithQuery+`")`, `url("`+localURL+`")`,
-						`url('`+bareWithQuery+`')`, `url('`+localURL+`')`,
-						`url(`+bareWithQuery+`)`, `url(`+localURL+`)`,
-					)
-				}
-
-				// 5c. &amp; 编码变体
-				relEncoded := strings.ReplaceAll(relWithQuery, "&", "&amp;")
-				if relEncoded != relWithQuery {
-					pairs = append(pairs,
-						` src="`+relEncoded+`"`, ` src="`+localURL+`"`,
-						` href="`+relEncoded+`"`, ` href="`+localURL+`"`,
-						` poster="`+relEncoded+`"`, ` poster="`+localURL+`"`,
-						` srcset="`+relEncoded+`"`, ` srcset="`+localURL+`"`,
-						`url("`+relEncoded+`")`, `url("`+localURL+`")`,
-						`url('`+relEncoded+`')`, `url('`+localURL+`')`,
-						`url(`+relEncoded+`)`, `url(`+localURL+`)`,
-					)
-				}
-				bareEncoded := strings.ReplaceAll(bareWithQuery, "&", "&amp;")
-				if bareEncoded != bareWithQuery {
-					pairs = append(pairs,
-						` src="`+bareEncoded+`"`, ` src="`+localURL+`"`,
-						` href="`+bareEncoded+`"`, ` href="`+localURL+`"`,
-						` poster="`+bareEncoded+`"`, ` poster="`+localURL+`"`,
-						` srcset="`+bareEncoded+`"`, ` srcset="`+localURL+`"`,
-						`url("`+bareEncoded+`")`, `url("`+localURL+`")`,
-						`url('`+bareEncoded+`')`, `url('`+localURL+`')`,
-						`url(`+bareEncoded+`)`, `url(`+localURL+`)`,
-					)
-				}
+			// 5a. 绝对路径的 &amp; 编码变体
+			pathEncoded := strings.ReplaceAll(pathWithQuery, "&", "&amp;")
+			if pathEncoded != pathWithQuery {
+				pairs = appendURLPairs(pairs, pathEncoded, localURL)
 			}
 		}
 	}
 
-	// 使用 strings.NewReplacer 做单次遍历替换
 	replacer := strings.NewReplacer(pairs...)
 	html = replacer.Replace(html)
 
-	// 6. 处理多值 srcset/imagesrcset（如 srcset="url1 1x, url2 2x"）
-	// strings.NewReplacer 只能匹配 srcset="<单个URL>"，无法处理逗号分隔的多值
+	// 6. 多值 srcset/imagesrcset
 	html = r.rewriteMultiValueSrcset(html)
 
-	// 7. 兜底：重写所有未被替换的绝对路径（如 /assets/...）
-	// 这些路径可能是动态生成的，或者在资源提取时被遗漏
-	// 将它们重写为归档路径格式，让服务器的 view handler 处理
+	// 7. 兜底：未映射的绝对路径和协议相对 URL
 	if r.pageID > 0 && r.timestamp != "" {
 		html = r.rewriteUnmappedAbsolutePaths(html)
 	}
@@ -203,7 +199,6 @@ func (r *URLRewriter) RewriteHTMLFast(html string) string {
 // rewriteUnmappedAbsolutePaths 重写所有未被映射的绝对路径
 // 这是一个兜底机制，用于处理动态生成或遗漏的资源引用
 func (r *URLRewriter) rewriteUnmappedAbsolutePaths(html string) string {
-	// 必须有 baseURL 才能构建完整的归档路径
 	if r.baseURL == "" {
 		return html
 	}
@@ -214,76 +209,43 @@ func (r *URLRewriter) rewriteUnmappedAbsolutePaths(html string) string {
 	}
 	baseHost := parsed.Scheme + "://" + parsed.Host
 
-	// 预编译正则（避免在闭包内重复编译）
-	// 绝对路径：以单个 / 开头，但不是 // 开头（协议相对 URL）
 	attrDQ := regexp.MustCompile(`(\s(?:src|href|poster|srcset))="(/[^"/][^"]*)"`)
 	attrSQ := regexp.MustCompile(`(\s(?:src|href|poster|srcset))='(/[^'/][^']*)'`)
 	protoRelDQ := regexp.MustCompile(`(\s(?:src|href|poster|srcset))="(//[^"]+)"`)
 	protoRelSQ := regexp.MustCompile(`(\s(?:src|href|poster|srcset))='(//[^']+)'`)
 	urlRe := regexp.MustCompile(`url\(["']?(/[^"')]+)["']?\)`)
 
-	// 1. 先处理协议相对 URL（如 //cdn.example.com/path）（双引号）
-	html = protoRelDQ.ReplaceAllStringFunc(html, func(match string) string {
-		sub := protoRelDQ.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		attr := sub[1]
-		p := sub[2]
-		if strings.HasPrefix(p, "//archive/") {
-			return match
-		}
-		// 协议相对 URL 补全为 https
-		localURL := fmt.Sprintf("/archive/%d/%smp_/https:%s", r.pageID, r.timestamp, p)
-		return attr + `="` + localURL + `"`
+	rewriteAttr := func(re *regexp.Regexp, quote string, buildURL func(string) string) string {
+		return re.ReplaceAllStringFunc(html, func(match string) string {
+			sub := re.FindStringSubmatch(match)
+			if len(sub) < 3 {
+				return match
+			}
+			attr, p := sub[1], sub[2]
+			if strings.HasPrefix(p, "/archive/") || strings.HasPrefix(p, "//archive/") {
+				return match
+			}
+			return attr + `=` + quote + buildURL(p) + quote
+		})
+	}
+
+	// 协议相对 URL
+	html = rewriteAttr(protoRelDQ, `"`, func(p string) string {
+		return fmt.Sprintf("/archive/%d/%smp_/https:%s", r.pageID, r.timestamp, p)
+	})
+	html = rewriteAttr(protoRelSQ, `'`, func(p string) string {
+		return fmt.Sprintf("/archive/%d/%smp_/https:%s", r.pageID, r.timestamp, p)
 	})
 
-	// 1b. 协议相对 URL（单引号）
-	html = protoRelSQ.ReplaceAllStringFunc(html, func(match string) string {
-		sub := protoRelSQ.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		attr := sub[1]
-		p := sub[2]
-		if strings.HasPrefix(p, "//archive/") {
-			return match
-		}
-		localURL := fmt.Sprintf("/archive/%d/%smp_/https:%s", r.pageID, r.timestamp, p)
-		return attr + `='` + localURL + `'`
+	// 绝对路径
+	html = rewriteAttr(attrDQ, `"`, func(p string) string {
+		return fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, baseHost+p)
+	})
+	html = rewriteAttr(attrSQ, `'`, func(p string) string {
+		return fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, baseHost+p)
 	})
 
-	// 2. 再处理绝对路径（以单个 / 开头）（双引号）
-	html = attrDQ.ReplaceAllStringFunc(html, func(match string) string {
-		sub := attrDQ.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		attr := sub[1]
-		p := sub[2]
-		if strings.HasPrefix(p, "/archive/") {
-			return match
-		}
-		localURL := fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, baseHost+p)
-		return attr + `="` + localURL + `"`
-	})
-
-	// 2b. 绝对路径（单引号）
-	html = attrSQ.ReplaceAllStringFunc(html, func(match string) string {
-		sub := attrSQ.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		attr := sub[1]
-		p := sub[2]
-		if strings.HasPrefix(p, "/archive/") {
-			return match
-		}
-		localURL := fmt.Sprintf("/archive/%d/%smp_/%s", r.pageID, r.timestamp, baseHost+p)
-		return attr + `='` + localURL + `'`
-	})
-
-	// 3. 重写 url() 中的绝对路径
+	// url() 中的绝对路径
 	html = urlRe.ReplaceAllStringFunc(html, func(match string) string {
 		sub := urlRe.FindStringSubmatch(match)
 		if len(sub) < 2 {
@@ -302,8 +264,8 @@ func (r *URLRewriter) rewriteUnmappedAbsolutePaths(html string) string {
 
 // rewriteMultiValueSrcset 重写 srcset 和 imagesrcset 属性中的多值 URL
 func (r *URLRewriter) rewriteMultiValueSrcset(html string) string {
-	// 构建 URL 查找表：各种 URL 变体 -> 本地 URL
 	urlMap := make(map[string]string)
+
 	for originalURL := range r.urlToLocalPath {
 		var localURL string
 		if r.pageID > 0 && r.timestamp != "" {
@@ -312,13 +274,10 @@ func (r *URLRewriter) rewriteMultiValueSrcset(html string) string {
 			localURL = "/archive/" + r.urlToLocalPath[originalURL]
 		}
 
-		// 绝对 URL
 		urlMap[originalURL] = localURL
-		// &amp; 编码
 		if enc := strings.ReplaceAll(originalURL, "&", "&amp;"); enc != originalURL {
 			urlMap[enc] = localURL
 		}
-		// 协议相对
 		pr := strings.TrimPrefix(strings.TrimPrefix(originalURL, "https:"), "http:")
 		if pr != originalURL && strings.HasPrefix(pr, "//") {
 			urlMap[pr] = localURL
@@ -326,7 +285,6 @@ func (r *URLRewriter) rewriteMultiValueSrcset(html string) string {
 				urlMap[enc] = localURL
 			}
 		}
-		// 绝对路径 + query
 		parsed, err := url.Parse(originalURL)
 		if err == nil && parsed.Path != "" {
 			pq := parsed.Path
@@ -340,20 +298,17 @@ func (r *URLRewriter) rewriteMultiValueSrcset(html string) string {
 		}
 	}
 
-	// 匹配 srcset="..." 和 imagesrcset="..."
 	srcsetDQ := regexp.MustCompile(`(?i)((?:image)?srcset)="([^"]+)"`)
 	html = srcsetDQ.ReplaceAllStringFunc(html, func(match string) string {
 		sub := srcsetDQ.FindStringSubmatch(match)
 		if len(sub) < 3 {
 			return match
 		}
-		attrName := sub[1]
-		value := sub[2]
-		rewritten := rewriteSrcsetValue(value, urlMap)
-		if rewritten == value {
+		rewritten := rewriteSrcsetValue(sub[2], urlMap)
+		if rewritten == sub[2] {
 			return match
 		}
-		return attrName + `="` + rewritten + `"`
+		return sub[1] + `="` + rewritten + `"`
 	})
 	srcsetSQ := regexp.MustCompile(`(?i)((?:image)?srcset)='([^']+)'`)
 	return srcsetSQ.ReplaceAllStringFunc(html, func(match string) string {
@@ -361,13 +316,11 @@ func (r *URLRewriter) rewriteMultiValueSrcset(html string) string {
 		if len(sub) < 3 {
 			return match
 		}
-		attrName := sub[1]
-		value := sub[2]
-		rewritten := rewriteSrcsetValue(value, urlMap)
-		if rewritten == value {
+		rewritten := rewriteSrcsetValue(sub[2], urlMap)
+		if rewritten == sub[2] {
 			return match
 		}
-		return attrName + `='` + rewritten + `'`
+		return sub[1] + `='` + rewritten + `'`
 	})
 }
 

--- a/server/internal/storage/rewriter_test.go
+++ b/server/internal/storage/rewriter_test.go
@@ -207,8 +207,10 @@ func TestRewriteHTML_DotSlashRelativePath(t *testing.T) {
 		"https://newshacker.me/favicon.png": "resources/f9/22/hash.img",
 		"https://newshacker.me/shared.js":   "resources/4d/ee/hash.js",
 	})
+	baseURL := "https://newshacker.me/"
 
 	html := `<link rel="stylesheet" href="./style.css"><link rel="icon" href="./favicon.png"><script src="./shared.js"></script>`
+	html = ResolveRelativeURLs(html, baseURL)
 	result := r.RewriteHTML(html)
 
 	if strings.Contains(result, `"./style.css"`) {
@@ -232,8 +234,10 @@ func TestRewriteHTML_BareRelativePath(t *testing.T) {
 		"https://dash.3ue.co/zh-Hans/main-QVKUS6BA.js":    "resources/87/4b/hash.js",
 		"https://dash.3ue.co/zh-Hans/polyfills-TR5YYZNL.js": "resources/32/bc/hash.js",
 	})
+	baseURL := "https://dash.3ue.co/zh-Hans/"
 
 	html := `<link rel="stylesheet" href="styles-V46MLXWF.css" media="all"><script src="main-QVKUS6BA.js" type="module"></script><link rel="modulepreload" href="polyfills-TR5YYZNL.js">`
+	html = ResolveRelativeURLs(html, baseURL)
 	result := r.RewriteHTML(html)
 
 	if strings.Contains(result, `"styles-V46MLXWF.css"`) {
@@ -346,6 +350,109 @@ func TestRewriteHTML_UnmappedProtocolRelative(t *testing.T) {
 	expected2 := `src='/archive/56/20260314070100mp_/https://cdn.example.com/app.js'`
 	if !strings.Contains(result2, expected2) {
 		t.Errorf("single-quoted protocol-relative URL should be rewritten, expected: %s, got: %s", expected2, result2)
+	}
+}
+
+func TestResolveRelativeURLs(t *testing.T) {
+	baseURL := "https://pub.sakana.ai/doc-to-lora/"
+
+	tests := []struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name:     "dot-slash subdir path",
+			html:     `<img src="./figs/image.png">`,
+			expected: `<img src="https://pub.sakana.ai/doc-to-lora/figs/image.png">`,
+		},
+		{
+			name:     "bare subdir path",
+			html:     `<link href="css/style.css">`,
+			expected: `<link href="https://pub.sakana.ai/doc-to-lora/css/style.css">`,
+		},
+		{
+			name:     "parent dir path",
+			html:     `<img src="../other/file.png">`,
+			expected: `<img src="https://pub.sakana.ai/other/file.png">`,
+		},
+		{
+			name:     "bare filename",
+			html:     `<img src="image.png">`,
+			expected: `<img src="https://pub.sakana.ai/doc-to-lora/image.png">`,
+		},
+		{
+			name:     "absolute URL unchanged",
+			html:     `<img src="https://cdn.example.com/img.png">`,
+			expected: `<img src="https://cdn.example.com/img.png">`,
+		},
+		{
+			name:     "absolute path unchanged",
+			html:     `<img src="/assets/img.png">`,
+			expected: `<img src="/assets/img.png">`,
+		},
+		{
+			name:     "data URI unchanged",
+			html:     `<img src="data:image/png;base64,abc">`,
+			expected: `<img src="data:image/png;base64,abc">`,
+		},
+		{
+			name:     "single-quoted attribute",
+			html:     `<img src='./figs/image.png'>`,
+			expected: `<img src='https://pub.sakana.ai/doc-to-lora/figs/image.png'>`,
+		},
+		{
+			name:     "url() in CSS",
+			html:     `url("../fonts/font.woff")`,
+			expected: `url("https://pub.sakana.ai/fonts/font.woff")`,
+		},
+		{
+			name:     "query string with &amp;",
+			html:     `<img src="api/data?a=1&amp;b=2">`,
+			expected: `<img src="https://pub.sakana.ai/doc-to-lora/api/data?a=1&b=2">`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveRelativeURLs(tt.html, baseURL)
+			if result != tt.expected {
+				t.Errorf("\nexpected: %s\n     got: %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRewriteHTML_SubdirRelativePath(t *testing.T) {
+	r := newTestRewriter(1713, "20260316102920", map[string]string{
+		"https://pub.sakana.ai/doc-to-lora/figs/image.png":     "resources/ab/cd/hash1.img",
+		"https://pub.sakana.ai/doc-to-lora/css/style.css":      "resources/ab/cd/hash2.css",
+		"https://pub.sakana.ai/doc-to-lora/lib/template.v1.js": "resources/ab/cd/hash3.js",
+	})
+	r.SetBaseURL("https://pub.sakana.ai/doc-to-lora/")
+	baseURL := "https://pub.sakana.ai/doc-to-lora/"
+	archivePrefix := "/archive/1713/20260316102920mp_/"
+
+	// 模拟完整流程：先 ResolveRelativeURLs，再 RewriteHTML
+	html := `<img src="./figs/image.png"> <link href="./css/style.css"> <script src="./lib/template.v1.js"></script>`
+	html = ResolveRelativeURLs(html, baseURL)
+	result := r.RewriteHTML(html)
+
+	if !strings.Contains(result, `src="`+archivePrefix+`https://pub.sakana.ai/doc-to-lora/figs/image.png"`) {
+		t.Errorf("./figs/image.png should be rewritten, got: %s", result)
+	}
+	if !strings.Contains(result, `href="`+archivePrefix+`https://pub.sakana.ai/doc-to-lora/css/style.css"`) {
+		t.Errorf("./css/style.css should be rewritten, got: %s", result)
+	}
+	if !strings.Contains(result, `src="`+archivePrefix+`https://pub.sakana.ai/doc-to-lora/lib/template.v1.js"`) {
+		t.Errorf("./lib/template.v1.js should be rewritten, got: %s", result)
+	}
+
+	// ../path 形式
+	html2 := ResolveRelativeURLs(`<img src="../other/file.png">`, baseURL)
+	// ../other/file.png 解析为 https://pub.sakana.ai/other/file.png，不在映射中，不会被 rewriter 替换
+	if !strings.Contains(html2, `src="https://pub.sakana.ai/other/file.png"`) {
+		t.Errorf("../other/file.png should be resolved to absolute URL, got: %s", html2)
 	}
 }
 


### PR DESCRIPTION
## 问题

使用子目录相对路径的页面（如 `pub.sakana.ai/doc-to-lora/`）归档后大量资源无法加载。

HTML 中的 `./figs/image.png`、`./css/style.css`、`./lib/script.js` 等路径未被重写为归档路径，因为旧的 rewriter 只用 `path.Base()` 提取文件名生成 `./image.png` 变体，无法匹配带子目录的相对路径。

## 方案

新增 `ResolveRelativeURLs(html, baseURL)` 预处理步骤，在 rewriter 之前将所有相对路径解析为绝对 URL：

- `./figs/image.png` → `https://pub.sakana.ai/doc-to-lora/figs/image.png`
- `../fonts/font.woff` → `https://pub.sakana.ai/fonts/font.woff`
- `css/style.css` → `https://pub.sakana.ai/doc-to-lora/css/style.css`

利用 Go 标准库 `url.ResolveReference` 处理，自动覆盖 `./`、`../`、裸路径等所有相对路径形式。

## 重构

- 从 `RewriteHTMLFast` 中移除了 sections 5b/5c/5d（相对路径变体枚举），不再需要
- 提取 `appendURLPairs` 辅助函数，消除重复的 7 行替换对代码块
- 简化 `rewriteUnmappedAbsolutePaths`，用 `rewriteAttr` 闭包减少重复

## 测试

- 新增 `TestResolveRelativeURLs`：10 个子测试覆盖各种路径形式
- 更新 `TestRewriteHTML_DotSlashRelativePath` 和 `TestRewriteHTML_BareRelativePath` 使用新的预处理流程
- 所有现有测试通过