### PR TITLE
fix: harden archive browser and API edge cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ data/
 server/wayback-server
 server/server
 bin/
+browser/dist-test/

--- a/browser/build.js
+++ b/browser/build.js
@@ -33,6 +33,7 @@ const userscriptModules = [
   'dom-collector.js',
   'html-url-normalizer.js',
   'bridge-auth.js',
+  'spa-coordinator.js',
   'frame-capture.js',
   'archiver.js',
   'main.js',
@@ -63,6 +64,7 @@ const header = `// ==UserScript==
 // @grant        GM_cookie
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_addValueChangeListener
 // @connect      localhost
 // @connect      *
 // @require      https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js

--- a/browser/package.json
+++ b/browser/package.json
@@ -5,6 +5,7 @@
   "main": "dist/wayback-userscript.js",
   "scripts": {
     "build": "tsc && node build.js",
+    "test": "tsc -p tsconfig.test.json && node --test tests/**/*.test.js",
     "watch": "tsc --watch"
   },
   "devDependencies": {

--- a/browser/src/bridge-auth.ts
+++ b/browser/src/bridge-auth.ts
@@ -1,10 +1,12 @@
 const BRIDGE_SECRET_STORAGE_KEY = 'wayback-bridge-secret-v1';
 const BRIDGE_REQUEST_MAX_AGE_MS = 15000;
+const BRIDGE_SECRET_SETTLE_MS = 75;
 const FALLBACK_BRIDGE_SECRET = 'wayback-puppeteer-bridge-secret-v1';
 
 let cachedBridgeSecret: Promise<string> | null = null;
 let cachedBridgeKey: Promise<CryptoKey> | null = null;
 let cachedBridgeKeySecret = '';
+let bridgeSecretListenerRegistered = false;
 
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
@@ -55,6 +57,31 @@ function buildBridgePayload(
   ].join('\n');
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function syncCachedBridgeSecret(secret: string): void {
+  cachedBridgeSecret = Promise.resolve(secret);
+  if (cachedBridgeKeySecret !== secret) {
+    cachedBridgeKey = null;
+    cachedBridgeKeySecret = '';
+  }
+}
+
+function registerBridgeSecretListener(): void {
+  if (bridgeSecretListenerRegistered || typeof GM_addValueChangeListener !== 'function') {
+    return;
+  }
+
+  GM_addValueChangeListener(BRIDGE_SECRET_STORAGE_KEY, (_name, _oldValue, newValue) => {
+    if (typeof newValue === 'string' && newValue) {
+      syncCachedBridgeSecret(newValue);
+    }
+  });
+  bridgeSecretListenerRegistered = true;
+}
+
 async function getBridgeSecret(): Promise<string> {
   if (cachedBridgeSecret) {
     return cachedBridgeSecret;
@@ -62,6 +89,8 @@ async function getBridgeSecret(): Promise<string> {
 
   cachedBridgeSecret = (async () => {
     if (typeof GM_getValue === 'function' && typeof GM_setValue === 'function') {
+      registerBridgeSecretListener();
+
       const existing = GM_getValue(BRIDGE_SECRET_STORAGE_KEY, '');
       if (typeof existing === 'string' && existing) {
         return existing;
@@ -69,11 +98,28 @@ async function getBridgeSecret(): Promise<string> {
 
       const generated = generateBridgeSecret();
       GM_setValue(BRIDGE_SECRET_STORAGE_KEY, generated);
+
+      // Multiple tabs can race on first-time initialization. Re-read after a
+      // short settle window so every page converges on the stored value.
+      await sleep(BRIDGE_SECRET_SETTLE_MS);
+      const settled = GM_getValue(BRIDGE_SECRET_STORAGE_KEY, '');
+      if (typeof settled === 'string' && settled) {
+        return settled;
+      }
+
       return generated;
     }
 
     return FALLBACK_BRIDGE_SECRET;
-  })();
+  })()
+    .then((secret) => {
+      syncCachedBridgeSecret(secret);
+      return secret;
+    })
+    .catch((error) => {
+      cachedBridgeSecret = null;
+      throw error;
+    });
 
   return cachedBridgeSecret;
 }

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -9,6 +9,7 @@
 // @grant        GM_cookie
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_addValueChangeListener
 // @connect      localhost
 // @run-at       document-idle
 // ==/UserScript==
@@ -20,6 +21,7 @@ import { waitForDOMStable } from './page-freezer';
 import { sendToServer, updateOnServer } from './archiver';
 import { DOMCollector } from './dom-collector';
 import { captureDocumentHTMLWithFrames, setupFrameCaptureBridge } from './frame-capture';
+import { chooseFlushAction, choosePendingFlushDependency, shouldCommitMonitorUpdate } from './spa-coordinator';
 
 // Early exit check before any initialization
 if (shouldSkipPage()) {
@@ -43,6 +45,7 @@ function initializeArchiver(): void {
   let isCapturing = false;
   let hasArchived = false;
   let sendPromise: Promise<void> | null = null;
+  let updatePromise: Promise<void> | null = null;
   let currentPageId: number | null = null;
   let initialHTMLSize = 0; // Track initial capture size for update quality guard
 
@@ -57,12 +60,44 @@ function initializeArchiver(): void {
   // Track pending SPA transition timers so we can cancel them on rapid re-navigation
   let spaCollectorTimerId: number | null = null;
   let spaCaptureTimerId: number | null = null;
+  // Incremented on SPA resets so stale async work can self-cancel.
+  let pageEpoch = 0;
+
+  async function captureSnapshot(headers?: Record<string, string>, expectedEpoch = pageEpoch): Promise<CaptureData | null> {
+    const captured = await captureDocumentHTMLWithFrames();
+    if (expectedEpoch !== pageEpoch) {
+      return null;
+    }
+
+    let html = captured.html;
+    if (domCollector.collectedCount > 0) {
+      console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes into snapshot...`);
+      html = domCollector.mergeInto(html);
+    }
+
+    return {
+      url: window.location.href,
+      title: document.title,
+      html,
+      frames: captured.frames,
+      headers,
+    };
+  }
+
+  function shouldAcceptUpdatedHTML(newHTML: string): boolean {
+    if (initialHTMLSize > 0 && newHTML.length < initialHTMLSize * 0.7) {
+      console.log(`[Wayback] Skipping update: HTML shrunk too much (${newHTML.length} vs initial ${initialHTMLSize}, ${Math.round(newHTML.length / initialHTMLSize * 100)}%)`);
+      return false;
+    }
+    return true;
+  }
 
   async function prepareCapture(): Promise<void> {
     if (isCapturing || hasArchived) {
       return;
     }
 
+    const expectedEpoch = pageEpoch;
     isCapturing = true;
     console.log('[Wayback] Preparing capture for:', window.location.href);
 
@@ -70,6 +105,9 @@ function initializeArchiver(): void {
       // Wait for DOM to stabilize
       console.log('[Wayback] Waiting for DOM to stabilize...');
       await waitForDOMStable(CONFIG.MUTATION_OBSERVER_TIMEOUT, CONFIG.DOM_STABLE_TIME);
+      if (expectedEpoch !== pageEpoch) {
+        return;
+      }
 
       // Collect cookies (including HttpOnly) via GM_cookie
       let headers: Record<string, string> | undefined;
@@ -91,25 +129,13 @@ function initializeArchiver(): void {
         }
       }
 
-      // 在克隆 DOM 上内联布局样式，并把 iframe 当前内容嵌入快照
-      const captured = await captureDocumentHTMLWithFrames();
-      let html = captured.html;
-
-      // Merge any nodes removed by virtual scrolling before/during capture
-      if (domCollector.collectedCount > 0) {
-        console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes into initial capture...`);
-        html = domCollector.mergeInto(html);
+      const preparedCapture = await captureSnapshot(headers, expectedEpoch);
+      if (!preparedCapture) {
+        return;
       }
 
-      captureData = {
-        url: window.location.href,
-        title: document.title,
-        html,
-        frames: captured.frames,
-        headers,
-      };
-
-      initialHTMLSize = html.length;
+      captureData = preparedCapture;
+      initialHTMLSize = preparedCapture.html.length;
       console.log('[Wayback] ✓ Data prepared, size:', JSON.stringify(captureData).length, 'bytes');
     } catch (error) {
       console.error('[Wayback] Failed to prepare:', error);
@@ -149,6 +175,53 @@ function initializeArchiver(): void {
     })();
 
     return sendPromise;
+  }
+
+  function flushCurrentPage(): Promise<void> {
+    const action = chooseFlushAction({
+      capturePrepared: captureData !== null,
+      hasArchived,
+      sendInFlight: sendPromise !== null,
+      updateInFlight: updatePromise !== null,
+      documentHidden: document.visibilityState === 'hidden',
+      currentPageId,
+    });
+
+    if (action === 'send-capture') {
+      return sendCapture();
+    }
+
+    if (action !== 'update-current-page' || currentPageId === null) {
+      const pendingDependency = choosePendingFlushDependency({
+        sendInFlight: sendPromise !== null,
+        updateInFlight: updatePromise !== null,
+      });
+      if (pendingDependency === 'send') {
+        return sendPromise || Promise.resolve();
+      }
+      return Promise.resolve();
+    }
+
+    const flushPageID = currentPageId;
+    const flushEpoch = pageEpoch;
+    updatePromise = (async () => {
+      try {
+        const newCaptureData = await captureSnapshot(captureData?.headers, flushEpoch);
+        if (!newCaptureData || !shouldAcceptUpdatedHTML(newCaptureData.html)) {
+          return;
+        }
+        if (!shouldCommitMonitorUpdate(flushEpoch, pageEpoch, flushPageID, currentPageId)) {
+          return;
+        }
+        await updateOnServer(flushPageID, newCaptureData);
+      } catch (error) {
+        console.error('[Wayback] Flush failed:', error);
+      } finally {
+        updatePromise = null;
+      }
+    })();
+
+    return updatePromise;
   }
 
   function stopDOMChangeMonitor(): void {
@@ -205,7 +278,7 @@ function initializeArchiver(): void {
 
     // Periodic check: every UPDATE_CHECK_INTERVAL, upload if DOM has changed
     const intervalId = nativeSetInterval(() => {
-      if (isUpdating) return;
+      if (isUpdating || updatePromise) return;
 
       // Guard: page ID changed (SPA navigation) — stop
       if (!monitorPageId || monitorPageId !== currentPageId) {
@@ -242,36 +315,30 @@ function initializeArchiver(): void {
       mutationCount = 0;
       isUpdating = true;
       const isFinal = domCollector.reachedLimit;
+      const monitorEpoch = pageEpoch;
 
       (async () => {
         try {
           console.log(`[Wayback] DOM changed (${currentMutations} mutations), triggering update...`);
 
-          // 在克隆 DOM 上内联布局样式，并把 iframe 当前内容嵌入快照
-          const captured = await captureDocumentHTMLWithFrames();
-          let newHTML = captured.html;
-
-          // Merge any nodes that were removed by virtual scrolling back into the snapshot
-          if (domCollector.collectedCount > 0) {
-            console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes...`);
-            newHTML = domCollector.mergeInto(newHTML);
-          }
-
-          // Guard: reject update if HTML shrunk significantly (< 70% of initial capture)
-          if (initialHTMLSize > 0 && newHTML.length < initialHTMLSize * 0.7) {
-            console.log(`[Wayback] Skipping update: HTML shrunk too much (${newHTML.length} vs initial ${initialHTMLSize}, ${Math.round(newHTML.length / initialHTMLSize * 100)}%)`);
+          const newCaptureData = await captureSnapshot(captureData?.headers, monitorEpoch);
+          if (!newCaptureData || !shouldAcceptUpdatedHTML(newCaptureData.html)) {
             return;
           }
 
-          const newCaptureData: CaptureData = {
-            url: window.location.href,
-            title: document.title,
-            html: newHTML,
-            frames: captured.frames,
-            headers: captureData?.headers,
-          };
+          if (!shouldCommitMonitorUpdate(monitorEpoch, pageEpoch, monitorPageId, currentPageId)) {
+            return;
+          }
 
-          await updateOnServer(monitorPageId, newCaptureData);
+          updatePromise = (async () => {
+            try {
+              await updateOnServer(monitorPageId, newCaptureData);
+            } finally {
+              updatePromise = null;
+            }
+          })();
+
+          await updatePromise;
         } catch (error) {
           console.error('[Wayback] Update failed:', error);
         } finally {
@@ -311,10 +378,12 @@ function initializeArchiver(): void {
 
   function resetState(): void {
     stopDOMChangeMonitor();
+    pageEpoch += 1;
     captureData = null;
     isCapturing = false;
     hasArchived = false;
     sendPromise = null;
+    updatePromise = null;
     currentPageId = null;
     initialHTMLSize = 0;
     if (collectorObserver) {
@@ -349,12 +418,12 @@ function initializeArchiver(): void {
   // Send on page unload events
   window.addEventListener('beforeunload', () => {
     console.log('[Wayback] beforeunload');
-    sendCapture();
+    void flushCurrentPage();
   });
 
   window.addEventListener('pagehide', () => {
     console.log('[Wayback] pagehide');
-    sendCapture();
+    void flushCurrentPage();
   });
 
   // Handle SPA navigation — send current capture, then re-capture the new page
@@ -367,7 +436,7 @@ function initializeArchiver(): void {
         }
         console.log('[Wayback] SPA navigate detected:', e.navigationType);
         // 等待 sendCapture 完成后再重置状态，防止竞态条件
-        sendCapture().then(() => {
+        flushCurrentPage().then(() => {
           resetState();
           // Start collector early (after SPA transition completes) to catch virtual scroll removals
           spaCollectorTimerId = nativeSetTimeout(() => {
@@ -397,7 +466,7 @@ function initializeArchiver(): void {
     console.log('[Wayback] URL changed:', lastURL, '->', newURL);
     lastURL = newURL;
     // 等待 sendCapture 完成后再重置状态，防止竞态条件
-    sendCapture().then(() => {
+    flushCurrentPage().then(() => {
       resetState();
       // Start collector early (after SPA transition completes) to catch virtual scroll removals
       spaCollectorTimerId = nativeSetTimeout(() => {
@@ -431,7 +500,7 @@ function initializeArchiver(): void {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
       console.log('[Wayback] hidden');
-      sendCapture();
+      void flushCurrentPage();
     }
   });
 }

--- a/browser/src/spa-coordinator.ts
+++ b/browser/src/spa-coordinator.ts
@@ -1,0 +1,39 @@
+export type FlushAction = 'none' | 'send-capture' | 'update-current-page';
+export type PendingFlushDependency = 'none' | 'send';
+
+export interface FlushDecisionInput {
+  capturePrepared: boolean;
+  hasArchived: boolean;
+  sendInFlight: boolean;
+  updateInFlight?: boolean;
+  documentHidden?: boolean;
+  currentPageId: number | null;
+}
+
+export function chooseFlushAction(input: FlushDecisionInput): FlushAction {
+  if (input.sendInFlight || input.updateInFlight) {
+    return 'none';
+  }
+
+  if (!input.hasArchived) {
+    return input.capturePrepared ? 'send-capture' : 'none';
+  }
+
+  if (input.documentHidden) {
+    return 'none';
+  }
+
+  return input.currentPageId !== null ? 'update-current-page' : 'none';
+}
+
+export function choosePendingFlushDependency(input: Pick<FlushDecisionInput, 'sendInFlight' | 'updateInFlight'>): PendingFlushDependency {
+  if (input.sendInFlight) {
+    return 'send';
+  }
+
+  return 'none';
+}
+
+export function shouldCommitMonitorUpdate(taskEpoch: number, currentEpoch: number, monitorPageId: number | null, currentPageId: number | null): boolean {
+  return taskEpoch === currentEpoch && monitorPageId !== null && monitorPageId === currentPageId;
+}

--- a/browser/tests/spa-coordinator.test.js
+++ b/browser/tests/spa-coordinator.test.js
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  chooseFlushAction,
+  choosePendingFlushDependency,
+  shouldCommitMonitorUpdate,
+} = require('../dist-test/spa-coordinator.js');
+
+test('chooseFlushAction sends initial capture before first archive', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
+    sendInFlight: false,
+    currentPageId: null,
+  }), 'send-capture');
+});
+
+test('chooseFlushAction flushes current page with update after initial archive', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: 42,
+  }), 'update-current-page');
+});
+
+test('chooseFlushAction does nothing when archived page has no page id yet', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: null,
+  }), 'none');
+});
+
+test('chooseFlushAction does not start a second flush while send is in flight', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
+    sendInFlight: true,
+    currentPageId: null,
+  }), 'none');
+});
+
+test('chooseFlushAction skips final flush when document is hidden', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: 42,
+    documentHidden: true,
+  }), 'none');
+});
+
+test('chooseFlushAction still sends initial capture when page hides before first archive', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
+    sendInFlight: false,
+    currentPageId: null,
+    documentHidden: true,
+  }), 'send-capture');
+});
+
+test('chooseFlushAction does not start a second update while final flush is in flight', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: 42,
+    updateInFlight: true,
+  }), 'none');
+});
+
+test('choosePendingFlushDependency waits for in-flight initial send', () => {
+  assert.equal(choosePendingFlushDependency({
+    sendInFlight: true,
+    updateInFlight: false,
+  }), 'send');
+});
+
+test('choosePendingFlushDependency does not wait for in-flight page update during navigation reset', () => {
+  assert.equal(choosePendingFlushDependency({
+    sendInFlight: false,
+    updateInFlight: true,
+  }), 'none');
+});
+
+test('shouldCommitMonitorUpdate rejects stale async work after SPA reset', () => {
+  assert.equal(shouldCommitMonitorUpdate(3, 4, 42, 42), false);
+});
+
+test('shouldCommitMonitorUpdate rejects updates when current page id changed', () => {
+  assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 43), false);
+});
+
+test('shouldCommitMonitorUpdate allows current async work for same page epoch', () => {
+  assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 42), true);
+});

