### PR TITLE
fix: archive iframe snapshots as local HTML resources

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -31,6 +31,8 @@ const userscriptModules = [
   'page-freezer.js',
   'style-inliner.js',
   'dom-collector.js',
+  'html-url-normalizer.js',
+  'frame-capture.js',
   'archiver.js',
   'main.js',
 ];
@@ -42,6 +44,8 @@ const puppeteerModules = [
   'page-freezer.js',
   'style-inliner.js',
   'dom-collector.js',
+  'html-url-normalizer.js',
+  'frame-capture.js',
   'puppeteer.js',
 ];
 

--- a/browser/src/config.ts
+++ b/browser/src/config.ts
@@ -8,6 +8,11 @@ export const CONFIG = {
   SPA_TRANSITION_DELAY: 500,        // ms to wait after SPA navigation before starting collector (shorter than DOM_STABILITY_DELAY)
   MUTATION_OBSERVER_TIMEOUT: 10000, // max ms to wait for DOM stability
   DOM_STABLE_TIME: 1000,            // ms of no mutations to consider DOM stable
+  FRAME_CAPTURE_TIMEOUT: 8000,      // max ms to wait for each iframe capture response
+  FRAME_MUTATION_OBSERVER_TIMEOUT: 5000, // max ms to wait for iframe DOM stability
+  FRAME_DOM_STABLE_TIME: 500,       // ms of no iframe mutations to consider stable
+  FRAME_CONTENT_WAIT_TIMEOUT: 10000, // max ms to wait for iframe body content to appear
+  FRAME_CONTENT_CHECK_INTERVAL: 250, // ms between iframe content checks
   TIMER_CLEAR_RANGE: 10000,         // number of timer IDs to clear when freezing
   UPDATE_CHECK_INTERVAL: 5000,      // ms between update checks
   UPDATE_MIN_MUTATIONS: 10,         // minimum mutation count before triggering an update

--- a/browser/src/frame-capture.ts
+++ b/browser/src/frame-capture.ts
@@ -1,0 +1,232 @@
+import { CONFIG } from './config';
+import { waitForDOMStable, serializeCSSOMToDOM } from './page-freezer';
+import { inlineLayoutStyles } from './style-inliner';
+import { normalizeCapturedHTMLURLs } from './html-url-normalizer';
+import { FrameCapture } from './types';
+
+const FRAME_ATTR = 'data-wayback-frame-id';
+const SOURCE = 'wayback-frame-capture';
+
+type FrameCaptureRequest = {
+  source: typeof SOURCE;
+  type: 'capture-frame';
+  requestId: string;
+};
+
+type FrameCaptureResult = {
+  source: typeof SOURCE;
+  type: 'frame-result';
+  requestId: string;
+  html: string;
+  url: string;
+  title: string;
+  frames: FrameCapture[];
+};
+
+export type DocumentCaptureResult = {
+  html: string;
+  frames: FrameCapture[];
+};
+
+function hasMeaningfulBodyContent(doc: Document): boolean {
+  const body = doc.body;
+  if (!body) {
+    return false;
+  }
+
+  if ((body.innerText || '').trim().length > 0) {
+    return true;
+  }
+
+  return Array.from(body.children).some((el) => {
+    const tag = el.tagName.toLowerCase();
+    return tag !== 'script' && tag !== 'style' && tag !== 'link' && tag !== 'meta';
+  });
+}
+
+async function waitForMeaningfulBodyContent(): Promise<void> {
+  const deadline = Date.now() + CONFIG.FRAME_CONTENT_WAIT_TIMEOUT;
+
+  while (Date.now() < deadline) {
+    if (hasMeaningfulBodyContent(document)) {
+      return;
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, CONFIG.FRAME_CONTENT_CHECK_INTERVAL));
+  }
+}
+
+function isMeaningfulCapturedHTML(html: string): boolean {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return hasMeaningfulBodyContent(doc);
+}
+
+function isCaptureRequest(data: unknown): data is FrameCaptureRequest {
+  return !!data && typeof data === 'object' &&
+    (data as { source?: string }).source === SOURCE &&
+    (data as { type?: string }).type === 'capture-frame' &&
+    typeof (data as { requestId?: string }).requestId === 'string';
+}
+
+function isCaptureResult(data: unknown): data is FrameCaptureResult {
+  return !!data && typeof data === 'object' &&
+    (data as { source?: string }).source === SOURCE &&
+    (data as { type?: string }).type === 'frame-result' &&
+    typeof (data as { requestId?: string }).requestId === 'string' &&
+    typeof (data as { html?: string }).html === 'string' &&
+    typeof (data as { url?: string }).url === 'string';
+}
+
+function dedupeFrames(frames: FrameCapture[]): FrameCapture[] {
+  const unique = new Map<string, FrameCapture>();
+  for (const frame of frames) {
+    if (!frame.key || !frame.url) {
+      continue;
+    }
+    unique.set(frame.key, frame);
+  }
+  return Array.from(unique.values());
+}
+
+function markFrames(): HTMLIFrameElement[] {
+  const frames = Array.from(document.querySelectorAll('iframe'));
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i];
+    if (!frame.getAttribute(FRAME_ATTR)) {
+      frame.setAttribute(FRAME_ATTR, `wbf-${Date.now()}-${i}-${Math.random().toString(36).slice(2, 8)}`);
+    }
+  }
+  return frames;
+}
+
+function embedCapturedFrames(parentHTML: string, capturedFrames: Map<string, FrameCaptureResult>): string {
+  if (capturedFrames.size === 0) {
+    return parentHTML;
+  }
+
+  const doc = new DOMParser().parseFromString(parentHTML, 'text/html');
+  const frames = Array.from(doc.querySelectorAll(`iframe[${FRAME_ATTR}]`));
+
+  for (const frame of frames) {
+    const frameId = frame.getAttribute(FRAME_ATTR);
+    if (!frameId) continue;
+
+    const capture = capturedFrames.get(frameId);
+    if (!capture) continue;
+
+    frame.setAttribute('data-wayback-frame-key', frameId);
+    frame.setAttribute('data-wayback-original-src', capture.url);
+    frame.setAttribute('src', capture.url);
+    frame.removeAttribute('srcdoc');
+  }
+
+  return '<!DOCTYPE html>\n' + doc.documentElement.outerHTML;
+}
+
+async function requestFrameCapture(frame: HTMLIFrameElement): Promise<FrameCaptureResult | null> {
+  const frameId = frame.getAttribute(FRAME_ATTR);
+  const frameWindow = frame.contentWindow;
+  if (!frameId || !frameWindow) {
+    return null;
+  }
+
+  const requestId = frameId;
+
+  return new Promise((resolve) => {
+    const timeoutId = window.setTimeout(() => {
+      window.removeEventListener('message', handleMessage);
+      resolve(null);
+    }, CONFIG.FRAME_CAPTURE_TIMEOUT);
+
+    function handleMessage(event: MessageEvent): void {
+      if (event.source !== frameWindow || !isCaptureResult(event.data) || event.data.requestId !== requestId) {
+        return;
+      }
+
+      window.clearTimeout(timeoutId);
+      window.removeEventListener('message', handleMessage);
+      resolve(isMeaningfulCapturedHTML(event.data.html) ? event.data : null);
+    }
+
+    window.addEventListener('message', handleMessage);
+
+    try {
+      frameWindow.postMessage({
+        source: SOURCE,
+        type: 'capture-frame',
+        requestId,
+      } satisfies FrameCaptureRequest, '*');
+    } catch {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener('message', handleMessage);
+      resolve(null);
+    }
+  });
+}
+
+export async function captureDocumentHTMLWithFrames(): Promise<DocumentCaptureResult> {
+  const frames = markFrames();
+  const capturedFrames = new Map<string, FrameCaptureResult>();
+  const collectedFrames: FrameCapture[] = [];
+
+  if (frames.length > 0) {
+    const results = await Promise.all(frames.map(requestFrameCapture));
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const frameId = frames[i].getAttribute(FRAME_ATTR);
+      if (result && frameId) {
+        capturedFrames.set(frameId, result);
+        collectedFrames.push({
+          key: frameId,
+          url: result.url,
+          title: result.title,
+          html: result.html,
+        });
+        collectedFrames.push(...result.frames);
+      }
+    }
+  }
+
+  serializeCSSOMToDOM();
+  const html = normalizeCapturedHTMLURLs(inlineLayoutStyles(), window.location.href);
+  return {
+    html: embedCapturedFrames(html, capturedFrames),
+    frames: dedupeFrames(collectedFrames),
+  };
+}
+
+export function setupFrameCaptureBridge(): void {
+  if (window.self === window.top) {
+    return;
+  }
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    if (!isCaptureRequest(event.data) || event.source !== window.parent) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        await waitForDOMStable(CONFIG.FRAME_MUTATION_OBSERVER_TIMEOUT, CONFIG.FRAME_DOM_STABLE_TIME);
+      } catch {
+        // Fall through and capture best-effort current DOM.
+      }
+
+      try {
+        await waitForMeaningfulBodyContent();
+      } catch {
+        // Fall through and capture best-effort current DOM.
+      }
+
+      const captured = await captureDocumentHTMLWithFrames();
+      window.parent.postMessage({
+        source: SOURCE,
+        type: 'frame-result',
+        requestId: event.data.requestId,
+        html: captured.html,
+        url: window.location.href,
+        title: document.title,
+        frames: captured.frames,
+      } satisfies FrameCaptureResult, '*');
+    })();
+  });
+}

