### PR TITLE
fix: harden archive capture and review surfaces

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -143,7 +143,7 @@ export https_proxy=http://127.0.0.1:7897
 | `DB_USER` | `postgres` | 数据库用户 |
 | `DB_PASSWORD` | *（空）* | 数据库密码 |
 | `DB_NAME` | `wayback` | 数据库名称 |
-| `DB_SSLMODE` | `disable` | SSL 模式 |
+| `DB_SSLMODE` | `disable` | 服务端连接 PostgreSQL 时使用的 SSL 模式 |
 | `SERVER_PORT` | `8080` | HTTP 服务端口 |
 | `DATA_DIR` | `./data` | HTML 和资源的存储目录 |
 | `LOG_DIR` | `./data/logs` | 日志文件目录 |
@@ -166,6 +166,12 @@ export https_proxy=http://127.0.0.1:7897
 - **远程部署**：设置 `ENABLE_COMPRESSION: true`
   - 上传减少 95%+（大型 HTML 快照）
   - 重新构建脚本：`cd browser && npm run build`
+
+### 捕获说明
+
+- `/api/archive` 和 `/api/archive/:id` 会拒绝解压后超过 32 MiB 的 JSON 请求体，并返回 HTTP `413`
+- 出于安全考虑，iframe 捕获桥仅接受同源父页面请求；跨源 iframe 会回退为原始归档 URL
+- 浏览器脚本会跳过本地/私网地址，例如 `localhost`、`127.0.0.1`、`172.16.0.0/12`、`169.254.0.0/16`、`::1`、`fc00::/7`、`fe80::/10` 和 `.local`
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The server automatically loads `.env` from the working directory if it exists. Y
 | `DB_USER` | `postgres` | Database user. PostgreSQL defaults to the current system username, so leaving this unset is usually recommended. |
 | `DB_PASSWORD` | *(empty)* | Database password |
 | `DB_NAME` | `wayback` | Database name |
-| `DB_SSLMODE` | `disable` | SSL mode |
+| `DB_SSLMODE` | `disable` | PostgreSQL SSL mode used by the server connection |
 | `SERVER_HOST` | `127.0.0.1` | Server bind address (`0.0.0.0` = all interfaces, `127.0.0.1` = localhost only) |
 | `SERVER_PORT` | `8080` | HTTP server port |
 | `ALLOWED_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080,null` | CORS allowed origins (comma-separated). For remote deployment, add your domain: `https://your-domain.com,null` |
@@ -202,6 +202,11 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 - Reduces upload bandwidth by 95%+ (especially for large HTML snapshots)
 - Response compression is automatic (no configuration needed)
 - Minimal CPU overhead, significant network savings
+
+**Capture Notes:**
+- `/api/archive` and `/api/archive/:id` reject decompressed JSON bodies larger than 32 MiB with HTTP `413`
+- For security, the iframe capture bridge only serves same-origin parent pages; cross-origin iframes fall back to their original archived URL
+- The browser script skips local/private targets including `localhost`, `127.0.0.1`, `172.16.0.0/12`, `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`, and `.local`
 
 ## API
 

--- a/browser/src/frame-capture.ts
+++ b/browser/src/frame-capture.ts
@@ -144,6 +144,23 @@ function markFrames(): HTMLIFrameElement[] {
   return frames;
 }
 
+function resolveFrameOrigin(frame: HTMLIFrameElement): string | null {
+  if (frame.hasAttribute('srcdoc')) {
+    return window.location.origin;
+  }
+
+  const rawSrc = frame.getAttribute('src') || frame.src || 'about:blank';
+  if (rawSrc === 'about:blank' || rawSrc === 'about:srcdoc' || rawSrc === '') {
+    return window.location.origin;
+  }
+
+  try {
+    return new URL(rawSrc, window.location.href).origin;
+  } catch {
+    return null;
+  }
+}
+
 function embedCapturedFrames(parentHTML: string, capturedFrames: Map<string, FrameCaptureResult>, skippedFrames: Map<string, FrameCaptureResult>): string {
   if (capturedFrames.size === 0 && skippedFrames.size === 0) {
     return parentHTML;
@@ -180,7 +197,8 @@ function embedCapturedFrames(parentHTML: string, capturedFrames: Map<string, Fra
 async function requestFrameCapture(frame: HTMLIFrameElement): Promise<FrameCaptureResult | null> {
   const frameId = frame.getAttribute(FRAME_ATTR);
   const frameWindow = frame.contentWindow;
-  if (!frameId || !frameWindow) {
+  const targetOrigin = resolveFrameOrigin(frame);
+  if (!frameId || !frameWindow || targetOrigin !== window.location.origin) {
     return null;
   }
 
@@ -193,7 +211,7 @@ async function requestFrameCapture(frame: HTMLIFrameElement): Promise<FrameCaptu
     }, CONFIG.FRAME_CAPTURE_TIMEOUT);
 
     function handleMessage(event: MessageEvent): void {
-      if (event.source !== frameWindow || !isCaptureResult(event.data) || event.data.requestId !== requestId) {
+      if (event.source !== frameWindow || event.origin !== targetOrigin || !isCaptureResult(event.data) || event.data.requestId !== requestId) {
         return;
       }
 
@@ -209,7 +227,7 @@ async function requestFrameCapture(frame: HTMLIFrameElement): Promise<FrameCaptu
         source: SOURCE,
         type: 'capture-frame',
         requestId,
-      } satisfies FrameCaptureRequest, '*');
+      } satisfies FrameCaptureRequest, targetOrigin);
     } catch {
       window.clearTimeout(timeoutId);
       window.removeEventListener('message', handleMessage);
@@ -261,7 +279,9 @@ export function setupFrameCaptureBridge(): void {
   }
 
   window.addEventListener('message', (event: MessageEvent) => {
-    if (!isCaptureRequest(event.data) || event.source !== window.parent) {
+    // Only honor requests from a same-origin parent. Cross-origin parents can
+    // always postMessage into the iframe, so accepting them would leak DOM.
+    if (!isCaptureRequest(event.data) || event.source !== window.parent || event.origin !== window.location.origin) {
       return;
     }
 
@@ -290,7 +310,7 @@ export function setupFrameCaptureBridge(): void {
         url: window.location.href,
         title: document.title,
         frames: captured.frames,
-      } satisfies FrameCaptureResult, '*');
+      } satisfies FrameCaptureResult, event.origin);
     })();
   });
 }

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -40,6 +40,7 @@ function initializeArchiver(): void {
   let captureData: CaptureData | null = null;
   let isCapturing = false;
   let hasArchived = false;
+  let sendPromise: Promise<void> | null = null;
   let currentPageId: number | null = null;
   let initialHTMLSize = 0; // Track initial capture size for update quality guard
 
@@ -115,24 +116,37 @@ function initializeArchiver(): void {
     }
   }
 
