### PR TITLE
feat: add Docker deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.claude
+.env
+.DS_Store
+bin/
+data/
+node_modules/
+tests/
+docs/
+screenshot/
+*.md
+!browser/README.md
+LICENSE
+skill.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Stage 1: Build userscript
+FROM node:20-alpine AS script-builder
+
+WORKDIR /build
+COPY browser/package*.json ./browser/
+RUN cd browser && npm ci --silent
+
+COPY browser/ ./browser/
+ARG VERSION=docker
+RUN cd browser && VERSION=${VERSION} npm run build --silent
+
+# Stage 2: Build Go server
+FROM golang:1.24-alpine AS server-builder
+
+WORKDIR /build
+COPY server/go.mod server/go.sum ./server/
+RUN cd server && go mod download
+
+COPY server/ ./server/
+ARG VERSION=docker
+ARG BUILD_TIME
+RUN cd server && \
+    CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X 'main.Version=${VERSION}' -X 'main.BuildTime=${BUILD_TIME}'" \
+    -o wayback-server ./cmd/server
+
+# Stage 3: Runtime
+FROM alpine:3.19
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates tzdata
+
+WORKDIR /app
+
+# Copy binaries
+COPY --from=server-builder /build/server/wayback-server /app/
+RUN mkdir -p /app/bin
+COPY --from=script-builder /build/browser/dist/wayback.user.js /app/bin/
+
+# Copy database initialization files
+COPY server/init_db.sql /app/
+COPY server/migrations/ /app/migrations/
+
+# Create data directory
+RUN mkdir -p /app/data/logs
+
+# Expose port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/api/version || exit 1
+
+# Run as non-root user
+RUN addgroup -g 1000 wayback && \
+    adduser -D -u 1000 -G wayback wayback && \
+    chown -R wayback:wayback /app
+USER wayback
+
+CMD ["/app/wayback-server"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build all server script test test-go test-e2e clean
+.PHONY: build all server script test test-go test-e2e clean docker-build docker-up docker-down docker-logs
 
 BINARY    := wayback-server
 SERVER_PKG := ./cmd/server
@@ -49,3 +49,19 @@ test-e2e:
 		echo "Running $$test ..."; \
 		node $$test || exit 1; \
 	done
+
+# Docker targets
+docker-build:
+	docker build -t wayback-archiver:latest \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg BUILD_TIME="$(BUILD_TIME)" \
+		.
+
+docker-up:
+	VERSION=$(VERSION) BUILD_TIME="$(BUILD_TIME)" docker compose up -d
+
+docker-down:
+	docker compose down
+
+docker-logs:
+	docker compose logs -f wayback

--- a/README-zh.md
+++ b/README-zh.md
@@ -46,6 +46,28 @@ Chrome + Tampermonkey ──HTTP POST──▶ Go 服务器 ──▶ PostgreSQL
 
 ## 快速开始
 
+### 方式一：Docker 部署（推荐）
+
+最快的启动方式。Docker Compose 会自动配置服务器和 PostgreSQL。
+
+```bash
+# 克隆仓库
+git clone https://github.com/icodeface/wayback-archiver.git
+cd wayback-archiver
+
+# 启动所有服务
+docker compose up -d
+
+# 查看日志
+docker compose logs -f wayback
+```
+
+服务启动后访问 `http://localhost:8080`，然后跳到[第 4 步（安装用户脚本）](#4-安装用户脚本)。
+
+详细的 Docker 配置和部署选项参见 [docs/DOCKER.md](docs/DOCKER.md)。
+
+### 方式二：预编译二进制
+
 ### 1. 下载预编译二进制
 
 从 [Releases 页面](https://github.com/icodeface/wayback-archiver/releases) 下载最新版本：

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ Chrome + Tampermonkey ──HTTP POST──▶ Go Server ──▶ PostgreSQL (m
 
 ## Quick Start
 
+### Option A: Docker (Recommended)
+
+The fastest way to get started. Docker Compose will set up both the server and PostgreSQL automatically.
+
+```bash
+# Clone the repository
+git clone https://github.com/icodeface/wayback-archiver.git
+cd wayback-archiver
+
+# Start all services
+docker compose up -d
+
+# View logs
+docker compose logs -f wayback
+```
+
+The server will be available at `http://localhost:8080`. Skip to [step 4 (Install the Userscript)](#4-install-the-userscript).
+
+For detailed Docker configuration and deployment options, see [docs/DOCKER.md](docs/DOCKER.md).
+
+### Option B: Pre-built Binaries
+
 ### 1. Download Pre-built Binaries
 
 Download the latest release from the [Releases page](https://github.com/icodeface/wayback-archiver/releases):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: wayback-postgres
+    environment:
+      POSTGRES_USER: wayback
+      POSTGRES_PASSWORD: wayback
+      POSTGRES_DB: wayback
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./server/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U wayback"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  wayback:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION:-docker}
+        BUILD_TIME: ${BUILD_TIME:-unknown}
+    container_name: wayback-server
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: wayback
+      DB_PASSWORD: wayback
+      DB_NAME: wayback
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: 8080
+      DATA_DIR: /app/data
+      LOG_DIR: /app/data/logs
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:8080,null}
+      AUTH_PASSWORD: ${AUTH_PASSWORD:-}
+    volumes:
+      - ./data:/app/data
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,157 @@
+# Docker Deployment Guide
+
+## Quick Start
+
+### 1. Using Docker Compose (Recommended)
+
+```bash
+# Start all services (server + PostgreSQL)
+docker compose up -d
+
+# View logs
+docker compose logs -f wayback
+
+# Stop services
+docker compose down
+
+# Stop and remove all data
+docker compose down -v  # This only removes postgres_data volume; ./data/ directory remains on host
+```
+
+The server will be available at http://localhost:8080
+
+### 2. Using Docker Only
+
+```bash
+# Build image
+docker build -t wayback-archiver:latest .
+
+# Run PostgreSQL
+docker run -d \
+  --name wayback-postgres \
+  -e POSTGRES_USER=wayback \
+  -e POSTGRES_PASSWORD=wayback \
+  -e POSTGRES_DB=wayback \
+  -v wayback_postgres:/var/lib/postgresql/data \
+  -v $(pwd)/server/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql:ro \
+  postgres:16-alpine
+
+# Run server
+docker run -d \
+  --name wayback-server \
+  --link wayback-postgres:postgres \
+  -e DB_HOST=postgres \
+  -e DB_USER=wayback \
+  -e DB_PASSWORD=wayback \
+  -e DB_NAME=wayback \
+  -e SERVER_HOST=0.0.0.0 \
+  -v $(pwd)/data:/app/data \
+  -p 8080:8080 \
+  wayback-archiver:latest
+```
+
+## Configuration
+
+### Environment Variables
+
+Create a `.env` file in the project root:
+
+```bash
+# Optional: Set version info
+VERSION=v1.0.0
+BUILD_TIME=2026-03-16
+
+# Optional: Configure CORS
+ALLOWED_ORIGINS=http://localhost:8080,https://your-domain.com,null
+
+# Optional: Set authentication password
+AUTH_PASSWORD=your-secure-password
+```
+
+### Remote Deployment
+
+For remote deployment, you MUST set `AUTH_PASSWORD`:
+
+```bash
+# In .env file
+AUTH_PASSWORD=your-secure-password
+ALLOWED_ORIGINS=https://your-domain.com,null
+```
+
+Then update your userscript to include the password:
+
+```javascript
+// In browser/src/config.ts
+export const API_BASE_URL = 'https://your-domain.com';
+export const AUTH_PASSWORD = 'your-secure-password';
+```
+
+## Data Persistence
+
+- **PostgreSQL** — Docker named volume `postgres_data`，由 Docker 管理
+- **Archived pages & resources** — Bind mount 到宿主机 `./data/` 目录，可直接访问
+
+### Backup
+
+```bash
+# Backup database
+docker exec wayback-postgres pg_dump -U wayback wayback > backup.sql
+
+# Archived files are already on the host at ./data/, just copy the directory
+cp -r ./data ./data-backup
+```
+
+### Restore
+
+```bash
+# Restore database
+docker exec -i wayback-postgres psql -U wayback wayback < backup.sql
+
+# Restore archived files
+cp -r ./data-backup/* ./data/
+```
+
+## Troubleshooting
+
+### Check service status
+
+```bash
+docker compose ps
+```
+
+### View logs
+
+```bash
+# All services
+docker compose logs
+
+# Server only
+docker compose logs wayback
+
+# Follow logs
+docker compose logs -f
+```
+
+### Access database
+
+```bash
+docker exec -it wayback-postgres psql -U wayback wayback
+```
+
+### Rebuild after code changes
+
+```bash
+docker compose down
+docker compose build --no-cache
+docker compose up -d
+```
+
+## Health Check
+
+The server includes a health check endpoint:
+
+```bash
+curl http://localhost:8080/api/version
+```
+
+Docker will automatically restart the container if the health check fails.


### PR DESCRIPTION
## Summary

Add complete Docker deployment solution for one-command setup.

## Changes

- **Dockerfile** — Multi-stage build (Node → Go → Alpine), non-root user, health check, final image ~39MB
- **docker-compose.yml** — Server + PostgreSQL with auto DB initialization
  - PostgreSQL: named volume (Docker managed)
  - Archived files: bind mount to `./data/` (directly accessible on host)
- **.dockerignore** — Optimize build context
- **docs/DOCKER.md** — Deployment guide with backup/restore, troubleshooting
- **Makefile** — New targets: `docker-build`, `docker-up`, `docker-down`, `docker-logs`
- **README.md / README-zh.md** — Add Docker as recommended quick start option

## Usage

```bash
docker compose up -d
# Server available at http://localhost:8080
```

## Tested

- [x] Docker image builds successfully
- [x] `docker compose up -d` starts both services
- [x] PostgreSQL auto-initializes with `init_db.sql`
- [x] `/api/version` responds correctly
- [x] `./data/` directory correctly mapped to host
- [x] `docker compose down -v` cleans up properly