--- a/browser/tsconfig.test.json
+++ b/browser/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist-test",
+    "rootDir": "./src"
+  },
+  "include": ["src/spa-coordinator.ts"],
+  "exclude": ["node_modules", "dist", "dist-test"]
+}

--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -219,7 +219,7 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 
 })();
 </script>
-`, page.URL, escapeHTML(page.URL), escapeHTML(page.URL), capturedTime, navHTML, nonce)
+`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), capturedTime, navHTML, nonce)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {

--- a/server/internal/api/injector_test.go
+++ b/server/internal/api/injector_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"wayback/internal/models"
+)
+
+func TestInjectArchiveHeader_EscapesHeaderLinkHref(t *testing.T) {
+	page := &models.Page{
+		ID:         1,
+		URL:        `https://example.com/?q=" onclick="alert(1)"&x=1`,
+		CapturedAt: time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC),
+	}
+
+	got := injectArchiveHeader(`<html><body><main>hello</main></body></html>`, page, nil, nil, 1, "nonce")
+
+	if strings.Contains(got, `href="https://example.com/?q=" onclick=`) {
+		t.Fatalf("header link href was not escaped: %s", got)
+	}
+
+	wantHref := `href="https://example.com/?q=&quot; onclick=&quot;alert(1)&quot;&amp;x=1"`
+	if !strings.Contains(got, wantHref) {
+		t.Fatalf("header link href missing escaped URL, want substring %q in %s", wantHref, got)
+	}
+}

