### PR TITLE
fix: show correct empty state message instead of connection error

### DIFF
--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -278,7 +278,7 @@ func (db *DB) ListPages(limit, offset int, from, to *time.Time, domain string) (
 	}
 	defer rows.Close()
 
-	var pages []models.Page
+	pages := []models.Page{}
 	for rows.Next() {
 		var p models.Page
 		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
@@ -377,7 +377,7 @@ func (db *DB) SearchPages(keyword string, from, to *time.Time, domain string) ([
 	}
 	defer rows.Close()
 
-	var pages []models.Page
+	pages := []models.Page{}
 	for rows.Next() {
 		var p models.Page
 		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
@@ -398,7 +398,7 @@ func (db *DB) GetPagesWithoutBodyText() ([]models.Page, error) {
 	}
 	defer rows.Close()
 
-	var pages []models.Page
+	pages := []models.Page{}
 	for rows.Next() {
 		var p models.Page
 		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {
@@ -514,7 +514,7 @@ func (db *DB) GetPagesByURL(pageURL string) ([]models.Page, error) {
 	}
 	defer rows.Close()
 
-	var pages []models.Page
+	pages := []models.Page{}
 	for rows.Next() {
 		var p models.Page
 		if err := rows.Scan(&p.ID, &p.URL, &p.Title, &p.CapturedAt, &p.HTMLPath, &p.ContentHash, &p.FirstVisited, &p.LastVisited); err != nil {

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -622,12 +622,12 @@
                 const data = await response.json();
 
                 // Handle new paginated response format
-                if (data.pages && data.total !== undefined) {
-                    allPages = data.pages;
+                if (data.pages !== undefined && data.total !== undefined) {
+                    allPages = data.pages || [];
                     totalCount = data.total;
                 } else {
                     // Fallback for old format (array)
-                    allPages = data;
+                    allPages = Array.isArray(data) ? data : [];
                     totalCount = allPages.length;
                 }
 
@@ -636,7 +636,12 @@
                 renderPages(allPages);
                 updatePagination();
             } catch (error) {
-                document.getElementById('pageList').innerHTML = '<li class="empty"><div class="empty-icon">[ ! ]</div>Unable to connect to server. Please check if the server is running.</li>';
+                console.error('Failed to load pages:', error);
+                const isNetworkError = error.message.includes('fetch') || error.message.includes('NetworkError');
+                const errorMsg = isNetworkError
+                    ? 'Unable to connect to server. Please check if the server is running.'
+                    : 'Failed to load pages. Please try again.';
+                document.getElementById('pageList').innerHTML = `<li class="empty"><div class="empty-icon">[ ! ]</div>${errorMsg}</li>`;
             }
         }
 

--- a/server/web/timeline.html
+++ b/server/web/timeline.html
@@ -281,7 +281,11 @@
                 renderTimeline(snapshots);
             } catch (error) {
                 console.error('Timeline error:', error);
-                document.getElementById('content').innerHTML = '<div class="empty">Unable to connect to server. Please check if the server is running.</div>';
+                const isNetworkError = error.message.includes('fetch') || error.message.includes('NetworkError');
+                const errorMsg = isNetworkError
+                    ? 'Unable to connect to server. Please check if the server is running.'
+                    : 'Failed to load timeline. Please try again.';
+                document.getElementById('content').innerHTML = `<div class="empty">${errorMsg}</div>`;
             }
         }
 


### PR DESCRIPTION
## Problem
When opening the web page after initial deployment with an empty database, users see a misleading error message: **"Unable to connect to server. Please check if the server is running."** — even though the server is running fine.

## Root Cause
1. Go's nil slice marshals to JSON `null` instead of `[]`
2. Frontend checked `data.pages` (falsy for `null`) and fell to else branch
3. Assigned whole response object to `allPages`: `allPages = data`
4. Called `renderPages(data)` → `data.map()` threw TypeError
5. Caught by catch block → showed connection error

## Changes
### Backend (`postgres.go`)
- Initialize slices as `pages := []models.Page{}` instead of `var pages []models.Page`
- Ensures empty results return `[]` not `null` in JSON

### Frontend (`index.html`, `timeline.html`)
- Use `data.pages !== undefined` check instead of truthy check
- Add `|| []` fallback for null values
- Distinguish network errors from other errors in catch blocks
- Only show "Unable to connect to server" for actual network failures

## Result
✅ Empty database now correctly shows: **"No archived pages found"**  
✅ Connection errors still show: **"Unable to connect to server"**

## Testing
```bash
# Tested with empty database
curl http://localhost:8080/api/pages
# Returns: {"pages":[],"total":0,"limit":100,"offset":0}

# Frontend correctly renders empty state
```