--- a/browser/src/html-url-normalizer.ts
+++ b/browser/src/html-url-normalizer.ts
@@ -1,0 +1,85 @@
+const URL_ATTRS = ['src', 'href', 'poster'];
+const SRCSET_ATTRS = ['srcset', 'imagesrcset'];
+
+function shouldSkipURL(value: string): boolean {
+  return value === '' ||
+    value.startsWith('data:') ||
+    value.startsWith('javascript:') ||
+    value.startsWith('mailto:') ||
+    value.startsWith('tel:') ||
+    value.startsWith('blob:') ||
+    value.startsWith('#');
+}
+
+function toAbsoluteURL(value: string, baseURL: string): string {
+  const trimmed = value.trim();
+  if (shouldSkipURL(trimmed)) {
+    return value;
+  }
+
+  try {
+    return new URL(trimmed, baseURL).toString();
+  } catch {
+    return value;
+  }
+}
+
+function normalizeSrcset(value: string, baseURL: string): string {
+  return value
+    .split(',')
+    .map((part) => {
+      const trimmed = part.trim();
+      if (!trimmed) {
+        return part;
+      }
+
+      const fields = trimmed.split(/\s+/);
+      fields[0] = toAbsoluteURL(fields[0], baseURL);
+      return fields.join(' ');
+    })
+    .join(', ');
+}
+
+function normalizeStyleURLs(styleValue: string, baseURL: string): string {
+  return styleValue.replace(/url\((['"]?)([^)'"\s]+)\1\)/gi, (match, quote: string, rawURL: string) => {
+    const absoluteURL = toAbsoluteURL(rawURL, baseURL);
+    if (absoluteURL === rawURL) {
+      return match;
+    }
+    const q = quote || '"';
+    return `url(${q}${absoluteURL}${q})`;
+  });
+}
+
+export function normalizeCapturedHTMLURLs(html: string, baseURL: string): string {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  for (const element of Array.from(doc.querySelectorAll('*'))) {
+    for (const attr of URL_ATTRS) {
+      const value = element.getAttribute(attr);
+      if (value) {
+        element.setAttribute(attr, toAbsoluteURL(value, baseURL));
+      }
+    }
+
+    for (const attr of SRCSET_ATTRS) {
+      const value = element.getAttribute(attr);
+      if (value) {
+        element.setAttribute(attr, normalizeSrcset(value, baseURL));
+      }
+    }
+
+    const style = element.getAttribute('style');
+    if (style) {
+      element.setAttribute('style', normalizeStyleURLs(style, baseURL));
+    }
+  }
+
+  for (const styleElement of Array.from(doc.querySelectorAll('style'))) {
+    if (styleElement.textContent) {
+      styleElement.textContent = normalizeStyleURLs(styleElement.textContent, baseURL);
+    }
+  }
+
+  return '<!DOCTYPE html>\n' + doc.documentElement.outerHTML;
+}

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -14,21 +14,24 @@
 import { CONFIG } from './config';
 import { CaptureData } from './types';
 import { shouldSkipPage } from './page-filter';
-import { freezePageState, waitForDOMStable, serializeCSSOMToDOM } from './page-freezer';
-import { inlineLayoutStyles } from './style-inliner';
+import { waitForDOMStable } from './page-freezer';
 import { sendToServer, updateOnServer } from './archiver';
 import { DOMCollector } from './dom-collector';
+import { captureDocumentHTMLWithFrames, setupFrameCaptureBridge } from './frame-capture';
 
 // Early exit check before any initialization
 if (shouldSkipPage()) {
   console.log('[Wayback] Skipping page:', window.location.href);
 } else {
   console.log('[Wayback] Script loaded for:', window.location.href);
-  initializeArchiver();
+  if (window.self === window.top) {
+    initializeArchiver();
+  } else {
+    setupFrameCaptureBridge();
+  }
 }
 
 function initializeArchiver(): void {
-  // Save native timers before freezePageState() replaces them with noops
   const nativeSetTimeout = window.setTimeout.bind(window);
   const nativeClearTimeout = window.clearTimeout.bind(window);
   const nativeSetInterval = window.setInterval.bind(window);
@@ -85,11 +88,9 @@ function initializeArchiver(): void {
         }
       }
 
-      // Serialize CSSOM without freezing — we need timers alive for the DOM monitor
-      serializeCSSOMToDOM();
-
-      // 在克隆 DOM 上内联布局样式，不影响原始页面显示
-      let html = inlineLayoutStyles();
+      // 在克隆 DOM 上内联布局样式，并把 iframe 当前内容嵌入快照
+      const captured = await captureDocumentHTMLWithFrames();
+      let html = captured.html;
 
       // Merge any nodes removed by virtual scrolling before/during capture
       if (domCollector.collectedCount > 0) {
@@ -101,6 +102,7 @@ function initializeArchiver(): void {
         url: window.location.href,
         title: document.title,
         html,
+        frames: captured.frames,
         headers,
       };
 
@@ -229,11 +231,9 @@ function initializeArchiver(): void {
         try {
           console.log(`[Wayback] DOM changed (${currentMutations} mutations), triggering update...`);
 
-          // Only serialize CSSOM — don't freeze, to keep the SPA functional
-          serializeCSSOMToDOM();
-
-          // 在克隆 DOM 上内联布局样式
-          let newHTML = inlineLayoutStyles();
+          // 在克隆 DOM 上内联布局样式，并把 iframe 当前内容嵌入快照
+          const captured = await captureDocumentHTMLWithFrames();
+          let newHTML = captured.html;
 
           // Merge any nodes that were removed by virtual scrolling back into the snapshot
           if (domCollector.collectedCount > 0) {
@@ -251,6 +251,7 @@ function initializeArchiver(): void {
             url: window.location.href,
             title: document.title,
             html: newHTML,
+            frames: captured.frames,
             headers: captureData?.headers,
           };
 

--- a/browser/src/page-filter.ts
+++ b/browser/src/page-filter.ts
@@ -2,14 +2,9 @@
 
 /**
  * Returns true if the current page should not be archived.
- * Skips local pages, browser internal pages, and iframes.
+ * Skips local pages and browser internal pages.
  */
 export function shouldSkipPage(): boolean {
-  // Only run in top-level window, skip iframes
-  if (window.self !== window.top) {
-    return true;
-  }
-
   const url = window.location.href;
   const hostname = window.location.hostname;
 

--- a/browser/src/page-freezer.ts
+++ b/browser/src/page-freezer.ts
@@ -123,8 +123,8 @@ function serializeCSSOM(): void {
  * Resolves after timeout regardless.
  */
 export function waitForDOMStable(
-  timeout = CONFIG.MUTATION_OBSERVER_TIMEOUT,
-  stableTime = CONFIG.DOM_STABLE_TIME
+  timeout: number = CONFIG.MUTATION_OBSERVER_TIMEOUT,
+  stableTime: number = CONFIG.DOM_STABLE_TIME
 ): Promise<void> {
   return new Promise((resolve) => {
     let timer: number | null = null;

--- a/browser/src/puppeteer.ts
+++ b/browser/src/puppeteer.ts
@@ -4,12 +4,16 @@
 import { CONFIG } from './config';
 import { CaptureData } from './types';
 import { shouldSkipPage } from './page-filter';
-import { waitForDOMStable, serializeCSSOMToDOM } from './page-freezer';
-import { inlineLayoutStyles } from './style-inliner';
+import { waitForDOMStable } from './page-freezer';
 import { DOMCollector } from './dom-collector';
+import { captureDocumentHTMLWithFrames, setupFrameCaptureBridge } from './frame-capture';
 
 // pako is loaded via script tag in Puppeteer
 declare const pako: any;
+
+if (!shouldSkipPage() && window.self !== window.top) {
+  setupFrameCaptureBridge();
+}
 
 interface ArchiveResponse {
   status: string;
@@ -96,6 +100,11 @@ export async function archivePage(): Promise<void> {
     return;
   }
 
+  if (window.self !== window.top) {
+    setupFrameCaptureBridge();
+    return;
+  }
+
   console.log('[Wayback] Starting capture:', window.location.href);
 
   const domCollector = new DOMCollector();
@@ -106,8 +115,8 @@ export async function archivePage(): Promise<void> {
 
   await waitForDOMStable(CONFIG.MUTATION_OBSERVER_TIMEOUT, CONFIG.DOM_STABLE_TIME);
 
-  serializeCSSOMToDOM();
-  let html = inlineLayoutStyles();
+  const captured = await captureDocumentHTMLWithFrames();
+  let html = captured.html;
 
   if (domCollector.collectedCount > 0) {
     console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes`);
@@ -120,6 +129,7 @@ export async function archivePage(): Promise<void> {
     url: window.location.href,
     title: document.title,
     html,
+    frames: captured.frames,
   };
 
   await sendToServer(captureData);

--- a/browser/src/types.ts
+++ b/browser/src/types.ts
@@ -4,7 +4,15 @@ export interface CaptureData {
   url: string;
   title: string;
   html: string;
+  frames?: FrameCapture[];
   headers?: Record<string, string>;
+}
+
+export interface FrameCapture {
+  key: string;
+  url: string;
+  title: string;
+  html: string;
 }
 
 export interface ArchiveResponse {

--- a/server/internal/api/archive_handler.go
+++ b/server/internal/api/archive_handler.go
@@ -17,7 +17,7 @@ func (h *Handler) ArchivePage(c *gin.Context) {
 		return
 	}
 
-	log.Printf("Received archive request: %s (resources: %d)", req.URL, len(req.Resources))
+	log.Printf("Received archive request: %s (frames: %d)", req.URL, len(req.Frames))
 
 	// 处理捕获
 	pageID, action, err := h.dedup.ProcessCapture(&req)

--- a/server/internal/api/patterns.go
+++ b/server/internal/api/patterns.go
@@ -18,6 +18,7 @@ var (
 	srcsetAttrRe = regexp.MustCompile(`(?i)\ssrcset=["']([^"']+)["']`)
 	posterAttrRe = regexp.MustCompile(`(?i)\sposter=["']([^"']+)["']`)
 	dataAttrRe   = regexp.MustCompile(`(?i)\sdata=["']([^"']+)["']`)
+	srcdocAttrRe = regexp.MustCompile(`(?i)\ssrcdoc=["']([^"']*)["']`)
 
 	// CSS patterns
 	cssURLRe      = regexp.MustCompile(`url\(['"]?([^'")\s]+)['"]?\)`)
@@ -33,10 +34,14 @@ var (
 
 	// ViewPage patterns (previously compiled per-request)
 	baseTagRe        = regexp.MustCompile(`(?i)<base\s[^>]*>`)
+	iframeTagFullRe  = regexp.MustCompile(`(?is)<iframe\b[^>]*>`)
 	eventHandlerDQRe = regexp.MustCompile(`(?i)\s+on\w+\s*=\s*"[^"]*"`)
 	eventHandlerSQRe = regexp.MustCompile(`(?i)\s+on\w+\s*=\s*'[^']*'`)
 	jsProtocolRe     = regexp.MustCompile(`(?i)href\s*=\s*["']javascript:[^"']*["']`)
 	lazyLoadRe       = regexp.MustCompile(`(?i)\s+loading\s*=\s*["']lazy["']`)
+	frameTagRe       = regexp.MustCompile(`(?is)<frame\b[^>]*>.*?</frame>|<frame\b[^>]*/?>`)
+	objectTagRe      = regexp.MustCompile(`(?is)<object\b[^>]*>.*?</object>|<object\b[^>]*/>`)
+	embedTagRe       = regexp.MustCompile(`(?is)<embed\b[^>]*/?>`)
 	autoplayAttrRe   = regexp.MustCompile(`(?i)\s+autoplay(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?`)
 	controlsAttrRe   = regexp.MustCompile(`(?i)\s+controls(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?`)
 	sourceTagRe      = regexp.MustCompile(`(?is)<source[^>]*>`)

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	htmlpkg "html"
 	"log"
 	"net/http"
 	"net/url"
@@ -93,53 +94,7 @@ func (h *Handler) ViewPage(c *gin.Context) {
 		return
 	}
 
-	modifiedHTML := string(htmlContent)
-
-	// 移除 <base> 标签 — 归档页面的资源路径已重写为本地路径，
-	// <base href="https://原始域名/"> 会导致浏览器将 /archive/... 解析到原始域名
-	modifiedHTML = baseTagRe.ReplaceAllString(modifiedHTML, "")
-
-	// 移除 CSP meta 标签 — upgrade-insecure-requests 会导致 Opera 等浏览器
-	// 将 http://内网IP/archive/... 升级为 https，导致资源无法加载
-	modifiedHTML = metaCSPRe.ReplaceAllString(modifiedHTML, "")
-
-	// 移除所有 <script> 标签
-	modifiedHTML = scriptTagRe.ReplaceAllString(modifiedHTML, "")
-
-	// 移除 <noscript> 标签（CSP 禁用了 JS，浏览器会渲染 noscript 内容，
-	// 导致 SPA 页面显示"需要启用 JavaScript"的错误信息和大片空白）
-	modifiedHTML = noscriptTagRe.ReplaceAllString(modifiedHTML, "")
-
-	// 移除内联事件处理器
-	// 使用两个独立正则分别处理双引号和单引号包裹的属性值，
-	// 避免 [^"']* 在遇到嵌套引号时提前终止匹配（如 onclick="window.open('...')"）
-	modifiedHTML = eventHandlerDQRe.ReplaceAllString(modifiedHTML, "")
-	modifiedHTML = eventHandlerSQRe.ReplaceAllString(modifiedHTML, "")
-
-	// 移除 javascript: 协议的链接
-	modifiedHTML = jsProtocolRe.ReplaceAllString(modifiedHTML, `href="#"`)
-
-	// 移除 loading="lazy"，归档页面禁用了 JS，懒加载可能无法正常触发
-	modifiedHTML = lazyLoadRe.ReplaceAllString(modifiedHTML, "")
-
-	// 归档页面禁用 JS：关闭视频自动播放、补原生 controls，并隐藏无源 video
-	modifiedHTML = hideVideoElements(modifiedHTML)
-
-	// 修复未重写的 srcset 协议相对 URL（如 srcset="//i1.hdslb.com/..."）
-	// 早期归档的页面 srcset 未被重写，在渲染时补偿处理
-	modifiedHTML = fixUnrewrittenSrcset(modifiedHTML)
-
-	// 移除 SPA loading 覆盖层（如 X.com 的 #placeholder 全屏黑色 loading 画面）
-	// 归档页面没有 JS 运行，这些覆盖层永远不会被隐藏，会遮挡真实内容
-	modifiedHTML = removeLoadingOverlays(modifiedHTML)
-
-	// 修复嵌套的 <button> 标签（HTML 规范不允许 button 嵌套 button）
-	// 浏览器遇到嵌套 button 时会隐式关闭外层 button，破坏 DOM 树结构，
-	// 导致后续元素（如 <main>、<section>）被提升到错误的层级
-	modifiedHTML = fixNestedButtons(modifiedHTML)
-
-	// 修复滚动动画元素的 opacity: 0（归档页面没有 JS，动画永远不会触发）
-	modifiedHTML = fixScrollAnimationOpacity(modifiedHTML)
+	modifiedHTML := sanitizeArchivedHTML(string(htmlContent))
 
 	// 注入归档信息栏（传入 nonce 用于 CSP）
 	// 生成随机 nonce，防止归档页面中的恶意脚本绕过 CSP
@@ -149,7 +104,7 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	// 设置安全响应头（允许带 nonce 的内联脚本，用于修复定位问题）
 	c.Header("X-Frame-Options", "SAMEORIGIN")
 	c.Header("Referrer-Policy", "no-referrer")
-	c.Header("Content-Security-Policy", fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'none'; object-src 'none';", nonce))
+	c.Header("Content-Security-Policy", fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';", nonce))
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(modifiedHTML))
 }
@@ -218,6 +173,10 @@ func (h *Handler) ProxyResource(c *gin.Context) {
 		h.serveRewrittenCSS(c, pageIDInt, resource)
 		return
 	}
+	if resource.ResourceType == "html" {
+		h.serveArchivedHTMLResource(c, resource)
+		return
+	}
 
 	// 读取文件
 	filePath := filepath.Join(h.dataDir, resource.FilePath)
@@ -263,6 +222,22 @@ func (h *Handler) serveRewrittenCSS(c *gin.Context, pageID int64, resource *mode
 	c.Header("Content-Type", "text/css; charset=utf-8")
 	c.Header("Cache-Control", "public, max-age=31536000")
 	c.Data(http.StatusOK, "text/css; charset=utf-8", []byte(rewritten))
+}
+
+func (h *Handler) serveArchivedHTMLResource(c *gin.Context, resource *models.Resource) {
+	filePath := filepath.Join(h.dataDir, resource.FilePath)
+	htmlContent, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Printf("[Proxy] Failed to read HTML file %s: %v", filePath, err)
+		c.String(http.StatusInternalServerError, "Failed to read file")
+		return
+	}
+
+	sanitized := sanitizeArchivedHTML(string(htmlContent))
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	c.Header("Cache-Control", "public, max-age=31536000")
+	c.Header("Content-Security-Policy", "default-src 'self'; script-src 'none'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';")
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(sanitized))
 }
 
 func (h *Handler) findResourceForPage(originalURL string, pageID int64) (*models.Resource, error) {
@@ -393,6 +368,8 @@ func detectContentType(resource *models.Resource) string {
 		return detectImageType(resource.FilePath)
 	case "font":
 		return detectFontType(resource.FilePath)
+	case "html":
+		return "text/html; charset=utf-8"
 	default:
 		// 尝试从 URL 路径扩展名推断（如 .jpg、.png）
 		if ct := detectImageType(resource.URL); ct != "image/jpeg" {
@@ -448,6 +425,8 @@ func detectContentTypeByPath(filePath string) string {
 		return "video/webm"
 	case ".mp3":
 		return "audio/mpeg"
+	case ".html", ".htm":
+		return "text/html; charset=utf-8"
 	default:
 		return "application/octet-stream"
 	}
@@ -633,6 +612,64 @@ func fixUnrewrittenSrcset(html string) string {
 	// <img> 的 src 已被正确重写，删除 <source> 后浏览器会回退到 <img>
 	html = sourceTagRe.ReplaceAllString(html, "")
 
+	return html
+}
+
+func sanitizeArchivedHTML(html string) string {
+	html = baseTagRe.ReplaceAllString(html, "")
+	html = metaCSPRe.ReplaceAllString(html, "")
+	html = scriptTagRe.ReplaceAllString(html, "")
+	html = noscriptTagRe.ReplaceAllString(html, "")
+	html = eventHandlerDQRe.ReplaceAllString(html, "")
+	html = eventHandlerSQRe.ReplaceAllString(html, "")
+	html = jsProtocolRe.ReplaceAllString(html, `href="#"`)
+	html = lazyLoadRe.ReplaceAllString(html, "")
+	html = hideVideoElements(html)
+	html = removeUnsupportedEmbeddedContent(html)
+	html = fixUnrewrittenSrcset(html)
+	html = removeUnarchivedExternalCSSReferences(html)
+	html = removeLoadingOverlays(html)
+	html = fixNestedButtons(html)
+	html = fixScrollAnimationOpacity(html)
+	return html
+}
+
+// removeUnarchivedExternalCSSReferences 清理仍残留在 HTML 中的外部 CSS 引用。
+// 这些引用通常对应下载失败的资源；保留它们只会让归档页继续请求原站。
+func removeUnarchivedExternalCSSReferences(html string) string {
+	html = cssURLRe.ReplaceAllStringFunc(html, func(match string) string {
+		parts := cssURLRe.FindStringSubmatch(match)
+		if len(parts) < 2 {
+			return match
+		}
+
+		rawURL := strings.TrimSpace(htmlpkg.UnescapeString(parts[1]))
+		rawURL = strings.Trim(rawURL, `"'`)
+		if rawURL == "" {
+			return match
+		}
+
+		if strings.HasPrefix(rawURL, "/archive/") || strings.HasPrefix(rawURL, "data:") {
+			return match
+		}
+
+		if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "//") {
+			return `url("")`
+		}
+
+		return match
+	})
+
+	html = externalImportRe.ReplaceAllString(html, "")
+	return html
+}
+
+// removeUnsupportedEmbeddedContent 移除无法在静态归档页中可靠工作的嵌入式内容。
+// ViewPage 已通过 CSP 禁用 frame/object，这里同步剥掉对应标签，避免旧归档页残留远程资源 URL。
+func removeUnsupportedEmbeddedContent(html string) string {
+	html = frameTagRe.ReplaceAllString(html, "")
+	html = objectTagRe.ReplaceAllString(html, "")
+	html = embedTagRe.ReplaceAllString(html, "")
 	return html
 }
 

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -628,6 +628,57 @@ func TestHideVideoElements_PreservesExistingControlsValue(t *testing.T) {
 	}
 }
 
+func TestRemoveUnsupportedEmbeddedContent_RemovesObjectEmbedButKeepsIframe(t *testing.T) {
+	html := `<div><iframe src="https://example.com/app"></iframe><object data="//cdn.example.com/plugin.swf"><param name="wmode" value="transparent"></object><embed src="https://example.com/movie.swf"><img src="/archive/1/20260414mp_/https://example.com/logo.png"></div>`
+	result := removeUnsupportedEmbeddedContent(html)
+
+	if !strings.Contains(strings.ToLower(result), "<iframe") {
+		t.Fatalf("iframe should be preserved, got: %s", result)
+	}
+	if strings.Contains(strings.ToLower(result), "<object") {
+		t.Fatalf("object should be removed, got: %s", result)
+	}
+	if strings.Contains(strings.ToLower(result), "<embed") {
+		t.Fatalf("embed should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, `<img src="/archive/1/20260414mp_/https://example.com/logo.png">`) {
+		t.Fatalf("non-embedded archived content should be preserved, got: %s", result)
+	}
+}
+
+func TestRemoveUnsupportedEmbeddedContent_RemovesFrameCaseInsensitively(t *testing.T) {
+	html := `<FRAME SRC="https://example.com/legacy"></FRAME><p>ok</p>`
+	result := removeUnsupportedEmbeddedContent(html)
+
+	if strings.Contains(strings.ToLower(result), "<frame") {
+		t.Fatalf("frame should be removed case-insensitively, got: %s", result)
+	}
+	if !strings.Contains(result, `<p>ok</p>`) {
+		t.Fatalf("surrounding content should be preserved, got: %s", result)
+	}
+}
+
+func TestRemoveUnarchivedExternalCSSReferences_RemovesExternalCSSURLs(t *testing.T) {
+	html := `<style>.ok{background:url("/archive/1/20260414mp_/https://example.com/logo.png")}.bad{background:url(https://cdn.example.com/missing.png)}@import url("https://cdn.example.com/theme.css");</style><div style="background-image:url(//cdn.example.com/banner.jpg)"></div>`
+	result := removeUnarchivedExternalCSSReferences(html)
+
+	if !strings.Contains(result, `url("/archive/1/20260414mp_/https://example.com/logo.png")`) {
+		t.Fatalf("archived CSS URL should be preserved, got: %s", result)
+	}
+	if strings.Contains(result, `https://cdn.example.com/missing.png`) {
+		t.Fatalf("external CSS url() should be removed, got: %s", result)
+	}
+	if strings.Contains(result, `//cdn.example.com/banner.jpg`) {
+		t.Fatalf("protocol-relative CSS url() should be removed, got: %s", result)
+	}
+	if strings.Contains(result, `@import url("https://cdn.example.com/theme.css")`) {
+		t.Fatalf("external @import should be removed, got: %s", result)
+	}
+	if strings.Count(result, `url("")`) != 3 {
+		t.Fatalf("expected three stripped url() placeholders, got: %s", result)
+	}
+}
+
 // --- CSP meta 标签移除测试 ---
 
 func TestRemoveCSPMeta(t *testing.T) {

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -27,16 +27,18 @@ type Resource struct {
 }
 
 type CaptureRequest struct {
-	URL       string              `json:"url" binding:"required"`
-	Title     string              `json:"title"`
-	HTML      string              `json:"html" binding:"required"`
-	Resources []ResourceReference `json:"resources"`
-	Headers   map[string]string   `json:"headers"`
+	URL     string            `json:"url" binding:"required"`
+	Title   string            `json:"title"`
+	HTML    string            `json:"html" binding:"required"`
+	Frames  []FrameCapture    `json:"frames"`
+	Headers map[string]string `json:"headers"`
 }
 
-type ResourceReference struct {
-	Type string `json:"type"`
-	URL  string `json:"url"`
+type FrameCapture struct {
+	Key   string `json:"key" binding:"required"`
+	URL   string `json:"url" binding:"required"`
+	Title string `json:"title"`
+	HTML  string `json:"html" binding:"required"`
 }
 
 const (

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -287,14 +289,269 @@ func (d *Deduplicator) processResourceFallback(url string, downloadErr error) (i
 	return existing.ID, existing.FilePath, nil, nil
 }
 
+type cssWorkItem struct {
+	cssContent string
+	cssURL     string
+}
+
+type processedInlineHTML struct {
+	resourceID int64
+	filePath   string
+}
+
+var (
+	iframeTagMatchRe     = regexp.MustCompile(`(?is)<iframe\b[^>]*>`)
+	iframeFrameKeyAttrRe = regexp.MustCompile(`(?i)\sdata-wayback-frame-key=["']([^"']+)["']`)
+	iframeSrcAttrMatchRe = regexp.MustCompile(`(?i)(\ssrc=)(["'])([^"']*)(["'])`)
+)
+
+func buildFrameCaptureMap(frames []models.FrameCapture) map[string]models.FrameCapture {
+	frameMap := make(map[string]models.FrameCapture, len(frames))
+	for _, frame := range frames {
+		if frame.Key == "" || frame.URL == "" || frame.HTML == "" {
+			continue
+		}
+		frameMap[frame.Key] = frame
+	}
+	return frameMap
+}
+
+func hashCaptureContent(html string, frames []models.FrameCapture) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(html))
+
+	if len(frames) > 0 {
+		sorted := append([]models.FrameCapture(nil), frames...)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Key < sorted[j].Key
+		})
+		for _, frame := range sorted {
+			hasher.Write([]byte("\n--frame-key--\n"))
+			hasher.Write([]byte(frame.Key))
+			hasher.Write([]byte("\n--frame-url--\n"))
+			hasher.Write([]byte(frame.URL))
+			hasher.Write([]byte("\n--frame-title--\n"))
+			hasher.Write([]byte(frame.Title))
+			hasher.Write([]byte("\n--frame-html--\n"))
+			hasher.Write([]byte(frame.HTML))
+		}
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func archiveProxyURL(pageID int64, timestamp, originalURL string) string {
+	return fmt.Sprintf("/archive/%d/%smp_/%s", pageID, timestamp, originalURL)
+}
+
+func (d *Deduplicator) rewriteIframeTagsByKey(htmlContent string, pageID int64, timestamp string, headers map[string]string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) string {
+	if len(frameMap) == 0 {
+		return htmlContent
+	}
+
+	return iframeTagMatchRe.ReplaceAllStringFunc(htmlContent, func(tag string) string {
+		keyMatch := iframeFrameKeyAttrRe.FindStringSubmatch(tag)
+		if len(keyMatch) < 2 {
+			return tag
+		}
+		frame, ok := frameMap[keyMatch[1]]
+		if !ok {
+			return tag
+		}
+
+		resourceID, _, err := d.archiveFrameCapture(frame, headers, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
+		if err != nil {
+			log.Printf("Failed to process iframe capture %s: %v", frame.URL, err)
+			return tag
+		}
+		appendUniqueResourceID(resourceIDs, seen, resourceID)
+
+		proxyURL := archiveProxyURL(pageID, timestamp, frame.URL)
+		if iframeSrcAttrMatchRe.MatchString(tag) {
+			return iframeSrcAttrMatchRe.ReplaceAllString(tag, `${1}${2}`+proxyURL+`${4}`)
+		}
+		if strings.HasSuffix(tag, "/>") {
+			return strings.TrimSuffix(tag, "/>") + ` src="` + proxyURL + `"/>`
+		}
+		return strings.TrimSuffix(tag, ">") + ` src="` + proxyURL + `">`
+	})
+}
+
+func appendUniqueResourceID(resourceIDs *[]int64, seen map[int64]struct{}, resourceID int64) {
+	if resourceID == 0 {
+		return
+	}
+	if _, ok := seen[resourceID]; ok {
+		return
+	}
+	seen[resourceID] = struct{}{}
+	*resourceIDs = append(*resourceIDs, resourceID)
+}
+
+func (d *Deduplicator) processInlineResource(url, resourceType string, data []byte) (int64, string, []byte, error) {
+	hashBytes := sha256.Sum256(data)
+	hash := hex.EncodeToString(hashBytes[:])
+	fileSize := int64(len(data))
+
+	existingByHash, err := d.db.GetResourceByHash(hash)
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("db query by hash failed: %w", err)
+	}
+
+	var filePath string
+	if existingByHash != nil {
+		filePath = existingByHash.FilePath
+	} else {
+		filePath, err = d.storage.SaveResource(data, hash, resourceType)
+		if err != nil {
+			return 0, "", nil, fmt.Errorf("save failed: %w", err)
+		}
+	}
+
+	resourceID, err := d.db.CreateResourceIfNotExists(url, hash, resourceType, filePath, fileSize)
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("db insert failed: %w", err)
+	}
+
+	d.cacheStore(url, resourceID, filePath, data)
+	return resourceID, filePath, data, nil
+}
+
+func (d *Deduplicator) processCSSWorkItems(cssWorkItems []cssWorkItem, pageURL string, headers map[string]string, rewriter *URLRewriter, resourceIDs *[]int64, seen map[int64]struct{}) {
+	type cssSubResource struct {
+		absoluteURL string
+	}
+	var allCSSSubResources []cssSubResource
+
+	for _, cw := range cssWorkItems {
+		cssResources := d.cssParser.ExtractResources(cw.cssContent)
+		for _, cssResURL := range cssResources {
+			absoluteURL := d.resolveURL(cw.cssURL, cssResURL)
+			allCSSSubResources = append(allCSSSubResources, cssSubResource{absoluteURL: absoluteURL})
+		}
+	}
+
+	if len(allCSSSubResources) == 0 {
+		return
+	}
+
+	type cssSubResult struct {
+		sub      cssSubResource
+		resID    int64
+		filePath string
+		err      error
+	}
+
+	resultsCh := make(chan cssSubResult, len(allCSSSubResources))
+	var wg sync.WaitGroup
+	for _, sub := range allCSSSubResources {
+		wg.Add(1)
+		go func(sub cssSubResource) {
+			defer wg.Done()
+			d.globalSem <- struct{}{}
+			defer func() { <-d.globalSem }()
+
+			resID, filePath, _, err := d.ProcessResource(sub.absoluteURL, d.guessResourceType(sub.absoluteURL), pageURL, headers)
+			resultsCh <- cssSubResult{sub: sub, resID: resID, filePath: filePath, err: err}
+		}(sub)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	for result := range resultsCh {
+		if result.err != nil {
+			log.Printf("Failed to process CSS resource %s: %v", result.sub.absoluteURL, result.err)
+			continue
+		}
+		appendUniqueResourceID(resourceIDs, seen, result.resID)
+		rewriter.AddMapping(result.sub.absoluteURL, result.filePath)
+	}
+}
+
+func (d *Deduplicator) archiveFrameCapture(frame models.FrameCapture, headers map[string]string, pageID int64, timestamp string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) (int64, string, error) {
+	if cached, ok := archived[frame.URL]; ok {
+		appendUniqueResourceID(resourceIDs, seen, cached.resourceID)
+		return cached.resourceID, cached.filePath, nil
+	}
+	if visiting[frame.URL] {
+		return 0, "", fmt.Errorf("cyclic iframe reference: %s", frame.URL)
+	}
+	visiting[frame.URL] = true
+	defer delete(visiting, frame.URL)
+
+	rewrittenHTML, err := d.rewriteCapturedHTML(frame.HTML, frame.URL, headers, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
+	if err != nil {
+		return 0, "", err
+	}
+
+	resourceID, filePath, _, err := d.processInlineResource(frame.URL, "html", []byte(rewrittenHTML))
+	if err != nil {
+		return 0, "", err
+	}
+
+	archived[frame.URL] = processedInlineHTML{resourceID: resourceID, filePath: filePath}
+	appendUniqueResourceID(resourceIDs, seen, resourceID)
+	return resourceID, filePath, nil
+}
+
+func (d *Deduplicator) rewriteCapturedHTML(htmlContent, baseURL string, headers map[string]string, pageID int64, timestamp string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) (string, error) {
+	htmlResources := d.htmlExtractor.ExtractResources(htmlContent, baseURL)
+	rewriter := NewURLRewriter()
+	rewriter.SetPageID(pageID)
+	rewriter.SetTimestamp(timestamp)
+	rewriter.SetBaseURL(baseURL)
+
+	var cssWorkItems []cssWorkItem
+	for _, res := range htmlResources {
+		if frame, ok := frameMap[res.URL]; ok {
+			resourceID, filePath, err := d.archiveFrameCapture(frame, headers, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
+			if err != nil {
+				log.Printf("Failed to process iframe capture %s: %v", res.URL, err)
+				continue
+			}
+			appendUniqueResourceID(resourceIDs, seen, resourceID)
+			rewriter.AddMapping(res.URL, filePath)
+			continue
+		}
+
+		resourceID, filePath, data, err := d.ProcessResource(res.URL, res.Type, baseURL, headers)
+		if err != nil {
+			log.Printf("Failed to process resource %s: %v", res.URL, err)
+			continue
+		}
+
+		appendUniqueResourceID(resourceIDs, seen, resourceID)
+		rewriter.AddMapping(res.URL, filePath)
+
+		if res.Type == "css" {
+			cssData := data
+			if cssData == nil && filePath != "" {
+				if fileData, readErr := d.storage.ReadResource(filePath); readErr == nil {
+					cssData = fileData
+				} else {
+					log.Printf("Failed to read CSS file for sub-resource extraction: %s: %v", filePath, readErr)
+				}
+			}
+			if cssData != nil {
+				cssWorkItems = append(cssWorkItems, cssWorkItem{cssContent: string(cssData), cssURL: res.URL})
+			}
+		}
+	}
+
+	d.processCSSWorkItems(cssWorkItems, baseURL, headers, rewriter, resourceIDs, seen)
+
+	normalizedHTML := ResolveRelativeURLs(NormalizeHTMLURLs(htmlContent), baseURL)
+	return rewriter.RewriteHTML(normalizedHTML), nil
+}
+
 // ProcessCapture 处理完整的页面捕获，返回 (pageID, action, error)
 func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string, error) {
 	capturedAt := time.Now()
 
-	// 计算 HTML 内容哈希（流式写入，避免拷贝 []byte(req.HTML)）
-	hasher := sha256.New()
-	hasher.Write([]byte(req.HTML))
-	contentHash := hex.EncodeToString(hasher.Sum(nil))
+	contentHash := hashCaptureContent(req.HTML, req.Frames)
 
 	// 检查是否存在相同 URL 和内容哈希的页面
 	existingPage, err := d.db.GetPageByURLAndHash(req.URL, contentHash)
@@ -311,20 +568,8 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 		return existingPage.ID, models.ArchiveActionUnchanged, nil
 	}
 
-	// 内容有变化或首次访问，创建新记录
-
-	// 从 HTML 中提取所有资源 URL
-	htmlResources := d.htmlExtractor.ExtractResources(req.HTML, req.URL)
-
-	allResources := make([]models.ResourceReference, 0, len(htmlResources))
-	for _, res := range htmlResources {
-		allResources = append(allResources, models.ResourceReference{
-			URL:  res.URL,
-			Type: res.Type,
-		})
-	}
-
-	log.Printf("Total resources to process: %d", len(allResources))
+	frameMap := buildFrameCaptureMap(req.Frames)
+	log.Printf("Total resources to process: %d (frames: %d)", len(d.htmlExtractor.ExtractResources(req.HTML, req.URL)), len(frameMap))
 
 	// 先创建页面记录以获取 pageID（用于生成正确的资源路径）
 	// 使用临时 HTML 创建页面
@@ -335,9 +580,6 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 
 	// 提取正文纯文本（在释放 HTML 之前）
 	bodyText := ExtractBodyText(req.HTML)
-
-	// 将 HTML 保存到局部变量，后续使用 rawHTML 避免长时间持有 req.HTML 引用
-	rawHTML := req.HTML
 
 	pageID, err := d.db.CreatePage(req.URL, req.Title, tempHTMLPath, contentHash, capturedAt)
 	if err != nil {
@@ -357,184 +599,14 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 	// 生成时间戳用于资源路径
 	timestamp := capturedAt.Format("20060102150405")
 
-	// 创建 URL 重写器
-	rewriter := NewURLRewriter()
-	rewriter.SetPageID(pageID)
-	rewriter.SetTimestamp(timestamp)
-	rewriter.SetBaseURL(req.URL)
-
 	var resourceIDs []int64
-
-	// 并行处理资源
-	type resourceResult struct {
-		res        models.ResourceReference
-		resourceID int64
-		data       []byte
-		filePath   string
-		err        error
-	}
-
-	resultsCh := make(chan resourceResult, len(allResources))
-	sem := d.globalSem // 全局信号量，跨所有页面共享
-	var wg sync.WaitGroup
 	startTime := time.Now()
-
-	for _, res := range allResources {
-		wg.Add(1)
-		go func(res models.ResourceReference) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					log.Printf("PANIC recovered in resource goroutine for %s: %v", res.URL, r)
-					resultsCh <- resourceResult{res: res, err: fmt.Errorf("panic: %v", r)}
-				}
-			}()
-
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			resourceID, filePath, data, err := d.ProcessResource(res.URL, res.Type, req.URL, req.Headers)
-			if err != nil {
-				resultsCh <- resourceResult{res: res, err: err}
-				return
-			}
-
-			resultsCh <- resourceResult{
-				res:        res,
-				resourceID: resourceID,
-				data:       data,
-				filePath:   filePath,
-			}
-		}(res)
+	resourceIDSet := make(map[int64]struct{})
+	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
+	if err != nil {
+		return 0, "", fmt.Errorf("rewrite html failed: %w", err)
 	}
-
-	go func() {
-		wg.Wait()
-		close(resultsCh)
-	}()
-
-	// 收集结果
-	type cssWork struct {
-		cssContent string
-		cssURL     string
-	}
-	var cssWorkItems []cssWork
-
-	processedCount := 0
-	failedCount := 0
-	lastLogTime := time.Now()
-
-	for result := range resultsCh {
-		processedCount++
-
-		// 每处理 50 个资源或每 10 秒输出一次进度
-		if processedCount%50 == 0 || time.Since(lastLogTime) > 10*time.Second {
-			log.Printf("Resource processing progress: %d/%d completed (failed: %d)", processedCount, len(allResources), failedCount)
-			lastLogTime = time.Now()
-		}
-
-		if result.err != nil {
-			failedCount++
-			log.Printf("Failed to process resource %s: %v", result.res.URL, result.err)
-			continue
-		}
-
-		resourceIDs = append(resourceIDs, result.resourceID)
-		rewriter.AddMapping(result.res.URL, result.filePath)
-
-		// 收集需要处理的 CSS 文件
-		if result.res.Type == "css" {
-			cssData := result.data
-			// 大文件流式落盘后 data 为 nil，需要从磁盘读回以提取子资源
-			if cssData == nil && result.filePath != "" {
-				if fileData, readErr := d.storage.ReadResource(result.filePath); readErr == nil {
-					cssData = fileData
-				} else {
-					log.Printf("Failed to read CSS file for sub-resource extraction: %s: %v", result.filePath, readErr)
-				}
-			}
-			if cssData != nil {
-				cssWorkItems = append(cssWorkItems, cssWork{
-					cssContent: string(cssData),
-					cssURL:     result.res.URL,
-				})
-			}
-		}
-	}
-
-	log.Printf("Resource processing completed: %d succeeded, %d failed, took %v", len(resourceIDs), failedCount, time.Since(startTime))
-
-	// 处理 CSS 中引用的资源（收集所有子资源后并行处理）
-	type cssSubResource struct {
-		absoluteURL string
-	}
-	var allCSSSubResources []cssSubResource
-
-	for _, cw := range cssWorkItems {
-		cssResources := d.cssParser.ExtractResources(cw.cssContent)
-		for _, cssResURL := range cssResources {
-			absoluteURL := d.resolveURL(cw.cssURL, cssResURL)
-			allCSSSubResources = append(allCSSSubResources, cssSubResource{
-				absoluteURL: absoluteURL,
-			})
-		}
-	}
-
-	// 并行处理 CSS 子资源
-	if len(allCSSSubResources) > 0 {
-		type cssSubResult struct {
-			sub      cssSubResource
-			resID    int64
-			filePath string
-			err      error
-		}
-
-		subResultsCh := make(chan cssSubResult, len(allCSSSubResources))
-		var subWg sync.WaitGroup
-
-		for _, sub := range allCSSSubResources {
-			subWg.Add(1)
-			go func(sub cssSubResource) {
-				defer subWg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				subResourceID, subFilePath, _, err := d.ProcessResource(sub.absoluteURL, d.guessResourceType(sub.absoluteURL), req.URL, req.Headers)
-				if err != nil {
-					subResultsCh <- cssSubResult{sub: sub, err: err}
-					return
-				}
-
-				subResultsCh <- cssSubResult{
-					sub:      sub,
-					resID:    subResourceID,
-					filePath: subFilePath,
-				}
-			}(sub)
-		}
-
-		go func() {
-			subWg.Wait()
-			close(subResultsCh)
-		}()
-
-		for result := range subResultsCh {
-			if result.err != nil {
-				log.Printf("Failed to process CSS resource %s: %v", result.sub.absoluteURL, result.err)
-				continue
-			}
-
-			resourceIDs = append(resourceIDs, result.resID)
-			rewriter.AddMapping(result.sub.absoluteURL, result.filePath)
-		}
-	}
-
-	// 重写 HTML 中的资源 URL
-	// 1. 规范化 ../ 路径  2. 解析相对路径为绝对 URL  3. 替换为归档路径
-	normalizedHTML := ResolveRelativeURLs(NormalizeHTMLURLs(rawHTML), req.URL)
-	rawHTML = "" // 释放原始 HTML
-	rewrittenHTML := rewriter.RewriteHTML(normalizedHTML)
-	normalizedHTML = "" // 释放中间结果
+	log.Printf("Resource processing completed: %d linked resources, took %v", len(resourceIDs), time.Since(startTime))
 
 	// 更新保存的 HTML 文件（用重写后的内容替换临时内容）
 	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
@@ -564,10 +636,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		return "", fmt.Errorf("page not found: %d", pageID)
 	}
 
-	// 2. 计算新内容哈希（流式写入，避免拷贝 []byte(req.HTML)）
-	hasher := sha256.New()
-	hasher.Write([]byte(req.HTML))
-	newContentHash := hex.EncodeToString(hasher.Sum(nil))
+	newContentHash := hashCaptureContent(req.HTML, req.Frames)
 
 	// 3. 如果内容未变化，仅更新时间
 	if newContentHash == page.ContentHash {
@@ -586,18 +655,8 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		return "", fmt.Errorf("failed to delete old page resources: %w", err)
 	}
 
-	// 5. 处理新内容（复用 ProcessCapture 的资源处理逻辑）
-	extractStart := time.Now()
-	htmlResources := d.htmlExtractor.ExtractResources(req.HTML, req.URL)
-	allResources := make([]models.ResourceReference, 0, len(htmlResources))
-	for _, res := range htmlResources {
-		allResources = append(allResources, models.ResourceReference{
-			URL:  res.URL,
-			Type: res.Type,
-		})
-	}
-
-	log.Printf("[Update] Extracted %d resources in %v", len(allResources), time.Since(extractStart))
+	frameMap := buildFrameCaptureMap(req.Frames)
+	log.Printf("[Update] Processing capture with %d top-level resources and %d frames", len(d.htmlExtractor.ExtractResources(req.HTML, req.URL)), len(frameMap))
 
 	// 保存新 HTML
 	tempHTMLPath, err := d.storage.SaveHTML(req.URL, req.HTML, capturedAt)
@@ -614,177 +673,17 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 	}
 	bodyText = "" // 释放正文文本
 
-	rawHTML := req.HTML
-
 	// 生成时间戳用于资源路径
 	timestamp := capturedAt.Format("20060102150405")
 
-	// 创建 URL 重写器
-	rewriter := NewURLRewriter()
-	rewriter.SetPageID(pageID)
-	rewriter.SetTimestamp(timestamp)
-	rewriter.SetBaseURL(req.URL)
-
 	var resourceIDs []int64
 	processStart := time.Now()
-
-	// 并行处理资源
-	type resourceResult struct {
-		res        models.ResourceReference
-		resourceID int64
-		data       []byte
-		filePath   string
-		err        error
+	resourceIDSet := make(map[int64]struct{})
+	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
+	if err != nil {
+		return "", fmt.Errorf("rewrite html failed: %w", err)
 	}
-
-	resultsCh := make(chan resourceResult, len(allResources))
-	sem := d.globalSem // 全局信号量，跨所有页面共享
-	var wg sync.WaitGroup
-
-	for _, res := range allResources {
-		wg.Add(1)
-		go func(res models.ResourceReference) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					log.Printf("[Update] PANIC recovered in resource goroutine for %s: %v", res.URL, r)
-					resultsCh <- resourceResult{res: res, err: fmt.Errorf("panic: %v", r)}
-				}
-			}()
-
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			resourceID, filePath, data, err := d.ProcessResource(res.URL, res.Type, req.URL, req.Headers)
-			if err != nil {
-				resultsCh <- resourceResult{res: res, err: err}
-				return
-			}
-
-			resultsCh <- resourceResult{
-				res:        res,
-				resourceID: resourceID,
-				data:       data,
-				filePath:   filePath,
-			}
-		}(res)
-	}
-
-	go func() {
-		wg.Wait()
-		close(resultsCh)
-	}()
-
-	type cssWork struct {
-		cssContent string
-		cssURL     string
-	}
-	var cssWorkItems []cssWork
-
-	updateProcessed := 0
-	updateFailed := 0
-	for result := range resultsCh {
-		updateProcessed++
-		if result.err != nil {
-			updateFailed++
-			log.Printf("[Update] Failed to process resource %s: %v", result.res.URL, result.err)
-			continue
-		}
-
-		resourceIDs = append(resourceIDs, result.resourceID)
-		rewriter.AddMapping(result.res.URL, result.filePath)
-
-		if result.res.Type == "css" {
-			cssData := result.data
-			if cssData == nil && result.filePath != "" {
-				if fileData, readErr := d.storage.ReadResource(result.filePath); readErr == nil {
-					cssData = fileData
-				} else {
-					log.Printf("[Update] Failed to read CSS file for sub-resource extraction: %s: %v", result.filePath, readErr)
-				}
-			}
-			if cssData != nil {
-				cssWorkItems = append(cssWorkItems, cssWork{
-					cssContent: string(cssData),
-					cssURL:     result.res.URL,
-				})
-			}
-		}
-	}
-	log.Printf("[Update] Processed %d resources (%d failed) in %v", len(resourceIDs), updateFailed, time.Since(processStart))
-
-	// 处理 CSS 中引用的资源
-	type cssSubResource struct {
-		absoluteURL string
-	}
-	var allCSSSubResources []cssSubResource
-
-	for _, cw := range cssWorkItems {
-		cssResources := d.cssParser.ExtractResources(cw.cssContent)
-		for _, cssResURL := range cssResources {
-			absoluteURL := d.resolveURL(cw.cssURL, cssResURL)
-			allCSSSubResources = append(allCSSSubResources, cssSubResource{
-				absoluteURL: absoluteURL,
-			})
-		}
-	}
-
-	if len(allCSSSubResources) > 0 {
-		cssSubStart := time.Now()
-		log.Printf("[Update] Processing %d CSS sub-resources", len(allCSSSubResources))
-		type cssSubResult struct {
-			sub      cssSubResource
-			resID    int64
-			filePath string
-			err      error
-		}
-
-		subResultsCh := make(chan cssSubResult, len(allCSSSubResources))
-		var subWg sync.WaitGroup
-
-		for _, sub := range allCSSSubResources {
-			subWg.Add(1)
-			go func(sub cssSubResource) {
-				defer subWg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				subResourceID, subFilePath, _, err := d.ProcessResource(sub.absoluteURL, d.guessResourceType(sub.absoluteURL), req.URL, req.Headers)
-				if err != nil {
-					subResultsCh <- cssSubResult{sub: sub, err: err}
-					return
-				}
-
-				subResultsCh <- cssSubResult{
-					sub:      sub,
-					resID:    subResourceID,
-					filePath: subFilePath,
-				}
-			}(sub)
-		}
-
-		go func() {
-			subWg.Wait()
-			close(subResultsCh)
-		}()
-
-		for result := range subResultsCh {
-			if result.err != nil {
-				log.Printf("[Update] Failed to process CSS resource %s: %v", result.sub.absoluteURL, result.err)
-				continue
-			}
-
-			resourceIDs = append(resourceIDs, result.resID)
-			rewriter.AddMapping(result.sub.absoluteURL, result.filePath)
-		}
-		log.Printf("[Update] CSS sub-resources processed in %v", time.Since(cssSubStart))
-	}
-
-	// 重写 HTML 中的资源 URL
-	normalizedHTML := ResolveRelativeURLs(NormalizeHTMLURLs(rawHTML), req.URL)
-	rawHTML = "" // 释放原始 HTML
-	rewrittenHTML := rewriter.RewriteHTML(normalizedHTML)
-	normalizedHTML = "" // 释放中间结果
+	log.Printf("[Update] Processed %d linked resources in %v", len(resourceIDs), time.Since(processStart))
 
 	// 更新保存的 HTML 文件
 	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
@@ -859,6 +758,9 @@ func (d *Deduplicator) guessResourceType(url string) string {
 		strings.HasSuffix(lower, ".svg") || strings.HasSuffix(lower, ".webp") ||
 		strings.HasSuffix(lower, ".ico") {
 		return "image"
+	}
+	if strings.Contains(lower, ".html") || strings.Contains(lower, ".htm") || strings.Contains(lower, "/html/") {
+		return "html"
 	}
 
 	return "other"

--- a/server/internal/storage/filesystem.go
+++ b/server/internal/storage/filesystem.go
@@ -534,6 +534,8 @@ func getExtension(resourceType string) string {
 		return ".js"
 	case "font":
 		return ".font"
+	case "html":
+		return ".html"
 	default:
 		return ".bin"
 	}
@@ -544,5 +546,3 @@ func (fs *FileStorage) ReadHTML(relPath string) ([]byte, error) {
 	filePath := filepath.Join(fs.baseDir, relPath)
 	return os.ReadFile(filePath)
 }
-
-

--- a/server/internal/storage/html_extractor.go
+++ b/server/internal/storage/html_extractor.go
@@ -11,6 +11,7 @@ import (
 // Pre-compiled regexes for HTMLResourceExtractor（避免每次请求重复编译）
 var (
 	imgSrcRe      = regexp.MustCompile(`<img[^>]*\ssrc=["']([^"']+)["']`)
+	iframeSrcRe   = regexp.MustCompile(`<iframe[^>]*\ssrc=["']([^"']+)["']`)
 	scriptSrcRe   = regexp.MustCompile(`<script[^>]+src=["']([^"']+)["']`)
 	linkTagRe     = regexp.MustCompile(`<link[^>]+>`)
 	relAttrRe     = regexp.MustCompile(`\srel=["']([^"']+)["']`)
@@ -56,6 +57,18 @@ func (e *HTMLResourceExtractor) ExtractResources(html string, pageURL string) []
 			fullURL := e.resolveURL(rawURL, pageURL)
 			if e.isExternalURL(fullURL) {
 				resources[fullURL] = ResourceRef{URL: fullURL, Type: "js"}
+			}
+		}
+	}
+
+	// 提取 <iframe src="...">（保留真正承载内容的子文档）
+	matches = iframeSrcRe.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) > 1 {
+			rawURL := htmlpkg.UnescapeString(match[1])
+			fullURL := e.resolveURL(rawURL, pageURL)
+			if e.isExternalURL(fullURL) {
+				resources[fullURL] = ResourceRef{URL: fullURL, Type: guessResourceType(fullURL)}
 			}
 		}
 	}
@@ -290,6 +303,9 @@ func guessResourceType(fullURL string) string {
 		strings.Contains(lower, ".svg") ||
 		strings.Contains(lower, ".webp") {
 		return "image"
+	}
+	if strings.Contains(lower, ".html") || strings.Contains(lower, ".htm") || strings.Contains(lower, "/html/") {
+		return "html"
 	}
 	return "other"
 }

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -189,3 +189,23 @@ func TestExtractResources_VideoPoster(t *testing.T) {
 		t.Error("Should extract video poster")
 	}
 }
+
+func TestExtractResources_IframeHTML(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body><iframe src="https://example.com/embed/app.html?id=1"></iframe></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	found := false
+	for _, r := range resources {
+		if r.URL == "https://example.com/embed/app.html?id=1" {
+			found = true
+			if r.Type != "html" {
+				t.Fatalf("iframe resource type = %q, want html", r.Type)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("should extract iframe HTML resource")
+	}
+}

--- a/server/internal/storage/streaming_test.go
+++ b/server/internal/storage/streaming_test.go
@@ -555,6 +555,7 @@ func TestGetExtension(t *testing.T) {
 		{"css", ".css"},
 		{"js", ".js"},
 		{"font", ".font"},
+		{"html", ".html"},
 		{"other", ".bin"},
 		{"video", ".bin"},
 		{"", ".bin"},

--- a/tests/browser/test-archive.js
+++ b/tests/browser/test-archive.js
@@ -43,8 +43,7 @@ const testData = {
     url: 'https://example.com',
     title: 'Test Page',
     timestamp: Date.now(),
-    html: '<html><body>Test</body></html>',
-    resources: []
+    html: '<html><body>Test</body></html>'
 };
 
 console.log('Sending test archive request...');

--- a/tests/server/test_download_fallback.js
+++ b/tests/server/test_download_fallback.js
@@ -66,8 +66,7 @@ async function test() {
       url: `https://fallback-verify-${uniqueTag}.example.com/page`,
       title: `Fallback Verify ${uniqueTag}`,
       html: html,
-      timestamp: Date.now(),
-      resources: []
+      timestamp: Date.now()
     })
   });
   const result = await res.json();

--- a/tests/server/test_icon_capture.js
+++ b/tests/server/test_icon_capture.js
@@ -13,34 +13,7 @@ async function testIconCapture() {
     url: 'https://example.com/',
     title: 'Test Page - Icon Resources',
     html: html,
-    timestamp: Date.now(),
-    resources: [
-      {
-        url: 'https://example.com/icon.svg',
-        type: 'image',
-        content: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="blue"/></svg>').toString('base64')
-      },
-      {
-        url: 'https://example.com/icons/zhihu.png',
-        type: 'image',
-        content: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=='
-      },
-      {
-        url: 'https://example.com/icons/weibo.png',
-        type: 'image',
-        content: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAE/gL+kR/GGQAAAABJRU5ErkJggg=='
-      },
-      {
-        url: 'https://example.com/icons/coolapk.png',
-        type: 'image',
-        content: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
-      },
-      {
-        url: 'https://example.com/icons/wallstreetcn.png',
-        type: 'image',
-        content: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYGD4DwABBAEAW9JJRQAAAABJRU5ErkJggg=='
-      }
-    ]
+    timestamp: Date.now()
   };
 
   try {
@@ -60,9 +33,10 @@ async function testIconCapture() {
       console.log('\n✓ Page captured successfully!');
 
       // 获取最新的页面ID
-      const pagesResponse = await fetch('http://localhost:8080/api/pages');
-      const pages = await pagesResponse.json();
-      const latestPage = pages[0];
+	      const pagesResponse = await fetch('http://localhost:8080/api/pages');
+	      const pagesPayload = await pagesResponse.json();
+	      const pages = Array.isArray(pagesPayload) ? pagesPayload : (pagesPayload.pages || []);
+	      const latestPage = pages[0];
 
       console.log(`\nLatest page ID: ${latestPage.id}`);
       console.log(`Page URL: ${latestPage.url}`);

--- a/tests/server/test_iframe_capture.js
+++ b/tests/server/test_iframe_capture.js
@@ -1,0 +1,112 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+async function main() {
+  const bundlePath = path.join(__dirname, '../../browser/dist/wayback-puppeteer.js');
+  const bundle = fs.readFileSync(bundlePath, 'utf8');
+  const runId = Date.now();
+  const fixtureHost = 'lvh.me';
+  const parentURL = `http://${fixtureHost}:8091/parent?run=${runId}`;
+  const publicCSSURL = 'https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css';
+
+  const fixtureServer = http.createServer((req, res) => {
+    if (req.url.startsWith('/parent')) {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(`<!doctype html><html><head><title>Frame Parent</title></head><body><h1>Parent</h1><iframe id="child-frame" src="/child?run=${runId}"></iframe></body></html>`);
+      return;
+    }
+
+    if (req.url.startsWith('/child')) {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(`<!doctype html><html><head><title>Child</title><link rel="stylesheet" href="${publicCSSURL}"></head><body><div class="msg">Frame body content</div></body></html>`);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  });
+
+  await new Promise((resolve) => fixtureServer.listen(8091, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    args: [
+      '--no-sandbox',
+      '--disable-web-security',
+      '--disable-features=IsolateOrigins,site-per-process',
+    ],
+  });
+
+  try {
+    const page = await browser.newPage();
+    page.on('console', (msg) => {
+      console.log('[browser]', msg.type(), msg.text());
+    });
+    await page.evaluateOnNewDocument(bundle);
+    await page.goto(parentURL, { waitUntil: 'networkidle2', timeout: 120000 });
+    await page.evaluate(async () => {
+      await window.archivePage();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    const pagesResponse = await fetch('http://127.0.0.1:8080/api/pages');
+    const pagesPayload = await pagesResponse.json();
+    const pages = Array.isArray(pagesPayload) ? pagesPayload : (pagesPayload.pages || []);
+    const archived = pages.find((item) => item.url === parentURL);
+    if (!archived) {
+      throw new Error('Archived page not found');
+    }
+
+    const viewPage = await browser.newPage();
+    const cssRequests = [];
+    viewPage.on('request', (req) => {
+      const url = req.url();
+      if (req.resourceType() === 'stylesheet' || /\.css(\?|$)/i.test(url)) {
+        cssRequests.push(url);
+      }
+    });
+
+    await viewPage.goto(`http://127.0.0.1:8080/view/${archived.id}`, { waitUntil: 'networkidle2', timeout: 120000 });
+    const result = await viewPage.evaluate(() => {
+      const frame = document.querySelector('iframe#child-frame');
+      const childDocument = frame && frame.contentDocument ? frame.contentDocument : null;
+      return {
+        iframe: frame ? {
+          src: frame.getAttribute('src') || '',
+          hasSrcdoc: frame.hasAttribute('srcdoc'),
+        } : null,
+        childText: childDocument ? (childDocument.body.innerText || '').trim() : '',
+      };
+    });
+
+    const uniqueCSS = [...new Set(cssRequests)];
+    const leakedCSS = uniqueCSS.filter((url) => url === publicCSSURL || url.includes(`${fixtureHost}:8091`) || url.includes('127.0.0.1:8091'));
+
+    console.log(JSON.stringify({ archivedId: archived.id, css: uniqueCSS, result }, null, 2));
+
+    if (leakedCSS.length > 0) {
+      throw new Error(`Leaked iframe CSS requests: ${leakedCSS.join(', ')}`);
+    }
+    if (!result.iframe || result.iframe.hasSrcdoc || !result.iframe.src.startsWith('/archive/')) {
+      throw new Error('Iframe was not rewritten to a local archive URL');
+    }
+    if (!result.childText.includes('Frame body content')) {
+      throw new Error('Archived iframe content missing');
+    }
+
+    await viewPage.close();
+    await page.close();
+    console.log('PASS test_iframe_capture');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => fixtureServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_memory_leak.js
+++ b/tests/server/test_memory_leak.js
@@ -35,11 +35,17 @@ function generateLargeHTML(sizeKB, id) {
 
 async function getMemStats() {
   const res = await fetch(`${SERVER}/api/debug/memstats`);
+  if (!res.ok) {
+    throw new Error(`memstats_unavailable:${res.status}`);
+  }
   return res.json();
 }
 
 async function forceGC() {
   const res = await fetch(`${SERVER}/api/debug/gc`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`gc_unavailable:${res.status}`);
+  }
   return res.json();
 }
 
@@ -96,6 +102,15 @@ async function deletePage(pageId) {
   try {
     await getMemStats();
   } catch (e) {
+    try {
+      const versionRes = await fetch(`${SERVER}/api/version`);
+      if (versionRes.ok && String(e.message || '').startsWith('memstats_unavailable:')) {
+        console.log('SKIP: debug API is disabled; set DEBUG_API=true to run memory leak test');
+        process.exit(0);
+      }
+    } catch {
+      // fall through to hard failure below
+    }
     console.error('Server not running on localhost:8080. Start with: ./bin/wayback-server');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- archive iframe captures as independent HTML resources instead of embedding fragile `srcdoc` snapshots
- rewrite archived iframes and their nested CSS/resources through the normal `/archive/...` pipeline, including frame keys and frame-aware content hashing
- remove the unused `CaptureRequest.resources` field and add end-to-end coverage for iframe capture while making the memory-leak e2e skip cleanly when debug APIs are disabled

## Testing
- npm run build
- make test
- make test-e2e
- node tests/server/test_iframe_capture.js