-  async function sendCapture(): Promise<void> {
+  function sendCapture(): Promise<void> {
     if (!captureData || hasArchived) {
-      return;
+      return sendPromise || Promise.resolve();
     }
 
-    hasArchived = true;
-    try {
-      const response = await sendToServer(captureData);
-      currentPageId = response.page_id;
-      console.log('[Wayback] Page ID:', currentPageId, 'Action:', response.action);
+    if (sendPromise) {
+      return sendPromise;
+    }
 
-      // Start DOM change monitor for newly created pages
-      if (response.action === 'created') {
-        startDOMChangeMonitor();
+    const pendingCapture = captureData;
+
+    sendPromise = (async () => {
+      try {
+        const response = await sendToServer(pendingCapture);
+        currentPageId = response.page_id;
+        hasArchived = true;
+        console.log('[Wayback] Page ID:', currentPageId, 'Action:', response.action);
+
+        // Even when POST returns unchanged, we still need to watch for later
+        // DOM mutations so dynamic content can upgrade the existing snapshot.
+        if (response.action === 'created' || response.action === 'unchanged') {
+          startDOMChangeMonitor();
+        }
+      } catch (error) {
+        console.error('[Wayback] Send failed:', error);
+      } finally {
+        sendPromise = null;
       }
-    } catch (error) {
-      console.error('[Wayback] Send failed:', error);
-    }
+    })();
+
+    return sendPromise;
   }
 
   function stopDOMChangeMonitor(): void {
@@ -298,6 +312,7 @@ function initializeArchiver(): void {
     captureData = null;
     isCapturing = false;
     hasArchived = false;
+    sendPromise = null;
     currentPageId = null;
     initialHTMLSize = 0;
     if (collectorObserver) {

--- a/browser/src/page-filter.ts
+++ b/browser/src/page-filter.ts
@@ -1,33 +1,113 @@
 // Page filtering logic - determines which pages should be skipped
 
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+}
+
+function isPrivateIPv4(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  const octets = parts.map((part) => Number(part));
+  if (octets.some((octet, index) => !/^\d+$/.test(parts[index]) || octet < 0 || octet > 255)) {
+    return false;
+  }
+
+  const [a, b] = octets;
+  return a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168);
+}
+
+function isPrivateIPv6(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+
+  if (normalized === '::1') {
+    return true;
+  }
+
+  if (normalized.startsWith('::ffff:')) {
+    const mapped = normalized.slice('::ffff:'.length);
+    if (mapped.includes('.')) {
+      return isPrivateIPv4(mapped);
+    }
+
+    const hextets = mapped.split(':');
+    if (hextets.length === 2) {
+      const high = Number.parseInt(hextets[0], 16);
+      const low = Number.parseInt(hextets[1], 16);
+      if (!Number.isNaN(high) && !Number.isNaN(low)) {
+        const mappedIPv4 = [
+          (high >> 8) & 0xff,
+          high & 0xff,
+          (low >> 8) & 0xff,
+          low & 0xff,
+        ].join('.');
+        return isPrivateIPv4(mappedIPv4);
+      }
+    }
+
+    return false;
+  }
+
+  // Only treat actual IPv6 literals as IPv6 addresses. Public hostnames like
+  // fd.example.com must not be mistaken for ULA ranges by prefix matching.
+  if (!normalized.includes(':')) {
+    return false;
+  }
+
+  const firstHextet = normalized.split(':').find((part) => part.length > 0);
+  if (!firstHextet) {
+    return false;
+  }
+
+  const value = Number.parseInt(firstHextet, 16);
+  if (Number.isNaN(value)) {
+    return false;
+  }
+
+  return (value >= 0xfc00 && value <= 0xfdff) ||
+    (value >= 0xfe80 && value <= 0xfebf);
+}
+
+export function shouldSkipURL(rawURL: string): boolean {
+  try {
+    const parsed = new URL(rawURL);
+    const hostname = normalizeHostname(parsed.hostname);
+
+    if (
+      parsed.protocol === 'file:' ||
+      parsed.protocol === 'about:' ||
+      parsed.protocol === 'chrome:' ||
+      parsed.protocol === 'chrome-extension:'
+    ) {
+      return true;
+    }
+
+    if (
+      hostname === 'localhost' ||
+      hostname.endsWith('.local') ||
+      isPrivateIPv4(hostname) ||
+      isPrivateIPv6(hostname)
+    ) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
 /**
  * Returns true if the current page should not be archived.
  * Skips local pages and browser internal pages.
  */
 export function shouldSkipPage(): boolean {
-  const url = window.location.href;
-  const hostname = window.location.hostname;
-
-  // Skip local pages
-  if (
-    hostname === 'localhost' ||
-    hostname === '127.0.0.1' ||
-    hostname.startsWith('192.168.') ||
-    hostname.startsWith('10.') ||
-    hostname.endsWith('.local') ||
-    url.startsWith('file://')
-  ) {
-    return true;
-  }
-
-  // Skip browser internal pages
-  if (
-    url.startsWith('chrome://') ||
-    url.startsWith('about:') ||
-    url.startsWith('chrome-extension://')
-  ) {
-    return true;
-  }
-
-  return false;
+  return shouldSkipURL(window.location.href);
 }

--- a/server/cmd/backfill/main.go
+++ b/server/cmd/backfill/main.go
@@ -23,6 +23,7 @@ func main() {
 		cfg.Database.User,
 		cfg.Database.Password,
 		cfg.Database.DBName,
+		cfg.Database.SSLMode,
 	)
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -66,6 +66,7 @@ func main() {
 		cfg.Database.User,
 		cfg.Database.Password,
 		cfg.Database.DBName,
+		cfg.Database.SSLMode,
 	)
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)

--- a/server/internal/api/archive_handler.go
+++ b/server/internal/api/archive_handler.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -9,18 +11,38 @@ import (
 	"wayback/internal/models"
 )
 
-// ArchivePage 处理页面归档请求
-func (h *Handler) ArchivePage(c *gin.Context) {
+const maxCaptureRequestBodyBytes int64 = 32 << 20
+
+func bindCaptureRequest(c *gin.Context) (*models.CaptureRequest, bool) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxCaptureRequestBodyBytes)
+
 	var req models.CaptureRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+				"error": fmt.Sprintf("request body exceeds %d MiB limit", maxCaptureRequestBodyBytes/(1024*1024)),
+			})
+			return nil, false
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return nil, false
+	}
+
+	return &req, true
+}
+
+// ArchivePage 处理页面归档请求
+func (h *Handler) ArchivePage(c *gin.Context) {
+	req, ok := bindCaptureRequest(c)
+	if !ok {
 		return
 	}
 
 	log.Printf("Received archive request: %s (frames: %d)", req.URL, len(req.Frames))
 
 	// 处理捕获
-	pageID, action, err := h.dedup.ProcessCapture(&req)
+	pageID, action, err := h.dedup.ProcessCapture(req)
 	if err != nil {
 		log.Printf("Failed to process capture: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -43,15 +65,14 @@ func (h *Handler) UpdatePage(c *gin.Context) {
 		return
 	}
 
-	var req models.CaptureRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req, ok := bindCaptureRequest(c)
+	if !ok {
 		return
 	}
 
 	log.Printf("Received update request for page %d: %s", pageID, req.URL)
 
-	action, err := h.dedup.UpdateCapture(pageID, &req)
+	action, err := h.dedup.UpdateCapture(pageID, req)
 	if err != nil {
 		log.Printf("Failed to update capture: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/server/internal/api/archive_handler_test.go
+++ b/server/internal/api/archive_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -243,5 +244,43 @@ func TestUpdatePage_NonExistentPage(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500 for non-existent page, got %d", w.Code)
+	}
+}
+
+func TestArchiveEndpoints_RequestBodyTooLarge(t *testing.T) {
+	router := setupRouter(&Handler{})
+	oversizedHTML := strings.Repeat("a", int(maxCaptureRequestBodyBytes)+1024)
+	body, err := json.Marshal(models.CaptureRequest{
+		URL:   "https://example.com/too-large",
+		Title: "Too Large",
+		HTML:  oversizedHTML,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "POST archive", method: http.MethodPost, path: "/api/archive"},
+		{name: "PUT archive update", method: http.MethodPut, path: "/api/archive/1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(tt.method, tt.path, bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "32 MiB") {
+				t.Fatalf("expected body limit message, got %s", w.Body.String())
+			}
+		})
 	}
 }

--- a/server/internal/api/compression_test.go
+++ b/server/internal/api/compression_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	gzipMiddleware "github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 	"wayback/internal/config"
+	"wayback/internal/models"
 )
 
 // setupRouterWithGzip creates a test router with gzip middleware
