### PR TITLE
fix: disable archived video autoplay and add controls

### DIFF
--- a/browser/src/style-inliner.ts
+++ b/browser/src/style-inliner.ts
@@ -44,6 +44,19 @@ const GSAP_ANIM_RE = /translate:\s*none|rotate:\s*none|scale:\s*none/;
 const ANIM_STYLE_CLEANUP_RE = /\b(?:opacity:\s*0|transform:\s*[^;]+|translate:\s*[^;]+|rotate:\s*[^;]+|scale:\s*[^;]+|stroke-dashoffset:\s*[^;]+)\s*;?/g;
 const MULTI_SEMI_RE = /;\s*;+/g;
 
+function neutralizeClonedMedia(cloneRoot: ParentNode): void {
+  for (const node of Array.from(cloneRoot.querySelectorAll('video, audio'))) {
+    if (!(node instanceof HTMLMediaElement)) continue;
+
+    // Detached media clones can still start fetching/playing on some sites.
+    // Keep src/poster in the serialized HTML, but disable eager playback/loading.
+    node.pause();
+    node.autoplay = false;
+    node.removeAttribute('autoplay');
+    node.preload = 'none';
+  }
+}
+
 // 检测元素是否有 data-animate* 属性（避免 getAttributeNames() 分配数组）
 function hasDataAnimateAttr(el: Element): boolean {
   const attrs = el.attributes;
@@ -151,6 +164,7 @@ export function inlineLayoutStyles(): string {
 
   // 深克隆整棵 DOM 树（不会触发 reflow/repaint）
   const clone = document.documentElement.cloneNode(true) as HTMLElement;
+  neutralizeClonedMedia(clone);
 
   // 同步遍历原始 DOM 和克隆 DOM
   const origWalker = document.createTreeWalker(

--- a/docs/technical/snapshot-and-update.md
+++ b/docs/technical/snapshot-and-update.md
@@ -193,6 +193,7 @@ CSS 文件按内容哈希去重后，会被多个页面共享复用。
 - 移除 `<script>`、`<noscript>`、`<base>` 标签
 - 移除内联事件处理器和 `javascript:` 链接
 - 移除 `loading="lazy"`（归档页面无 JS，懒加载无法触发）
+- 移除 `<video autoplay>` 并补上原生 `controls`，避免自动播放，同时保留手动播放能力
 - 隐藏无源的 `<video>` 元素
 - 修复未重写的 `srcset`、嵌套 `<button>`
 - 移除 SPA loading 覆盖层

--- a/server/internal/api/patterns.go
+++ b/server/internal/api/patterns.go
@@ -6,9 +6,9 @@ import "regexp"
 // These patterns are compiled once at package initialization and reused throughout the application.
 var (
 	// HTML tag patterns
-	bodyTagRe   = regexp.MustCompile(`(?i)(<body[^>]*>)`)
-	headTagRe   = regexp.MustCompile(`(?i)(<head[^>]*>)`)
-	htmlTagRe   = regexp.MustCompile(`(?i)(<html[^>]*>)`)
+	bodyTagRe     = regexp.MustCompile(`(?i)(<body[^>]*>)`)
+	headTagRe     = regexp.MustCompile(`(?i)(<head[^>]*>)`)
+	htmlTagRe     = regexp.MustCompile(`(?i)(<html[^>]*>)`)
 	scriptTagRe   = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
 	noscriptTagRe = regexp.MustCompile(`(?is)<noscript[^>]*>.*?</noscript>`)
 
@@ -37,6 +37,8 @@ var (
 	eventHandlerSQRe = regexp.MustCompile(`(?i)\s+on\w+\s*=\s*'[^']*'`)
 	jsProtocolRe     = regexp.MustCompile(`(?i)href\s*=\s*["']javascript:[^"']*["']`)
 	lazyLoadRe       = regexp.MustCompile(`(?i)\s+loading\s*=\s*["']lazy["']`)
+	autoplayAttrRe   = regexp.MustCompile(`(?i)\s+autoplay(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?`)
+	controlsAttrRe   = regexp.MustCompile(`(?i)\s+controls(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?`)
 	sourceTagRe      = regexp.MustCompile(`(?is)<source[^>]*>`)
 	videoBlockRe     = regexp.MustCompile(`(?is)<video\b([^>]*)>(.*?)</video>|<video\b([^>]*)/>`)
 )

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -122,7 +122,7 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	// 移除 loading="lazy"，归档页面禁用了 JS，懒加载可能无法正常触发
 	modifiedHTML = lazyLoadRe.ReplaceAllString(modifiedHTML, "")
 
-	// 隐藏 <video> 元素 — 归档不保存视频源文件，空 video 标签会渲染为大黑块
+	// 归档页面禁用 JS：关闭视频自动播放、补原生 controls，并隐藏无源 video
 	modifiedHTML = hideVideoElements(modifiedHTML)
 
 	// 修复未重写的 srcset 协议相对 URL（如 srcset="//i1.hdslb.com/..."）
@@ -636,17 +636,27 @@ func fixUnrewrittenSrcset(html string) string {
 	return html
 }
 
-// hideVideoElements 隐藏没有任何视频源的 video 元素
-// 只隐藏既没有 src 属性、内部也没有 <source> 子元素的 video（空壳会渲染为黑块）
+// hideVideoElements 规范化归档页面中的 video 元素
+// 1. 去掉 autoplay，避免归档页一打开就自动播放
+// 2. 给可播放视频补上原生 controls，方便在无 JS 页面中手动播放
+// 3. 隐藏既没有 src、也没有 <source> 的空 video，避免渲染黑块
 func hideVideoElements(html string) string {
 	// 匹配完整的 <video>...</video> 或自闭合 <video/>
 	html = videoBlockRe.ReplaceAllStringFunc(html, func(match string) string {
+		match = autoplayAttrRe.ReplaceAllString(match, "")
+
 		// 有 src 属性 → 保留（不管是本地还是外部）
 		if srcAttrRe.MatchString(match) {
+			if !controlsAttrRe.MatchString(match) {
+				return strings.Replace(match, "<video", `<video controls`, 1)
+			}
 			return match
 		}
 		// 内部有 <source> 子元素 → 保留
 		if strings.Contains(strings.ToLower(match), "<source") {
+			if !controlsAttrRe.MatchString(match) {
+				return strings.Replace(match, "<video", `<video controls`, 1)
+			}
 			return match
 		}
 		// 无源的空 video → 隐藏

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -529,6 +529,105 @@ func TestFixScrollAnimationOpacity_LeadingWhitespace(t *testing.T) {
 	}
 }
 
+func TestHideVideoElements_DisablesAutoplayAndAddsControls(t *testing.T) {
+	html := `<video autoplay src="/video.mp4"></video>`
+	result := hideVideoElements(html)
+
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed, got: %s", result)
+	}
+	if !strings.Contains(strings.ToLower(result), "controls") {
+		t.Fatalf("controls should be added for manual playback, got: %s", result)
+	}
+	if !strings.Contains(result, `src="/video.mp4"`) {
+		t.Fatalf("video src should be preserved, got: %s", result)
+	}
+}
+
+func TestHideVideoElements_PreservesExistingControls(t *testing.T) {
+	html := `<video controls autoplay><source src="/video.mp4"></video>`
+	result := hideVideoElements(html)
+
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed, got: %s", result)
+	}
+	if strings.Count(strings.ToLower(result), "controls") != 1 {
+		t.Fatalf("controls should not be duplicated, got: %s", result)
+	}
+}
+
+func TestHideVideoElements_HidesEmptyVideo(t *testing.T) {
+	html := `<video autoplay></video>`
+	result := hideVideoElements(html)
+
+	if !strings.Contains(result, `style="display:none!important"`) {
+		t.Fatalf("empty video should be hidden, got: %s", result)
+	}
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed from hidden empty video, got: %s", result)
+	}
+}
+
+func TestHideVideoElements_AddsControlsWhenVideoUsesSourceChild(t *testing.T) {
+	html := `<video autoplay><source src="/video.mp4" type="video/mp4"></video>`
+	result := hideVideoElements(html)
+
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed, got: %s", result)
+	}
+	if !strings.Contains(strings.ToLower(result), "controls") {
+		t.Fatalf("controls should be added for video with source child, got: %s", result)
+	}
+	if !strings.Contains(result, `<source src="/video.mp4" type="video/mp4">`) {
+		t.Fatalf("source child should be preserved, got: %s", result)
+	}
+}
+
+func TestHideVideoElements_SelfClosingVideo(t *testing.T) {
+	html := `<video autoplay src="/video.mp4"/>`
+	result := hideVideoElements(html)
+
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed from self-closing video, got: %s", result)
+	}
+	if !strings.Contains(strings.ToLower(result), "controls") {
+		t.Fatalf("controls should be added to self-closing video, got: %s", result)
+	}
+	if !strings.Contains(result, `src="/video.mp4"`) {
+		t.Fatalf("src should be preserved on self-closing video, got: %s", result)
+	}
+}
+
+func TestHideVideoElements_CaseInsensitiveAttributes(t *testing.T) {
+	html := `<video AUTOPLAY SRC="/video.mp4"></video>`
+	result := hideVideoElements(html)
+
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed case-insensitively, got: %s", result)
+	}
+	if !strings.Contains(strings.ToLower(result), "controls") {
+		t.Fatalf("controls should be added with uppercase attrs, got: %s", result)
+	}
+	if !strings.Contains(result, `SRC="/video.mp4"`) {
+		t.Fatalf("original src attribute should be preserved, got: %s", result)
+	}
+}
+
+func TestHideVideoElements_PreservesExistingControlsValue(t *testing.T) {
+	html := `<video controls="controls" autoplay src="/video.mp4"></video>`
+	result := hideVideoElements(html)
+
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("autoplay should be removed, got: %s", result)
+	}
+	if len(controlsAttrRe.FindAllString(result, -1)) != 1 {
+		t.Fatalf("existing controls attribute should be preserved without duplication, got: %s", result)
+	}
+	if !strings.Contains(result, `controls="controls"`) {
+		t.Fatalf("existing controls value should be preserved, got: %s", result)
+	}
+}
+
 // --- CSP meta 标签移除测试 ---
 
 func TestRemoveCSPMeta(t *testing.T) {


### PR DESCRIPTION
## Summary
- disable `autoplay` on archived `<video>` elements so snapshots do not start playback automatically
- add native `controls` for playable archived videos so manual playback still works when site JS is disabled
- expand API tests to cover video normalization cases and document the archived video behavior

## Testing
- go test ./internal/api/...
- go test ./...