### PR TITLE
feat: add GitHub Actions release workflow with auto-versioned userscript

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: server/go.sum
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: browser/package-lock.json
+
+      - name: Install browser dependencies
+        run: cd browser && npm ci
+
+      - name: Build userscript
+        run: make script
+        env:
+          VERSION: ${{ github.ref_name }}
+
+      - name: Cross-compile all platforms
+        run: make all
+
+      - name: Package release artifacts
+        run: |
+          cp .env.example bin/
+          cd bin
+          for f in wayback-server-*; do
+            name="${f%.*}"
+            ext="${f##*.}"
+            if [ "$ext" = "exe" ]; then
+              zip "${name}.zip" "$f" wayback.user.js .env.example
+            else
+              chmod +x "$f"
+              tar czf "${name}.tar.gz" "$f" wayback.user.js .env.example
+            fi
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            bin/*.tar.gz
+            bin/*.zip
+            bin/wayback.user.js

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ server:
 	cd server && go build -ldflags "$(LDFLAGS)" -o ../$(BIN_DIR)/$(BINARY) $(SERVER_PKG)
 
 script:
-	cd browser && npm run build --silent
+	cd browser && VERSION=$(VERSION) npm run build --silent
 	mkdir -p $(BIN_DIR)
 	cp browser/dist/wayback.user.js $(BIN_DIR)/wayback.user.js
 

--- a/browser/build.js
+++ b/browser/build.js
@@ -11,6 +11,10 @@ try {
   process.exit(1);
 }
 
+// Version from git tag or environment variable
+const version = process.env.VERSION
+  || execSync('git describe --tags --always --dirty 2>/dev/null || echo "dev"', { encoding: 'utf8' }).trim().replace(/^v/, '');
+
 const distDir = path.join(__dirname, 'dist');
 const outputPath = path.join(distDir, 'wayback.user.js');
 
@@ -33,7 +37,7 @@ const moduleFiles = [
 const header = `// ==UserScript==
 // @name         Wayback Web Archiver
 // @namespace    http://tampermonkey.net/
-// @version      1.0.0
+// @version      ${version}
 // @description  Archive web pages to local server
 // @author       You
 // @match        *://*/*


### PR DESCRIPTION
## Changes

- **GitHub Actions workflow** (`.github/workflows/release.yml`): push `v*` tag 触发，交叉编译 5 个平台，打包产物（含 `.env.example`），自动创建 Release 并生成 release notes
- **Userscript 版本号跟随 tag**: `build.js` 读取 `VERSION` 环境变量，CI 中传入 tag 名，自动去掉 `v` 前缀
- **Makefile**: `script` target 透传 `VERSION` 变量给 build script

## 使用方式

```bash
git tag v1.0.0
git push origin v1.0.0
```

自动编译并创建 Release，产物包含：
- `wayback-server-{os}-{arch}.tar.gz/.zip`（含二进制、userscript、.env.example）
- `wayback.user.js`（单独一份）