### PR TITLE
fix: remove CSP meta tag to prevent Opera resource loading failure

### DIFF
--- a/server/internal/api/patterns.go
+++ b/server/internal/api/patterns.go
@@ -27,6 +27,7 @@ var (
 	// Path patterns
 	archivePathRe = regexp.MustCompile(`/archive/resources/`)
 
-	// Meta refresh pattern
+	// Meta patterns
 	metaRefreshRe = regexp.MustCompile(`(?i)<meta[^>]*http-equiv=["']?refresh["']?[^>]*>`)
+	metaCSPRe     = regexp.MustCompile(`(?i)<meta[^>]*http-equiv\s*=\s*["']?Content-Security-Policy["']?[^>]*>`)
 )

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -100,6 +100,10 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	baseTagRe := regexp.MustCompile(`(?i)<base\s[^>]*>`)
 	modifiedHTML = baseTagRe.ReplaceAllString(modifiedHTML, "")
 
+	// 移除 CSP meta 标签 — upgrade-insecure-requests 会导致 Opera 等浏览器
+	// 将 http://内网IP/archive/... 升级为 https，导致资源无法加载
+	modifiedHTML = metaCSPRe.ReplaceAllString(modifiedHTML, "")
+
 	// 移除所有 <script> 标签
 	modifiedHTML = scriptTagRe.ReplaceAllString(modifiedHTML, "")
 

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -312,3 +312,63 @@ func TestFixScrollAnimationOpacity_LeadingWhitespace(t *testing.T) {
 		t.Errorf("color should be preserved, got: %s", result)
 	}
 }
+
+// --- CSP meta 标签移除测试 ---
+
+func TestRemoveCSPMeta(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "upgrade-insecure-requests",
+			input: `<head><meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests"><title>Test</title></head>`,
+			want:  `<head><title>Test</title></head>`,
+		},
+		{
+			name:  "single quotes",
+			input: `<head><meta http-equiv='Content-Security-Policy' content='upgrade-insecure-requests'><title>Test</title></head>`,
+			want:  `<head><title>Test</title></head>`,
+		},
+		{
+			name:  "no quotes on http-equiv",
+			input: `<head><meta http-equiv=Content-Security-Policy content="upgrade-insecure-requests"><title>Test</title></head>`,
+			want:  `<head><title>Test</title></head>`,
+		},
+		{
+			name:  "case insensitive",
+			input: `<head><META HTTP-EQUIV="Content-Security-Policy" CONTENT="upgrade-insecure-requests"></head>`,
+			want:  `<head></head>`,
+		},
+		{
+			name:  "complex CSP directive",
+			input: `<head><meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests"></head>`,
+			want:  `<head></head>`,
+		},
+		{
+			name:  "preserves other meta tags",
+			input: `<head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests"><meta name="viewport" content="width=device-width"></head>`,
+			want:  `<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>`,
+		},
+		{
+			name:  "weibo real case with operaUserStyle",
+			input: `<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests"><style type="text/css" id="operaUserStyle"></style>`,
+			want:  `<style type="text/css" id="operaUserStyle"></style>`,
+		},
+		{
+			name:  "no CSP meta — unchanged",
+			input: `<head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"></head>`,
+			want:  `<head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"></head>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := metaCSPRe.ReplaceAllString(tt.input, "")
+			if result != tt.want {
+				t.Errorf("got  %q\nwant %q", result, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Opera strictly follows `<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">` from archived pages, upgrading all http:// resource requests to https://, which fails when the archive server runs on plain HTTP (e.g. internal IP).