### PR TITLE
chore: include init_db.sql in release archives (v1.0.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,15 +41,16 @@ jobs:
       - name: Package release artifacts
         run: |
           cp .env.example bin/
+          cp server/init_db.sql bin/
           cd bin
           for f in wayback-server-*; do
             name="${f%.*}"
             ext="${f##*.}"
             if [ "$ext" = "exe" ]; then
-              zip "${name}.zip" "$f" wayback.user.js .env.example
+              zip "${name}.zip" "$f" wayback.user.js .env.example init_db.sql
             else
               chmod +x "$f"
-              tar czf "${name}.tar.gz" "$f" wayback.user.js .env.example
+              tar czf "${name}.tar.gz" "$f" wayback.user.js .env.example init_db.sql
             fi
           done
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -71,8 +71,7 @@ tar -xzf wayback-server-*.tar.gz
 ```bash
 createdb -U postgres wayback
 
-# 下载并执行建表脚本
-curl -O https://raw.githubusercontent.com/icodeface/wayback-archiver/main/server/init_db.sql
+# 执行建表脚本（init_db.sql 已包含在 release 压缩包中）
 psql -U postgres wayback < init_db.sql
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ tar -xzf wayback-server-*.tar.gz
 # 如果你的系统用户名是 alice，以下命令等同于 createdb -U alice wayback
 createdb wayback
 
-# Download and run the schema
-curl -O https://raw.githubusercontent.com/icodeface/wayback-archiver/main/server/init_db.sql
+# Run the schema (init_db.sql is included in the release archive)
 psql wayback < init_db.sql
 ```
 

--- a/skill.md
+++ b/skill.md
@@ -52,8 +52,7 @@ tar -xzf wayback-server-*.tar.gz
 # Create database (PostgreSQL 默认使用当前系统用户名)
 createdb wayback
 
-# Download and run schema
-curl -O https://raw.githubusercontent.com/icodeface/wayback-archiver/main/server/init_db.sql
+# Run schema (init_db.sql is included in the release archive)
 psql wayback < init_db.sql
 ```
 


### PR DESCRIPTION
## Changes
- Add `init_db.sql` to release packages (tar.gz and zip)
- Update documentation to reflect that `init_db.sql` is bundled
- Remove curl download step from setup instructions

## Benefits
This simplifies the setup process for users downloading pre-built binaries. They no longer need to download the SQL schema separately from GitHub.

## Testing
- [ ] Verify release workflow includes init_db.sql in archives
- [ ] Test setup process with bundled init_db.sql

Closes #55