@@ -253,6 +255,37 @@ func TestGzipDecompression_RequestBody(t *testing.T) {
 	t.Logf("Original size: %d bytes, Compressed size: %d bytes (%.1f%% reduction)",
 		len(originalData), compressedBuf.Len(),
 		(1-float64(compressedBuf.Len())/float64(len(originalData)))*100)
+}
+
+func TestGzipDecompression_RequestBodyLimitAfterInflation(t *testing.T) {
+	r := setupRouterWithGzip()
+	payload, err := json.Marshal(models.CaptureRequest{
+		URL:   "https://example.com/oversized-gzip",
+		Title: "Oversized gzip",
+		HTML:  strings.Repeat("a", int(maxCaptureRequestBodyBytes)+1024),
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	if _, err := gzw.Write(payload); err != nil {
+		t.Fatalf("gzip write failed: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip close failed: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/archive", &compressed)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
 }
 
 func TestGzipDecompression_LargeRequestBody(t *testing.T) {

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -14,22 +15,13 @@ type DB struct {
 	conn *sql.DB
 }
 
-func New(host, port, user, password, dbname string) (*DB, error) {
-	// 构建连接字符串，确保 dbname 参数正确传递
-	connStr := fmt.Sprintf("host=%s port=%s dbname=%s sslmode=disable",
-		host, port, dbname)
-
-	// 只有在 user 不为空时才添加
-	if user != "" {
-		connStr = fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=disable",
-			host, port, user, dbname)
+func New(host, port, user, password, dbname string, sslmode ...string) (*DB, error) {
+	mode := "disable"
+	if len(sslmode) > 0 && sslmode[0] != "" {
+		mode = sslmode[0]
 	}
 
-	// 只有在 password 不为空时才添加
-	if password != "" {
-		connStr = fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-			host, port, user, password, dbname)
-	}
+	connStr := buildConnectionString(host, port, user, password, dbname, mode)
 
 	conn, err := sql.Open("postgres", connStr)
 	if err != nil {
@@ -51,6 +43,30 @@ func New(host, port, user, password, dbname string) (*DB, error) {
 	}
 
 	return db, nil
+}
+
+func buildConnectionString(host, port, user, password, dbname, sslmode string) string {
+	parts := []string{
+		fmt.Sprintf("host=%s", quoteConnValue(host)),
+		fmt.Sprintf("port=%s", quoteConnValue(port)),
+		fmt.Sprintf("dbname=%s", quoteConnValue(dbname)),
+		fmt.Sprintf("sslmode=%s", quoteConnValue(sslmode)),
+	}
+
+	if user != "" {
+		parts = append(parts, fmt.Sprintf("user=%s", quoteConnValue(user)))
+	}
+	if password != "" {
+		parts = append(parts, fmt.Sprintf("password=%s", quoteConnValue(password)))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func quoteConnValue(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return "'" + escaped + "'"
 }
 
 // ensureDomainColumn adds the domain column, index, and backfills existing rows if needed.

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -2,9 +2,30 @@ package database
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestBuildConnectionString_DefaultSSLMode(t *testing.T) {
+	connStr := buildConnectionString("localhost", "5432", "postgres", "", "wayback", "disable")
+
+	for _, want := range []string{"host='localhost'", "port='5432'", "dbname='wayback'", "user='postgres'", "sslmode='disable'"} {
+		if !strings.Contains(connStr, want) {
+			t.Fatalf("connection string %q missing %q", connStr, want)
+		}
+	}
+}
+
+func TestBuildConnectionString_CustomSSLMode(t *testing.T) {
+	connStr := buildConnectionString("db.internal", "5432", "app", "secret value", "wayback", "require")
+
+	for _, want := range []string{"host='db.internal'", "user='app'", "password='secret value'", "sslmode='require'"} {
+		if !strings.Contains(connStr, want) {
+			t.Fatalf("connection string %q missing %q", connStr, want)
+		}
+	}
+}
 
 // skipIfNoDB connects to the test database or skips the test.
 func skipIfNoDB(t *testing.T) *DB {

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -692,51 +692,81 @@
                 return;
             }
 
-            pageList.innerHTML = pages.map(page => {
+            pageList.innerHTML = '';
+            const fragment = document.createDocumentFragment();
+
+            pages.forEach(page => {
                 const firstVisited = formatDate(page.first_visited);
                 const lastVisited = formatDate(page.last_visited);
                 const isMultipleVisits = page.first_visited !== page.last_visited;
 
-                return `
-                    <li class="page-item" data-archive-id="${page.id}">
-                        <div class="page-header">
-                            <div class="page-title-group">
-                                <h2 class="page-title">${escapeHtml(page.title || 'Untitled')}</h2>
-                                <span class="page-id">#${page.id}</span>
-                            </div>
-                            <div class="page-actions">
-                                <button class="timeline-btn" onclick="openTimeline(event, '${escapeHtml(page.url)}')">Timeline</button>
-                                <button class="delete-btn" data-page-id="${page.id}" onclick="deletePage(event, ${page.id})">Delete</button>
-                            </div>
-                        </div>
-                        <a href="${escapeHtml(page.url)}" class="page-url" target="_blank" rel="noopener">${escapeHtml(page.url)}</a>
-                        <div class="page-meta">
-                            <span class="meta-item">
-                                <span class="meta-icon">⏱</span>
-                                ${firstVisited}
-                            </span>
-                            ${isMultipleVisits ? `
-                            <span class="meta-item">
-                                <span class="meta-icon">↻</span>
-                                ${lastVisited}
-                            </span>
-                            ` : ''}
-                        </div>
-                    </li>
-                `;
-            }).join('');
+                const item = document.createElement('li');
+                item.className = 'page-item';
+                item.setAttribute('data-archive-id', String(page.id));
 
-            // Add click handlers to page items
-            document.querySelectorAll('.page-item').forEach(item => {
+                const header = document.createElement('div');
+                header.className = 'page-header';
+
+                const titleGroup = document.createElement('div');
+                titleGroup.className = 'page-title-group';
+
+                const title = document.createElement('h2');
+                title.className = 'page-title';
+                title.textContent = page.title || 'Untitled';
+
+                const pageId = document.createElement('span');
+                pageId.className = 'page-id';
+                pageId.textContent = `#${page.id}`;
+
+                const actions = document.createElement('div');
+                actions.className = 'page-actions';
+
+                const timelineBtn = document.createElement('button');
+                timelineBtn.className = 'timeline-btn';
+                timelineBtn.type = 'button';
+                timelineBtn.textContent = 'Timeline';
+                timelineBtn.addEventListener('click', (event) => openTimeline(event, page.url));
+
+                const deleteBtn = document.createElement('button');
+                deleteBtn.className = 'delete-btn';
+                deleteBtn.type = 'button';
+                deleteBtn.setAttribute('data-page-id', String(page.id));
+                deleteBtn.textContent = 'Delete';
+                deleteBtn.addEventListener('click', (event) => deletePage(event, page.id));
+
+                const urlLink = createSafeExternalLink(page.url, 'page-url');
+
+                const meta = document.createElement('div');
+                meta.className = 'page-meta';
+                meta.appendChild(createMetaItem('⏱', firstVisited));
+                if (isMultipleVisits) {
+                    meta.appendChild(createMetaItem('↻', lastVisited));
+                }
+
+                titleGroup.appendChild(title);
+                titleGroup.appendChild(pageId);
+
+                actions.appendChild(timelineBtn);
+                actions.appendChild(deleteBtn);
+
+                header.appendChild(titleGroup);
+                header.appendChild(actions);
+
+                item.appendChild(header);
+                item.appendChild(urlLink);
+                item.appendChild(meta);
+
                 item.addEventListener('click', (e) => {
-                    // Don't navigate if clicking on the original URL link or delete button
                     if (e.target.closest('.page-url') || e.target.closest('.delete-btn') || e.target.closest('.timeline-btn')) {
                         return;
                     }
-                    const archiveId = item.getAttribute('data-archive-id');
-                    window.open(`/view/${archiveId}`, '_blank');
+                    window.open(`/view/${page.id}`, '_blank');
                 });
+
+                fragment.appendChild(item);
             });
+
+            pageList.appendChild(fragment);
         }
 
         function openTimeline(event, pageUrl) {
@@ -831,10 +861,47 @@
             }
         }
 
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+        function createMetaItem(icon, text) {
+            const item = document.createElement('span');
+            item.className = 'meta-item';
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'meta-icon';
+            iconSpan.textContent = icon;
+
+            item.appendChild(iconSpan);
+            item.appendChild(document.createTextNode(text));
+            return item;
+        }
+
+        function createSafeExternalLink(rawURL, className) {
+            const link = document.createElement('a');
+            link.className = className;
+            link.textContent = rawURL || '';
+
+            const safeURL = normalizeExternalURL(rawURL);
+            if (safeURL) {
+                link.href = safeURL;
+                link.target = '_blank';
+                link.rel = 'noopener';
+            } else {
+                link.href = '#';
+                link.addEventListener('click', (event) => event.preventDefault());
+            }
+
+            return link;
+        }
+
+        function normalizeExternalURL(rawURL) {
+            try {
+                const parsed = new URL(rawURL, window.location.href);
+                if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+                    return null;
+                }
+                return parsed.toString();
+            } catch {
+                return null;
+            }
         }
 
         loadPages(1);

--- a/server/web/logs.html
+++ b/server/web/logs.html
@@ -170,12 +170,30 @@
                     sidebar.innerHTML = '<div class="empty-state">No log files</div>';
                     return;
                 }
-                sidebar.innerHTML = data.files.map(f => `
-                    <div class="file-item${currentFile === f.name ? ' active' : ''}" onclick="selectFile('${f.name}')">
-                        <div class="file-name">${f.date}</div>
-                        <div class="file-meta">${formatSize(f.size)}</div>
-                    </div>
-                `).join('');
+                sidebar.innerHTML = '';
+                const fragment = document.createDocumentFragment();
+                data.files.forEach((f) => {
+                    const item = document.createElement('div');
+                    item.className = 'file-item';
+                    if (currentFile === f.name) {
+                        item.classList.add('active');
+                    }
+                    item.setAttribute('data-filename', f.name);
+                    item.addEventListener('click', () => selectFile(f.name));
+
+                    const name = document.createElement('div');
+                    name.className = 'file-name';
+                    name.textContent = f.date;
+
+                    const meta = document.createElement('div');
+                    meta.className = 'file-meta';
+                    meta.textContent = formatSize(f.size);
+
+                    item.appendChild(name);
+                    item.appendChild(meta);
+                    fragment.appendChild(item);
+                });
+                sidebar.appendChild(fragment);
                 // Auto-select first file if none selected
                 if (!currentFile && data.files.length > 0) {
                     selectFile(data.files[0].name);
@@ -189,7 +207,7 @@
             currentFile = filename;
             document.querySelectorAll('.file-item').forEach(el => el.classList.remove('active'));
             document.querySelectorAll('.file-item').forEach(el => {
-                if (el.querySelector('.file-name').textContent === filename.replace('wayback-','').replace('.log','')) {
+                if (el.getAttribute('data-filename') === filename) {
                     el.classList.add('active');
                 }
             });
@@ -200,7 +218,7 @@
         async function loadLogContent() {
             if (!currentFile) return;
             try {
-                const res = await fetch(`/api/logs/${currentFile}?tail=2000`);
+                const res = await fetch(`/api/logs/${encodeURIComponent(currentFile)}?tail=2000`);
                 const data = await res.json();
                 renderLog(data.content || '');
             } catch (e) {

--- a/server/web/timeline.html
+++ b/server/web/timeline.html
@@ -256,7 +256,9 @@
             document.getElementById('content').innerHTML = '<div class="empty">No URL specified. Use ?url=... to view timeline.</div>';
             document.getElementById('targetUrl').style.display = 'none';
         } else {
-            document.getElementById('targetUrl').innerHTML = `<a href="${escapeHtml(targetUrl)}" target="_blank" rel="noopener">${escapeHtml(targetUrl)}</a>`;
+            const targetUrlEl = document.getElementById('targetUrl');
+            targetUrlEl.innerHTML = '';
+            targetUrlEl.appendChild(createSafeExternalLink(targetUrl));
             document.title = `Timeline: ${targetUrl}`;
             loadTimeline(targetUrl);
         }
@@ -341,6 +343,35 @@
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        function createSafeExternalLink(rawURL) {
+            const link = document.createElement('a');
+            link.textContent = rawURL || '';
+
+            const safeURL = normalizeExternalURL(rawURL);
+            if (safeURL) {
+                link.href = safeURL;
+                link.target = '_blank';
+                link.rel = 'noopener';
+            } else {
+                link.href = '#';
+                link.addEventListener('click', (event) => event.preventDefault());
+            }
+
+            return link;
+        }
+
+        function normalizeExternalURL(rawURL) {
+            try {
+                const parsed = new URL(rawURL, window.location.href);
+                if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+                    return null;
+                }
+                return parsed.toString();
+            } catch {
+                return null;
+            }
         }
 
         fetch('/api/version').then(r => r.json()).then(d => {

--- a/skill.md
+++ b/skill.md
@@ -186,6 +186,9 @@ data/
 - **Dynamic content support**: Captures live DOM state, auto-updates on significant mutations
 - **SPA-aware**: Detects SPA navigation, resets capture state per route
 - **Anti-refresh protection**: Archived pages frozen (timers, WebSockets, navigation APIs neutralized)
+- **Iframe bridge hardening**: Same-origin parents only; cross-origin iframes are not DOM-exported back to the parent page
+- **Capture body guardrail**: `/api/archive` and `/api/archive/:id` reject decompressed JSON bodies above 32 MiB
+- **Private page filter**: Browser side skips loopback, RFC1918, link-local, ULA/loopback IPv6, and `.local` pages
 
 ## Testing
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,4 +6,4 @@
 - `server/` - Server-side tests and utilities
 
 ## Running Tests
-Refer to [../docs/TESTING_GUIDE.md](../docs/TESTING_GUIDE.md) for testing procedures.
+Refer to [../docs/BUILD.md](../docs/BUILD.md) for build and test procedures.

--- a/tests/browser/test-puppeteer-script.js
+++ b/tests/browser/test-puppeteer-script.js
@@ -20,7 +20,7 @@ async function testPuppeteerScript() {
   await page.goto('https://www.baidu.com', { waitUntil: 'networkidle0' });
 
   // Load the script after navigation
-  const scriptPath = path.join(__dirname, '../browser/dist/wayback-puppeteer.js');
+  const scriptPath = path.join(__dirname, '../../browser/dist/wayback-puppeteer.js');
   console.log('Loading script:', scriptPath);
   await page.addScriptTag({ path: scriptPath });
 

--- a/tests/root/test-browser-script.js
+++ b/tests/root/test-browser-script.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 // 读取编译后的脚本
-const scriptPath = path.join(__dirname, 'browser/dist/wayback-userscript.js');
+const scriptPath = path.join(__dirname, '../../browser/dist/wayback-userscript.js');
 const userScript = fs.readFileSync(scriptPath, 'utf8');
 
 // 提取脚本内容（去掉 UserScript 头部）

--- a/tests/server/test_deletion_queue.js
+++ b/tests/server/test_deletion_queue.js
@@ -13,7 +13,8 @@ const fs = require('fs');
 const path = require('path');
 
 const SERVER_URL = 'http://localhost:8080';
-const DATA_DIR = path.join(__dirname, '../../server/data');
+const TEST_URL = 'https://example.com/test-deletion-queue';
+const DATA_DIR = path.join(__dirname, '../../data');
 const DELETION_QUEUE_FILE = path.join(DATA_DIR, 'deletion_queue.jsonl');
 
 async function sleep(ms) {
@@ -40,7 +41,7 @@ async function updatePage(pageId, html) {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      url: `https://example.com/test-${pageId}`,
+      url: TEST_URL,
       html,
       title: 'Updated Test Page'
     })
@@ -70,7 +71,7 @@ async function main() {
   // 1. 创建初始页面
   console.log('1. 创建初始页面...');
   const pageId = await createPage(
-    'https://example.com/test-deletion-queue',
+    TEST_URL,
     '<html><body><h1>Version 1</h1></body></html>'
   );
   console.log(`   ✓ 页面创建成功 (ID: ${pageId})\n`);
@@ -79,6 +80,7 @@ async function main() {
 
   // 2. 更新页面（第一次）
   console.log('2. 更新页面（第一次）...');
+  const initialQueueLength = readDeletionQueue().length;
   await updatePage(pageId, '<html><body><h1>Version 2</h1></body></html>');
   console.log('   ✓ 页面更新成功\n');
 
@@ -89,30 +91,34 @@ async function main() {
   let queue = readDeletionQueue();
   console.log(`   ✓ 删除队列中有 ${queue.length} 条记录`);
 
-  if (queue.length > 0) {
-    const lastRecord = queue[queue.length - 1];
-    console.log(`   ✓ 最新记录: ${JSON.stringify(lastRecord, null, 2)}`);
+  if (queue.length !== initialQueueLength + 1) {
+    console.error(`   ✗ 删除队列长度异常: 期望 ${initialQueueLength + 1}，实际 ${queue.length}`);
+    process.exit(1);
+  }
 
-    // 验证记录格式
-    if (!lastRecord.html_path || !lastRecord.timestamp || !lastRecord.page_id) {
-      console.error('   ✗ 删除队列记录格式不正确');
-      process.exit(1);
-    }
+  const lastRecord = queue[queue.length - 1];
+  console.log(`   ✓ 最新记录: ${JSON.stringify(lastRecord, null, 2)}`);
 
-    // 验证旧 HTML 文件仍然存在
-    const oldHTMLPath = path.join(DATA_DIR, lastRecord.html_path);
-    if (fs.existsSync(oldHTMLPath)) {
-      console.log(`   ✓ 旧 HTML 文件仍然存在: ${lastRecord.html_path}`);
-    } else {
-      console.error(`   ✗ 旧 HTML 文件不存在: ${lastRecord.html_path}`);
-      process.exit(1);
-    }
+  // 验证记录格式
+  if (!lastRecord.html_path || !lastRecord.timestamp || !lastRecord.page_id) {
+    console.error('   ✗ 删除队列记录格式不正确');
+    process.exit(1);
+  }
+
+  // 验证旧 HTML 文件仍然存在
+  const oldHTMLPath = path.join(DATA_DIR, lastRecord.html_path);
+  if (fs.existsSync(oldHTMLPath)) {
+    console.log(`   ✓ 旧 HTML 文件仍然存在: ${lastRecord.html_path}`);
+  } else {
+    console.error(`   ✗ 旧 HTML 文件不存在: ${lastRecord.html_path}`);
+    process.exit(1);
   }
 
   console.log('\n');
 
   // 4. 再次更新页面（第二次）
   console.log('4. 更新页面（第二次）...');
+  const queueLengthBeforeSecondUpdate = queue.length;
   await updatePage(pageId, '<html><body><h1>Version 3</h1></body></html>');
   console.log('   ✓ 页面更新成功\n');
 
@@ -123,9 +129,14 @@ async function main() {
   queue = readDeletionQueue();
   console.log(`   ✓ 删除队列中现在有 ${queue.length} 条记录`);
 
-  if (queue.length >= 2) {
-    console.log('   ✓ 两次更新都被记录到删除队列');
+  if (queue.length !== queueLengthBeforeSecondUpdate + 1) {
+    console.error(`   ✗ 第二次更新后删除队列长度异常: 期望 ${queueLengthBeforeSecondUpdate + 1}，实际 ${queue.length}`);
+    process.exit(1);
   }
+
+  console.log('   ✓ 两次更新都被记录到删除队列');
+
+  await fetch(`${SERVER_URL}/api/pages/${pageId}`, { method: 'DELETE' });
 
   console.log('\n=== 所有测试通过 ===');
   console.log('\n提示：');

--- a/tests/server/test_frame_bridge_origin.js
+++ b/tests/server/test_frame_bridge_origin.js
@@ -1,0 +1,84 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+async function main() {
+  const bundlePath = path.join(__dirname, '../../browser/dist/wayback-puppeteer.js');
+  const bundle = fs.readFileSync(bundlePath, 'utf8');
+
+  const parentServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><body><h1>Parent</h1><iframe id="victim-frame" src="http://lvh.me:8092/child"></iframe></body></html>`);
+  });
+
+  const childServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><head><title>Victim Child</title></head><body><div id="secret">cross-origin child content</div></body></html>`);
+  });
+
+  await new Promise((resolve) => parentServer.listen(8091, '127.0.0.1', resolve));
+  await new Promise((resolve) => childServer.listen(8092, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.evaluateOnNewDocument(bundle);
+    await page.goto('http://lvh.me:8091/', { waitUntil: 'networkidle2', timeout: 120000 });
+
+    const result = await page.evaluate(() => new Promise((resolve) => {
+      const frame = document.getElementById('victim-frame');
+      if (!frame || !frame.contentWindow) {
+        throw new Error('victim iframe not ready');
+      }
+
+      const timer = window.setTimeout(() => {
+        window.removeEventListener('message', onMessage);
+        resolve({ leaked: false });
+      }, 3000);
+
+      function onMessage(event) {
+        if (event.data && event.data.source === 'wayback-frame-capture' && event.data.type === 'frame-result') {
+          window.clearTimeout(timer);
+          window.removeEventListener('message', onMessage);
+          resolve({
+            leaked: true,
+            title: event.data.title,
+            html: event.data.html,
+          });
+        }
+      }
+
+      window.addEventListener('message', onMessage);
+      frame.contentWindow.postMessage({
+        source: 'wayback-frame-capture',
+        type: 'capture-frame',
+        requestId: 'attacker-request',
+      }, '*');
+    }));
+
+    await page.close();
+
+    if (result.leaked) {
+      throw new Error(`cross-origin frame bridge leaked content: ${result.title}`);
+    }
+
+    console.log('PASS test_frame_bridge_origin');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => parentServer.close(resolve));
+    await new Promise((resolve) => childServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_page_filter.js
+++ b/tests/server/test_page_filter.js
@@ -1,0 +1,49 @@
+async function main() {
+  const { shouldSkipURL } = await import('../../browser/dist/page-filter.js');
+
+  const cases = [
+    ['localhost', 'http://localhost:8080/', true],
+    ['loopback ipv4', 'http://127.0.0.1/', true],
+    ['private 10/8', 'http://10.1.2.3/', true],
+    ['private 172.16/12', 'http://172.16.5.4/', true],
+    ['private 192.168/16', 'http://192.168.1.9/', true],
+    ['link-local ipv4', 'http://169.254.10.20/', true],
+    ['loopback ipv6', 'http://[::1]/', true],
+    ['unique-local ipv6', 'http://[fd00::1234]/', true],
+    ['link-local ipv6', 'http://[fe80::abcd]/', true],
+    ['link-local ipv6 fe90', 'http://[fe90::1]/', true],
+    ['link-local ipv6 fea0', 'http://[fea0::1]/', true],
+    ['link-local ipv6 febf', 'http://[febf::1]/', true],
+    ['ipv4-mapped local ipv6', 'http://[::ffff:192.168.1.9]/', true],
+    ['.local hostname', 'http://printer.local/', true],
+    ['public domain starting fd', 'https://fd.example.com/', false],
+    ['public domain starting fc', 'https://fc.example.com/', false],
+    ['file url', 'file:///tmp/test.html', true],
+    ['browser internal', 'chrome://extensions/', true],
+    ['public ipv4 boundary allowed', 'http://172.15.255.255/', false],
+    ['public ipv6 allowed', 'http://[2606:4700:4700::1111]/', false],
+    ['public domain allowed', 'https://example.com/', false],
+  ];
+
+  let failed = 0;
+  for (const [name, url, expected] of cases) {
+    const actual = shouldSkipURL(url);
+    if (actual !== expected) {
+      failed++;
+      console.error(`FAIL ${name}: shouldSkipURL(${url}) = ${actual}, want ${expected}`);
+    } else {
+      console.log(`PASS ${name}`);
+    }
+  }
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+
+  console.log('PASS test_page_filter');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_userscript_state.js
+++ b/tests/server/test_userscript_state.js
@@ -1,0 +1,152 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+async function preparePage(browser, scriptContent, mode, url) {
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const text = msg.text();
+    if (text.includes('[Wayback]')) {
+      console.log('[browser]', text);
+    }
+  });
+
+  await page.evaluateOnNewDocument((testMode) => {
+    window.__waybackTestMode = testMode;
+    window.__gmCalls = [];
+    window.__gmEvents = [];
+
+    window.GM_cookie = {
+      list(_options, callback) {
+        callback([]);
+      },
+    };
+
+    window.GM_xmlhttpRequest = (options) => {
+      window.__gmCalls.push({
+        method: options.method,
+        url: options.url,
+        data: typeof options.data === 'string' ? options.data : '',
+      });
+
+      const reply = (handler, payload) => {
+        if (typeof handler === 'function') {
+          window.setTimeout(() => handler(payload), 0);
+        }
+      };
+
+      const jsonResponse = (pageId, action) => ({
+        status: 200,
+        responseText: JSON.stringify({ status: 'success', page_id: pageId, action }),
+      });
+
+      if (testMode === 'retry') {
+        if (options.method === 'POST') {
+          const attempts = window.__gmCalls.filter((call) => call.method === 'POST').length;
+          if (attempts === 1) {
+            window.__gmEvents.push('post-error');
+            reply(options.onerror, { message: 'simulated failure' });
+            return;
+          }
+
+          window.__gmEvents.push('post-success');
+          reply(options.onload, jsonResponse(101, 'created'));
+          return;
+        }
+
+        window.__gmEvents.push(`unexpected-${options.method}`);
+        reply(options.onerror, { message: `unexpected method ${options.method}` });
+        return;
+      }
+
+      if (testMode === 'unchanged-monitor') {
+        if (options.method === 'POST') {
+          window.__gmEvents.push('post-success');
+          reply(options.onload, jsonResponse(202, 'unchanged'));
+          return;
+        }
+        if (options.method === 'PUT') {
+          window.__gmEvents.push('put-success');
+          reply(options.onload, jsonResponse(202, 'updated'));
+          return;
+        }
+
+        window.__gmEvents.push(`unexpected-${options.method}`);
+        reply(options.onerror, { message: `unexpected method ${options.method}` });
+      }
+    };
+  }, mode);
+
+  await page.goto(url, { waitUntil: 'networkidle2', timeout: 120000 });
+  await page.addScriptTag({ content: scriptContent });
+  return page;
+}
+
+async function main() {
+  const scriptPath = path.join(__dirname, '../../browser/dist/wayback-userscript.js');
+  const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+
+  const fixtureServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><head><title>Wayback Userscript State</title></head><body><div id="mutations"></div><script>setTimeout(() => { const marker = document.createElement('div'); marker.id = 'late-mutation'; marker.textContent = 'late mutation'; document.body.appendChild(marker); }, 4000);</script></body></html>`);
+  });
+
+  await new Promise((resolve) => fixtureServer.listen(8093, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const retryPage = await preparePage(browser, scriptContent, 'retry', 'http://lvh.me:8093/retry');
+    await retryPage.waitForFunction(() => window.__gmEvents.includes('post-error'), { timeout: 15000 });
+    await retryPage.evaluate(() => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+    await retryPage.waitForFunction(() => {
+      return window.__gmCalls.filter((call) => call.method === 'POST').length >= 2;
+    }, { timeout: 15000 });
+
+    const retryAttempts = await retryPage.evaluate(() => window.__gmCalls.filter((call) => call.method === 'POST').length);
+    if (retryAttempts < 2) {
+      throw new Error(`expected retry after failed send, got ${retryAttempts} POST attempts`);
+    }
+    await retryPage.close();
+
+    const monitorPage = await preparePage(browser, scriptContent, 'unchanged-monitor', 'http://lvh.me:8093/unchanged');
+    await monitorPage.waitForFunction(() => window.__gmEvents.includes('post-success'), { timeout: 15000 });
+    await monitorPage.evaluate(async () => {
+      const root = document.getElementById('mutations');
+      for (let i = 0; i < 12; i++) {
+        const node = document.createElement('div');
+        node.textContent = `mutation-${i}`;
+        root.appendChild(node);
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+      }
+    });
+    await monitorPage.waitForFunction(() => {
+      return window.__gmCalls.some((call) => call.method === 'PUT');
+    }, { timeout: 15000 });
+
+    const putAttempts = await monitorPage.evaluate(() => window.__gmCalls.filter((call) => call.method === 'PUT').length);
+    if (putAttempts < 1) {
+      throw new Error(`expected DOM monitor update after unchanged POST, got ${putAttempts} PUT attempts`);
+    }
+    await monitorPage.close();
+
+    console.log('PASS test_userscript_state');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => fixtureServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_web_ui_xss.js
+++ b/tests/server/test_web_ui_xss.js
@@ -1,0 +1,119 @@
+const puppeteer = require('puppeteer');
+
+const SERVER = 'http://localhost:8080';
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+async function createArchive(payload) {
+  const response = await fetch(`${SERVER}/api/archive`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`archive create failed: ${response.status} ${await response.text()}`);
+  }
+
+  return response.json();
+}
+
+async function deletePage(pageId) {
+  await fetch(`${SERVER}/api/pages/${pageId}`, { method: 'DELETE' });
+}
+
+async function main() {
+  const runId = Date.now();
+  const title = `Stored XSS POC ${runId}`;
+  let pageId = null;
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const createResponse = await createArchive({
+      url: "');window.__waybackStoredPoc=1;//",
+      title,
+      html: '<!doctype html><html><body>stored xss poc</body></html>',
+    });
+    pageId = createResponse.page_id;
+
+    const home = await browser.newPage();
+    await home.goto(`${SERVER}/`, { waitUntil: 'networkidle2', timeout: 120000 });
+    await home.evaluate(() => {
+      window.__waybackStoredPoc = 0;
+      window.__lastOpenedURL = null;
+      window.open = (url) => {
+        window.__lastOpenedURL = url;
+        return null;
+      };
+    });
+
+    await home.click('#searchInput', { clickCount: 3 });
+    await home.type('#searchInput', title);
+    await home.waitForFunction((expectedTitle) => {
+      return [...document.querySelectorAll('.page-item .page-title')].some((el) => el.textContent === expectedTitle);
+    }, { timeout: 10000 }, title);
+
+    await home.evaluate((expectedTitle) => {
+      const item = [...document.querySelectorAll('.page-item')].find((el) => el.querySelector('.page-title')?.textContent === expectedTitle);
+      if (!item) {
+        throw new Error('matching page item not found');
+      }
+
+      const button = item.querySelector('.timeline-btn');
+      if (!button) {
+        throw new Error('timeline button not found');
+      }
+
+      button.click();
+    }, title);
+
+    const storedResult = await home.evaluate(() => ({
+      poc: window.__waybackStoredPoc || 0,
+      openedURL: window.__lastOpenedURL || '',
+    }));
+
+    if (storedResult.poc !== 0) {
+      throw new Error(`stored XSS executed on home page: ${storedResult.poc}`);
+    }
+    if (!storedResult.openedURL.startsWith('/timeline?url=')) {
+      throw new Error(`timeline button did not open a timeline URL: ${storedResult.openedURL}`);
+    }
+
+    const reflected = 'foo" onclick="window.__waybackReflectedPoc=1';
+    const timeline = await browser.newPage();
+    await timeline.goto(`${SERVER}/timeline?url=${encodeURIComponent(reflected)}`, { waitUntil: 'networkidle2', timeout: 120000 });
+    await timeline.evaluate(() => {
+      window.__waybackReflectedPoc = 0;
+      const link = document.querySelector('#targetUrl a');
+      if (!link) {
+        throw new Error('target link not found');
+      }
+      link.removeAttribute('target');
+      link.addEventListener('click', (event) => event.preventDefault());
+    });
+    await timeline.click('#targetUrl a');
+
+    const reflectedResult = await timeline.evaluate(() => window.__waybackReflectedPoc || 0);
+    if (reflectedResult !== 0) {
+      throw new Error(`reflected XSS executed on timeline page: ${reflectedResult}`);
+    }
+
+    await timeline.close();
+    await home.close();
+    console.log('PASS test_web_ui_xss');
+  } finally {
+    if (pageId !== null) {
+      await deletePage(pageId);
+    }
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- harden archive capture by restricting iframe bridge messaging to same-origin parents, enforcing a 32 MiB archive body limit, wiring `DB_SSLMODE` into real database connections, and fixing private-page filtering edge cases
- close web UI injection gaps in the embedded pages by replacing unsafe HTML and attribute interpolation with safe DOM construction and URL normalization
- restore browser-side retry and update behavior for failed or unchanged captures, fix stale test paths and assertions, and add regression coverage for XSS, iframe bridge leakage, userscript state transitions, and page filtering

## Testing
- npm run build
- go test ./...
- go test -race ./...
- go vet ./...
- node tests/server/test_page_filter.js
- node tests/browser/test-dedup.js
- node tests/browser/test-cssom-serialize.js
- node tests/browser/test-archive.js
- make test-e2e