--- a/server/internal/api/log_handler.go
+++ b/server/internal/api/log_handler.go
@@ -1,12 +1,42 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 )
+
+func parseTailQuery(c *gin.Context) (int, bool) {
+	tail := 2000
+	if t := c.Query("tail"); t != "" {
+		v, err := strconv.Atoi(t)
+		if err != nil || v <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid tail"})
+			return 0, false
+		}
+		tail = v
+	}
+	return tail, true
+}
+
+func logReadStatus(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+
+	message := err.Error()
+	switch {
+	case errors.Is(err, strconv.ErrSyntax), strings.Contains(message, "invalid filename"), strings.Contains(message, "invalid log filename"):
+		return http.StatusBadRequest
+	case strings.Contains(message, "symlink not allowed"), strings.Contains(message, "log file too large"):
+		return http.StatusInternalServerError
+	default:
+		return http.StatusNotFound
+	}
+}
 
 // ListLogs returns available log files.
 func (h *Handler) ListLogs(c *gin.Context) {
@@ -21,16 +51,14 @@ func (h *Handler) ListLogs(c *gin.Context) {
 // GetLog returns the content of a specific log file.
 func (h *Handler) GetLog(c *gin.Context) {
 	filename := c.Param("filename")
-	tail := 2000
-	if t := c.Query("tail"); t != "" {
-		if v, err := strconv.Atoi(t); err == nil && v > 0 {
-			tail = v
-		}
+	tail, ok := parseTailQuery(c)
+	if !ok {
+		return
 	}
 
 	content, err := h.logger.ReadLogFile(filename, tail)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		c.JSON(logReadStatus(err), gin.H{"error": err.Error()})
 		return
 	}
 
@@ -61,16 +89,14 @@ func (h *Handler) GetLatestLog(c *gin.Context) {
 	// files are sorted newest first
 	latest := files[0].Name
 
-	tail := 2000
-	if t := c.Query("tail"); t != "" {
-		if v, err := strconv.Atoi(t); err == nil && v > 0 {
-			tail = v
-		}
+	tail, ok := parseTailQuery(c)
+	if !ok {
+		return
 	}
 
 	content, err := h.logger.ReadLogFile(latest, tail)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(logReadStatus(err), gin.H{"error": err.Error()})
 		return
 	}
 

--- a/server/internal/api/log_handler_test.go
+++ b/server/internal/api/log_handler_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"wayback/internal/logging"
+)
+
+func setupLogTestHandler(t *testing.T) (*Handler, func()) {
+	t.Helper()
+
+	logDir := t.TempDir()
+	logger, err := logging.Setup(logDir)
+	if err != nil {
+		t.Fatalf("logging.Setup failed: %v", err)
+	}
+
+	handler := &Handler{logger: logger}
+	cleanup := func() {
+		logger.Close()
+	}
+	return handler, cleanup
+}
+
+func setupLogRouter(handler *Handler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	api := r.Group("/api")
+	api.GET("/logs", handler.ListLogs)
+	api.GET("/logs/latest", handler.GetLatestLog)
+	api.GET("/logs/:filename", handler.GetLog)
+	return r
+}
+
+func TestGetLog_InvalidTail(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/latest?tail=not-a-number", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid tail, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetLog_InvalidFilenameReturnsBadRequest(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/evil.log", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid filename, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetLog_SymlinkReturnsInternalServerError(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	target := filepath.Join(handler.logger.Dir(), "target.log")
+	if err := os.WriteFile(target, []byte("hello"), 0644); err != nil {
+		t.Fatalf("WriteFile target failed: %v", err)
+	}
+	linkName := filepath.Join(handler.logger.Dir(), "wayback-2099-04-15.001.log")
+	if err := os.Symlink(target, linkName); err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/wayback-2099-04-15.001.log", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for symlink log file, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/api/pages_handler.go
+++ b/server/internal/api/pages_handler.go
@@ -1,48 +1,91 @@
 package api
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"wayback/internal/storage"
 )
 
-// ListPages 列出所有归档页面（支持分页和时间过滤）
-func (h *Handler) ListPages(c *gin.Context) {
-	// 从查询参数获取分页信息，默认每页100条
+func parsePageIDParam(c *gin.Context) (int64, bool) {
+	idStr := c.Param("id")
+	pageID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || pageID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page id"})
+		return 0, false
+	}
+	return pageID, true
+}
+
+func parsePaginationParams(c *gin.Context) (int, int, bool) {
 	limit := 100
 	offset := 0
 
 	if limitStr := c.Query("limit"); limitStr != "" {
-		fmt.Sscanf(limitStr, "%d", &limit)
-		if limit <= 0 || limit > 1000 {
-			limit = 100
+		parsed, err := strconv.Atoi(limitStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid limit"})
+			return 0, 0, false
 		}
+		if parsed <= 0 || parsed > 1000 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be between 1 and 1000"})
+			return 0, 0, false
+		}
+		limit = parsed
 	}
 
 	if offsetStr := c.Query("offset"); offsetStr != "" {
-		fmt.Sscanf(offsetStr, "%d", &offset)
-		if offset < 0 {
-			offset = 0
+		parsed, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid offset"})
+			return 0, 0, false
 		}
+		if parsed < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be non-negative"})
+			return 0, 0, false
+		}
+		offset = parsed
 	}
 
-	// 解析时间参数
+	return limit, offset, true
+}
+
+func parseDateFilters(c *gin.Context) (*time.Time, *time.Time, bool) {
 	var from, to *time.Time
 	if fromStr := c.Query("from"); fromStr != "" {
-		if t, err := time.Parse("2006-01-02", fromStr); err == nil {
-			from = &t
+		t, err := time.Parse("2006-01-02", fromStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid from date, expected YYYY-MM-DD"})
+			return nil, nil, false
 		}
+		from = &t
 	}
 	if toStr := c.Query("to"); toStr != "" {
-		if t, err := time.Parse("2006-01-02", toStr); err == nil {
-			to = &t
+		t, err := time.Parse("2006-01-02", toStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid to date, expected YYYY-MM-DD"})
+			return nil, nil, false
 		}
+		to = &t
+	}
+	return from, to, true
+}
+
+// ListPages 列出所有归档页面（支持分页和时间过滤）
+func (h *Handler) ListPages(c *gin.Context) {
+	limit, offset, ok := parsePaginationParams(c)
+	if !ok {
+		return
+	}
+
+	from, to, ok := parseDateFilters(c)
+	if !ok {
+		return
 	}
 
 	domain := c.Query("domain")
@@ -61,17 +104,21 @@ func (h *Handler) ListPages(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"pages": pages,
-		"total": total,
-		"limit": limit,
+		"pages":  pages,
+		"total":  total,
+		"limit":  limit,
 		"offset": offset,
 	})
 }
 
 // GetPage 获取单个页面详情
 func (h *Handler) GetPage(c *gin.Context) {
-	id := c.Param("id")
-	page, err := h.db.GetPageByID(id)
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+
+	page, err := h.db.GetPageByID(strconv.FormatInt(pageID, 10))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -91,17 +138,9 @@ func (h *Handler) SearchPages(c *gin.Context) {
 		return
 	}
 
-	// 解析时间参数
-	var from, to *time.Time
-	if fromStr := c.Query("from"); fromStr != "" {
-		if t, err := time.Parse("2006-01-02", fromStr); err == nil {
-			from = &t
-		}
-	}
-	if toStr := c.Query("to"); toStr != "" {
-		if t, err := time.Parse("2006-01-02", toStr); err == nil {
-			to = &t
-		}
+	from, to, ok := parseDateFilters(c)
+	if !ok {
+		return
 	}
 
 	domain := c.Query("domain")
@@ -137,7 +176,11 @@ func (h *Handler) GetPageTimeline(c *gin.Context) {
 
 // DeletePage 删除页面
 func (h *Handler) DeletePage(c *gin.Context) {
-	id := c.Param("id")
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+	id := strconv.FormatInt(pageID, 10)
 
 	// 先检查页面是否存在
 	page, err := h.db.GetPageByID(id)
@@ -151,8 +194,6 @@ func (h *Handler) DeletePage(c *gin.Context) {
 	}
 
 	// 删除页面记录
-	var pageID int64
-	fmt.Sscanf(id, "%d", &pageID)
 	if err := h.db.DeletePage(pageID); err != nil {
 		log.Printf("Failed to delete page %s: %v", id, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -172,8 +213,12 @@ func (h *Handler) DeletePage(c *gin.Context) {
 
 // GetPageContent 返回页面正文的 Markdown 格式（精简版，方便 AI 读取）
 func (h *Handler) GetPageContent(c *gin.Context) {
-	id := c.Param("id")
-	page, err := h.db.GetPageByID(id)
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+
+	page, err := h.db.GetPageByID(strconv.FormatInt(pageID, 10))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/server/internal/api/pages_handler_test.go
+++ b/server/internal/api/pages_handler_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupPagesRouter(handler *Handler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	api := r.Group("/api")
+	api.GET("/pages", handler.ListPages)
+	api.GET("/pages/:id", handler.GetPage)
+	api.GET("/pages/:id/content", handler.GetPageContent)
+	api.DELETE("/pages/:id", handler.DeletePage)
+	api.GET("/search", handler.SearchPages)
+	return r
+}
+
+func TestGetPage_InvalidID(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/pages/not-a-number", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid page ID, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeletePage_InvalidID(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/pages/not-a-number", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid page ID, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetPageContent_InvalidID(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/pages/not-a-number/content", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid page ID, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListPages_InvalidLimit(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/pages?limit=not-a-number", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid limit, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSearchPages_InvalidFromDate(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/search?q=test&from=2026-99-99", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid from date, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/api/proxy_resource_integration_test.go
+++ b/server/internal/api/proxy_resource_integration_test.go
@@ -277,6 +277,59 @@ func TestProxyResource_ServesLegacyIframeDocumentAsHTML(t *testing.T) {
 	}
 }
 
+func TestProxyResource_InvalidPageIDReturnsBadRequest(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+
+	router := gin.New()
+	router.GET("/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
+
+	resourceURL := "https://invalid-page-id.example.com/assets/app.css"
+	resourcePath := "resources/ab/cd/invalid-page.css"
+	writeTestResourceFile(t, handler.dataDir, resourcePath, []byte("body{}"))
+	if _, err := handler.db.CreateResource(resourceURL, strings.Repeat("d", 64), "css", resourcePath, 6); err != nil {
+		t.Fatalf("CreateResource failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/archive/not-a-page/20260410124000mp_/"+resourceURL, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestProxyResource_DoesNotFallbackToGlobalResourceFromOtherPage(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+
+	router := gin.New()
+	router.GET("/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pageID, err := handler.db.CreatePage("https://scope-test.example.com/page-"+suffix, "Scope Test", "html/test/scope.html", strings.Repeat("e", 64), time.Now())
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer handler.db.DeletePage(pageID)
+
+	resourceURL := "https://scope-test.example.com/assets/private.png?token=shared"
+	resourcePath := "resources/de/ad/global-private.img"
+	writeTestResourceFile(t, handler.dataDir, resourcePath, []byte("img"))
+	if _, err := handler.db.CreateResource(resourceURL, strings.Repeat("f", 64), "image", resourcePath, 3); err != nil {
+		t.Fatalf("CreateResource failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/archive/%d/20260410125000mp_/%s", pageID, resourceURL), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func writeTestResourceFile(t *testing.T, dataDir, relPath string, content []byte) {
 	t.Helper()
 	absPath := filepath.Join(dataDir, relPath)

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -4,20 +4,59 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/pprof"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"wayback/internal/config"
 	"wayback/web"
 )
 
+func embeddedFileContentType(name string) string {
+	switch {
+	case len(name) > 5 && name[len(name)-5:] == ".html":
+		return "text/html; charset=utf-8"
+	case len(name) > 4 && name[len(name)-4:] == ".ico":
+		return "image/x-icon"
+	case len(name) > 4 && name[len(name)-4:] == ".txt":
+		return "text/plain; charset=utf-8"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func serveEmbeddedFile(webFS fs.FS, name string) gin.HandlerFunc {
+	data, err := fs.ReadFile(webFS, name)
+	contentType := embeddedFileContentType(name)
+
+	return func(c *gin.Context) {
+		if err != nil {
+			c.String(http.StatusInternalServerError, "Failed to load embedded file")
+			return
+		}
+		c.Data(http.StatusOK, contentType, data)
+	}
+}
+
 // SetupRoutes 设置路由
 func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, serverCfg *config.ServerConfig, version, buildTime string) {
+	origins := serverCfg.AllowedOrigins
+	if len(origins) == 0 {
+		origins = config.DefaultAllowedOrigins()
+	}
+
+	allowedOrigins := make(map[string]struct{}, len(origins))
+	for _, origin := range origins {
+		trimmed := strings.TrimSpace(origin)
+		if trimmed == "" {
+			continue
+		}
+		allowedOrigins[trimmed] = struct{}{}
+	}
+
 	// CORS 中间件 - 仅允许本地来源，防止 CSRF 攻击
 	r.Use(func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
-		// 仅允许本地来源（localhost, 127.0.0.1, file://)
-		if origin == "http://localhost:8080" || origin == "http://127.0.0.1:8080" ||
-			origin == "null" || origin == "" { // null = file:// protocol
+		if _, ok := allowedOrigins[origin]; ok {
 			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
 			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		}
@@ -32,22 +71,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 
 	// robots.txt（在认证之前，确保爬虫和工具可以访问）
 	webFS, _ := fs.Sub(web.StaticFiles, ".")
-	serveFile := func(name string) gin.HandlerFunc {
-		data, _ := fs.ReadFile(webFS, name)
-		contentType := "application/octet-stream"
-		switch {
-		case len(name) > 5 && name[len(name)-5:] == ".html":
-			contentType = "text/html; charset=utf-8"
-		case len(name) > 4 && name[len(name)-4:] == ".ico":
-			contentType = "image/x-icon"
-		case len(name) > 4 && name[len(name)-4:] == ".txt":
-			contentType = "text/plain; charset=utf-8"
-		}
-		return func(c *gin.Context) {
-			c.Data(http.StatusOK, contentType, data)
-		}
-	}
-	r.GET("/robots.txt", serveFile("robots.txt"))
+	r.GET("/robots.txt", serveEmbeddedFile(webFS, "robots.txt"))
 
 	// Basic Auth 中间件（如果启用）
 	if authCfg.Enabled() {
@@ -58,13 +82,13 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 	}
 
 	// Web UI (embedded)
-	r.GET("/", serveFile("index.html"))
-	r.GET("/index.html", serveFile("index.html"))
-	r.GET("/timeline", serveFile("timeline.html"))
-	r.GET("/timeline.html", serveFile("timeline.html"))
-	r.GET("/logs", serveFile("logs.html"))
-	r.GET("/logs.html", serveFile("logs.html"))
-	r.GET("/favicon.ico", serveFile("favicon.ico"))
+	r.GET("/", serveEmbeddedFile(webFS, "index.html"))
+	r.GET("/index.html", serveEmbeddedFile(webFS, "index.html"))
+	r.GET("/timeline", serveEmbeddedFile(webFS, "timeline.html"))
+	r.GET("/timeline.html", serveEmbeddedFile(webFS, "timeline.html"))
+	r.GET("/logs", serveEmbeddedFile(webFS, "logs.html"))
+	r.GET("/logs.html", serveEmbeddedFile(webFS, "logs.html"))
+	r.GET("/favicon.ico", serveEmbeddedFile(webFS, "favicon.ico"))
 
 	api := r.Group("/api")
 	{

--- a/server/internal/api/routes_test.go
+++ b/server/internal/api/routes_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/fstest"
 
 	"github.com/gin-gonic/gin"
 	"wayback/internal/config"
@@ -16,6 +17,17 @@ func setupAuthRouter(authCfg *config.AuthConfig, serverCfg *config.ServerConfig)
 
 	SetupRoutes(r, handler, authCfg, serverCfg, "test", "")
 	return r
+}
+
+func setupRouterFromEnv(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv failed: %v", err)
+	}
+
+	return setupAuthRouter(&cfg.Auth, &cfg.Server)
 }
 
 func TestRoutes_NoAuth_AllowsAccess(t *testing.T) {
@@ -98,6 +110,34 @@ func TestRoutes_CORS_IncludesAuthorizationHeader(t *testing.T) {
 	}
 }
 
+func TestRoutes_CORS_AllowedOriginsEnvEnablesCustomOrigin(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "https://allowed.example.com")
+	r := setupRouterFromEnv(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/api/archive", nil)
+	req.Header.Set("Origin", "https://allowed.example.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://allowed.example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want custom allowed origin", got)
+	}
+}
+
+func TestRoutes_CORS_AllowedOriginsEnvOverridesDefaultLocalhostSet(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "https://allowed.example.com")
+	r := setupRouterFromEnv(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/api/archive", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want localhost blocked when not configured", got)
+	}
+}
+
 func TestRoutes_DebugAPI_DisabledByDefault(t *testing.T) {
 	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
 
@@ -119,6 +159,40 @@ func TestRoutes_DebugAPI_CanBeEnabled(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 when debug API is enabled, got %d", w.Code)
+	}
+}
+
+func TestServeEmbeddedFile_MissingFileReturnsInternalServerError(t *testing.T) {
+	handler := serveEmbeddedFile(fstest.MapFS{}, "missing.html")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/missing.html", nil)
+	handler(c)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for missing embedded file, got %d", w.Code)
+	}
+}
+
+func TestServeEmbeddedFile_SetsContentType(t *testing.T) {
+	handler := serveEmbeddedFile(fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("<html></html>")},
+	}, "index.html")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/index.html", nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+	}
+	if body := w.Body.String(); body != "<html></html>" {
+		t.Fatalf("body = %q, want embedded content", body)
 	}
 }
 

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -77,9 +78,17 @@ func validateResourcePath(baseDir, resourcePath string) (string, error) {
 
 // ViewPage 查看归档页面（静态快照模式，禁用JavaScript）
 func (h *Handler) ViewPage(c *gin.Context) {
-	id := c.Param("id")
-	page, err := h.db.GetPageByID(id)
-	if err != nil || page == nil {
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+
+	page, err := h.db.GetPageByID(strconv.FormatInt(pageID, 10))
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Database error")
+		return
+	}
+	if page == nil {
 		c.String(http.StatusNotFound, "Page not found")
 		return
 	}
@@ -154,8 +163,11 @@ func (h *Handler) ProxyResource(c *gin.Context) {
 	}
 
 	// 否则，按原来的逻辑处理（从数据库查询）
-	pageIDInt := int64(0)
-	fmt.Sscanf(pageID, "%d", &pageIDInt)
+	pageIDInt, err := strconv.ParseInt(pageID, 10, 64)
+	if err != nil || pageIDInt <= 0 {
+		c.String(http.StatusBadRequest, "Invalid page ID")
+		return
+	}
 
 	resource, err := h.findResourceForPage(originalURL, pageIDInt)
 	if err != nil {
@@ -301,22 +313,7 @@ func resourceLooksLikeHTML(filePath string) bool {
 }
 
 func (h *Handler) findResourceForPage(originalURL string, pageID int64) (*models.Resource, error) {
-	resource, err := h.findResourceForPageOnly(originalURL, pageID)
-	if err != nil || resource != nil {
-		return resource, err
-	}
-
-	urlPath := originalURL
-	if idx := strings.IndexByte(urlPath, '?'); idx != -1 {
-		urlPath = urlPath[:idx]
-	}
-
-	resource, err = h.db.GetResourceByURL(urlPath)
-	if err != nil || resource != nil {
-		return resource, err
-	}
-
-	return h.db.GetResourceByURLLike(urlPath + "%")
+	return h.findResourceForPageOnly(originalURL, pageID)
 }
 
 func (h *Handler) findResourceForPageOnly(originalURL string, pageID int64) (*models.Resource, error) {

--- a/server/internal/api/view_page_handler_test.go
+++ b/server/internal/api/view_page_handler_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupViewRouter(handler *Handler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/view/:id", handler.ViewPage)
+	return r
+}
+
+func TestViewPage_InvalidID(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+
+	router := setupViewRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/view/not-a-number", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid page id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestViewPage_DatabaseErrorReturnsInternalServerError(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+
+	router := setupViewRouter(handler)
+	_ = handler.db.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/view/1", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for database error, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 )
 
 // Config holds all application configuration
@@ -30,8 +31,19 @@ type DatabaseConfig struct {
 type ServerConfig struct {
 	Host             string
 	Port             int
+	AllowedOrigins   []string
 	EnableDebugAPI   bool
 	CompressionLevel int // Compression level (1-9, -1=default). Response compression always enabled, auto-negotiated via Accept-Encoding
+}
+
+var defaultAllowedOrigins = []string{
+	"http://localhost:8080",
+	"http://127.0.0.1:8080",
+	"null",
+}
+
+func DefaultAllowedOrigins() []string {
+	return append([]string(nil), defaultAllowedOrigins...)
 }
 
 // StorageConfig holds storage settings
@@ -80,6 +92,7 @@ func LoadFromEnv() (*Config, error) {
 		Server: ServerConfig{
 			Host:             getEnv("SERVER_HOST", "127.0.0.1"),
 			Port:             getEnvInt("SERVER_PORT", 8080),
+			AllowedOrigins:   getEnvCSV("ALLOWED_ORIGINS", defaultAllowedOrigins),
 			EnableDebugAPI:   getEnvBool("ENABLE_DEBUG_API", false),
 			CompressionLevel: getEnvInt("COMPRESSION_LEVEL", -1), // -1 = DefaultCompression
 		},
@@ -130,6 +143,26 @@ func getEnvBool(key string, defaultValue bool) bool {
 		}
 	}
 	return defaultValue
+}
+
+func getEnvCSV(key string, defaultValue []string) []string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return append([]string(nil), defaultValue...)
+	}
+
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return append([]string(nil), defaultValue...)
+	}
+	return result
 }
 
 // ConnectionString returns the PostgreSQL connection string

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -230,3 +230,41 @@ func TestLoadFromEnv_DebugAPIEnabled(t *testing.T) {
 		t.Fatal("EnableDebugAPI = false, want true")
 	}
 }
+
+func TestLoadFromEnv_DefaultAllowedOrigins(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "")
+
+	cfg, err := LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v", err)
+	}
+
+	want := []string{"http://localhost:8080", "http://127.0.0.1:8080", "null"}
+	if len(cfg.Server.AllowedOrigins) != len(want) {
+		t.Fatalf("AllowedOrigins len = %d, want %d (%v)", len(cfg.Server.AllowedOrigins), len(want), cfg.Server.AllowedOrigins)
+	}
+	for i, origin := range want {
+		if cfg.Server.AllowedOrigins[i] != origin {
+			t.Fatalf("AllowedOrigins[%d] = %q, want %q", i, cfg.Server.AllowedOrigins[i], origin)
+		}
+	}
+}
+
+func TestLoadFromEnv_CustomAllowedOrigins(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "https://allowed.example.com, https://admin.example.com ,null")
+
+	cfg, err := LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v", err)
+	}
+
+	want := []string{"https://allowed.example.com", "https://admin.example.com", "null"}
+	if len(cfg.Server.AllowedOrigins) != len(want) {
+		t.Fatalf("AllowedOrigins len = %d, want %d (%v)", len(cfg.Server.AllowedOrigins), len(want), cfg.Server.AllowedOrigins)
+	}
+	for i, origin := range want {
+		if cfg.Server.AllowedOrigins[i] != origin {
+			t.Fatalf("AllowedOrigins[%d] = %q, want %q", i, cfg.Server.AllowedOrigins[i], origin)
+		}
+	}
+}

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -303,7 +303,7 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 		cachedLastModified(cached),
 	)
 	if err != nil {
-		log.Printf("Download failed for %s: %v, trying fallback", url, err)
+		log.Printf("Download failed for %s: %v", url, err)
 		return d.processResourceFallback(url, err)
 	}
 	if metadata.notModified {
@@ -321,7 +321,7 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 			d.cacheDelete(url)
 			data, hash, tmpPath, metadata, trace, err = d.storage.DownloadResourceWithMetadata(url, pageURL, headers, streamThreshold, "", "")
 			if err != nil {
-				log.Printf("Download failed for %s after cache revalidation miss: %v, trying fallback", url, err)
+				log.Printf("Download failed for %s after cache revalidation miss: %v", url, err)
 				return d.processResourceFallback(url, err)
 			}
 		} else {
@@ -462,25 +462,9 @@ func cachedLastModified(cached *resourceCacheEntry) string {
 }
 
 // processResourceFallback 下载失败时的兜底逻辑
-// 不读取文件内容到内存，仅返回 DB 中的路径信息（调用方按需从磁盘读取）
+// 下载失败时直接返回错误，避免静默复用旧版本资源导致错误归档。
 func (d *Deduplicator) processResourceFallback(url string, downloadErr error) (int64, string, []byte, error) {
-	existing, dbErr := d.db.GetResourceByURL(url)
-	if (dbErr != nil || existing == nil) && strings.Contains(url, "?") {
-		urlPath := url[:strings.IndexByte(url, '?')]
-		existing, dbErr = d.db.GetResourceByURLLike(urlPath + "%")
-		if existing != nil {
-			log.Printf("Fallback: found resource by URL path match: %s -> %s", url, existing.URL)
-		}
-	}
-	if dbErr != nil || existing == nil {
-		return 0, "", nil, fmt.Errorf("download failed and no fallback: %w", downloadErr)
-	}
-	log.Printf("Fallback: reusing previous resource (ID: %d) for: %s", existing.ID, url)
-	if updateErr := d.db.UpdateResourceLastSeen(existing.ID); updateErr != nil {
-		log.Printf("Failed to update last_seen for fallback resource: %v", updateErr)
-	}
-	// 不读取文件到内存、不缓存，避免大文件导致内存膨胀
-	return existing.ID, existing.FilePath, nil, nil
+	return 0, "", nil, fmt.Errorf("download failed: %w", downloadErr)
 }
 
 type cssWorkItem struct {
@@ -922,10 +906,7 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		}
 	}
 
-	var bodyTextPtr *string
-	if bodyText != "" {
-		bodyTextPtr = &bodyText
-	}
+	bodyTextPtr := &bodyText
 
 	if err := d.db.ReplacePageSnapshot(pageID, tempHTMLPath, newContentHash, req.Title, bodyTextPtr, resourceIDs); err != nil {
 		return "", fmt.Errorf("replace page snapshot failed: %w", err)

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -256,6 +256,31 @@ func TestProcessResource_304NoCacheDoesNotRestoreOldFreshness(t *testing.T) {
 	}
 }
 
+func TestProcessResource_DownloadFailureDoesNotFallbackAcrossQueryVariants(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer db.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte("body { color: red; }"))
+	}))
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	pageURL := baseURL + "/page"
+	resourceURL1 := baseURL + "/style.css?token=one"
+	resourceURL2 := baseURL + "/style.css?token=two"
+
+	if _, _, _, err := dedup.ProcessResource(resourceURL1, "css", pageURL, nil); err != nil {
+		t.Fatalf("ProcessResource(resourceURL1) failed: %v", err)
+	}
+
+	server.Close()
+
+	if _, _, _, err := dedup.ProcessResource(resourceURL2, "css", pageURL, nil); err == nil {
+		t.Fatalf("expected download failure for query variant without unsafe fallback")
+	}
+}
+
 func TestProcessResource_LastModifiedRevalidationAvoidsBodyRedownload(t *testing.T) {
 	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
 	defer db.Close()
@@ -494,5 +519,58 @@ func TestUpdateCapture_PreservesOldSnapshotOnCommitFailure(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(fs.baseDir, tempHTMLPath)); !os.IsNotExist(err) {
 		t.Fatalf("failed update should delete temporary HTML, got err=%v", err)
+	}
+}
+
+func TestUpdateCapture_ClearsBodyTextWhenSnapshotBecomesEmpty(t *testing.T) {
+	dedup, db, _ := newFrameCaptureTestDeduplicator(t)
+	defer db.Close()
+
+	pageURL := fmt.Sprintf("https://body-text-clear.example.com/page-%d", time.Now().UnixNano())
+	createReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "before body text clear",
+		HTML:  `<html><body>search term should disappear</body></html>`,
+	}
+
+	pageID, action, err := dedup.ProcessCapture(createReq)
+	if err != nil {
+		t.Fatalf("ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID)
+
+	matches, err := db.SearchPages("disappear", nil, nil, "")
+	if err != nil {
+		t.Fatalf("SearchPages(before update) failed: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected body text to be searchable before update")
+	}
+
+	updateReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "after body text clear",
+		HTML:  `<html><body><script>ignored</script></body></html>`,
+	}
+
+	action, err = dedup.UpdateCapture(pageID, updateReq)
+	if err != nil {
+		t.Fatalf("UpdateCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionUpdated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionUpdated)
+	}
+
+	matches, err = db.SearchPages("disappear", nil, nil, "")
+	if err != nil {
+		t.Fatalf("SearchPages(after update) failed: %v", err)
+	}
+	for _, match := range matches {
+		if match.ID == pageID {
+			t.Fatalf("updated page should no longer match cleared body text")
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- harden browser-side capture/update coordination for SPA navigation, shared iframe bridge secrets, and duplicate update suppression, and add focused browser regression tests
- tighten server-side validation and resource scoping for pages, views, logs, embedded assets, and CORS configuration to avoid stale data, cross-page resource fallback, and misleading status codes
- add regression coverage for body text updates, proxy resource lookup, log/view handlers, embedded UI asset serving, and archive header escaping

## Testing
- make test
- cd browser && npm test
- cd browser && npm run build