### PR TITLE
fix: harden browser snapshot flush and bundle tests

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -3,15 +3,6 @@ const path = require('path');
 const { execSync } = require('child_process');
 const ts = require('typescript');
 
-// Step 1: Compile TypeScript
-console.log('Compiling TypeScript...');
-try {
-  execSync('npx tsc', { cwd: __dirname, stdio: 'inherit' });
-} catch (error) {
-  console.error('TypeScript compilation failed');
-  process.exit(1);
-}
-
 // Version from git tag or environment variable
 const version = process.env.VERSION
   || execSync('git describe --tags --always --dirty 2>/dev/null || echo "dev"', { encoding: 'utf8' }).trim().replace(/^v/, '');
@@ -22,6 +13,40 @@ const userscriptPath = path.join(distDir, 'wayback-userscript.js');
 const puppeteerPath = path.join(distDir, 'wayback-puppeteer.js');
 const distPackageJSONPath = path.join(distDir, 'package.json');
 const pakoPath = path.join(__dirname, 'node_modules/pako/dist/pako.min.js');
+
+function rewriteRelativeESMImports() {
+  for (const fileName of fs.readdirSync(distDir)) {
+    if (!fileName.endsWith('.js')) {
+      continue;
+    }
+
+    const filePath = path.join(distDir, fileName);
+    const content = fs.readFileSync(filePath, 'utf8');
+    const rewritten = content.replace(
+      /((?:import|export)\s+(?:[^'"]*?\s+from\s+)?)(['"])(\.{1,2}\/[^'"]+)(\2)/g,
+      (match, prefix, quote, specifier, suffix) => {
+        if (path.extname(specifier)) {
+          return match;
+        }
+        return `${prefix}${quote}${specifier}.js${suffix}`;
+      }
+    );
+
+    if (rewritten !== content) {
+      fs.writeFileSync(filePath, rewritten, 'utf8');
+    }
+  }
+}
+
+// Step 1: Compile TypeScript
+console.log('Compiling TypeScript...');
+try {
+  execSync('npx tsc', { cwd: __dirname, stdio: 'inherit' });
+  rewriteRelativeESMImports();
+} catch (error) {
+  console.error('TypeScript compilation failed');
+  process.exit(1);
+}
 
 // Module files to bundle in dependency order
 const userscriptModules = [

--- a/browser/src/dom-collector.ts
+++ b/browser/src/dom-collector.ts
@@ -127,7 +127,7 @@ export class DOMCollector {
       // Fix virtual scroll layout: sort children by translateY and convert to normal flow
       this.fixVirtualScrollLayout(doc);
     }
-    return doc.documentElement.outerHTML;
+    return '<!DOCTYPE html>\n' + doc.documentElement.outerHTML;
   }
 
   /**

--- a/browser/src/frame-capture.ts
+++ b/browser/src/frame-capture.ts
@@ -68,7 +68,8 @@ function isElementHidden(element: Element | null): boolean {
   }
 
   const styleAttr = normalizeText(element.getAttribute('style') || '');
-  return styleAttr.includes('display:none') || styleAttr.includes('visibility:hidden');
+  return /(?:^|[;\s])display\s*:\s*none(?:;|$)/.test(styleAttr) ||
+    /(?:^|[;\s])visibility\s*:\s*hidden(?:;|$)/.test(styleAttr);
 }
 
 function assessFrameDocument(doc: Document, url: string): FrameCaptureStatus {
@@ -262,7 +263,7 @@ async function requestFrameCapture(frame: HTMLIFrameElement): Promise<FrameCaptu
   });
 }
 
-export async function captureDocumentHTMLWithFrames(): Promise<DocumentCaptureResult> {
+export async function captureDocumentHTMLWithFrames(baseURL = window.location.href): Promise<DocumentCaptureResult> {
   const frames = markFrames();
   const capturedFrames = new Map<string, FrameCaptureResult>();
   const skippedFrames = new Map<string, FrameCaptureResult>();
@@ -292,7 +293,7 @@ export async function captureDocumentHTMLWithFrames(): Promise<DocumentCaptureRe
   }
 
   serializeCSSOMToDOM();
-  const html = normalizeCapturedHTMLURLs(inlineLayoutStyles(), window.location.href);
+  const html = normalizeCapturedHTMLURLs(inlineLayoutStyles(), baseURL);
   return {
     html: embedCapturedFrames(html, capturedFrames, skippedFrames),
     frames: dedupeFrames(collectedFrames),

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -21,7 +21,7 @@ import { waitForDOMStable } from './page-freezer';
 import { sendToServer, updateOnServer } from './archiver';
 import { DOMCollector } from './dom-collector';
 import { captureDocumentHTMLWithFrames, setupFrameCaptureBridge } from './frame-capture';
-import { chooseFlushAction, choosePendingFlushDependency, shouldCommitMonitorUpdate } from './spa-coordinator';
+import { chooseFlushAction, choosePendingFlushDependency, shouldClearAsyncState, shouldCommitMonitorUpdate } from './spa-coordinator';
 
 // Early exit check before any initialization
 if (shouldSkipPage()) {
@@ -36,6 +36,11 @@ if (shouldSkipPage()) {
 }
 
 function initializeArchiver(): void {
+  type CapturePageContext = {
+    url: string;
+    title: string;
+  };
+
   const nativeSetTimeout = window.setTimeout.bind(window);
   const nativeClearTimeout = window.clearTimeout.bind(window);
   const nativeSetInterval = window.setInterval.bind(window);
@@ -48,6 +53,8 @@ function initializeArchiver(): void {
   let updatePromise: Promise<void> | null = null;
   let currentPageId: number | null = null;
   let initialHTMLSize = 0; // Track initial capture size for update quality guard
+  let currentPageURL = window.location.href;
+  let currentPageTitle = document.title;
 
   // Collects nodes removed by virtual scrolling so we can merge them into snapshots
   const domCollector = new DOMCollector();
@@ -63,8 +70,14 @@ function initializeArchiver(): void {
   // Incremented on SPA resets so stale async work can self-cancel.
   let pageEpoch = 0;
 
-  async function captureSnapshot(headers?: Record<string, string>, expectedEpoch = pageEpoch): Promise<CaptureData | null> {
-    const captured = await captureDocumentHTMLWithFrames();
+  async function captureSnapshot(
+    headers?: Record<string, string>,
+    expectedEpoch = pageEpoch,
+    pageContext?: CapturePageContext,
+  ): Promise<CaptureData | null> {
+    const snapshotURL = pageContext?.url || window.location.href;
+    const snapshotTitle = pageContext?.title || document.title;
+    const captured = await captureDocumentHTMLWithFrames(snapshotURL);
     if (expectedEpoch !== pageEpoch) {
       return null;
     }
@@ -76,8 +89,8 @@ function initializeArchiver(): void {
     }
 
     return {
-      url: window.location.href,
-      title: document.title,
+      url: snapshotURL,
+      title: snapshotTitle,
       html,
       frames: captured.frames,
       headers,
@@ -136,6 +149,8 @@ function initializeArchiver(): void {
 
       captureData = preparedCapture;
       initialHTMLSize = preparedCapture.html.length;
+      currentPageURL = preparedCapture.url;
+      currentPageTitle = preparedCapture.title;
       console.log('[Wayback] ✓ Data prepared, size:', JSON.stringify(captureData).length, 'bytes');
     } catch (error) {
       console.error('[Wayback] Failed to prepare:', error);
@@ -155,7 +170,8 @@ function initializeArchiver(): void {
 
     const pendingCapture = captureData;
 
-    sendPromise = (async () => {
+    let activeSendPromise: Promise<void> | null = null;
+    activeSendPromise = (async () => {
       try {
         const response = await sendToServer(pendingCapture);
         currentPageId = response.page_id;
@@ -170,14 +186,18 @@ function initializeArchiver(): void {
       } catch (error) {
         console.error('[Wayback] Send failed:', error);
       } finally {
-        sendPromise = null;
+        if (activeSendPromise && shouldClearAsyncState(sendPromise, activeSendPromise)) {
+          sendPromise = null;
+        }
       }
     })();
+
+    sendPromise = activeSendPromise;
 
     return sendPromise;
   }
 
-  function flushCurrentPage(): Promise<void> {
+  function flushCurrentPage(pageContext?: CapturePageContext): Promise<void> {
     const action = chooseFlushAction({
       capturePrepared: captureData !== null,
       hasArchived,
@@ -204,9 +224,10 @@ function initializeArchiver(): void {
 
     const flushPageID = currentPageId;
     const flushEpoch = pageEpoch;
-    updatePromise = (async () => {
+    let activeFlushPromise: Promise<void> | null = null;
+    activeFlushPromise = (async () => {
       try {
-        const newCaptureData = await captureSnapshot(captureData?.headers, flushEpoch);
+        const newCaptureData = await captureSnapshot(captureData?.headers, flushEpoch, pageContext);
         if (!newCaptureData || !shouldAcceptUpdatedHTML(newCaptureData.html)) {
           return;
         }
@@ -217,9 +238,13 @@ function initializeArchiver(): void {
       } catch (error) {
         console.error('[Wayback] Flush failed:', error);
       } finally {
-        updatePromise = null;
+        if (activeFlushPromise && shouldClearAsyncState(updatePromise, activeFlushPromise)) {
+          updatePromise = null;
+        }
       }
     })();
+
+    updatePromise = activeFlushPromise;
 
     return updatePromise;
   }
@@ -330,13 +355,18 @@ function initializeArchiver(): void {
             return;
           }
 
-          updatePromise = (async () => {
+          let activeMonitorPromise: Promise<void> | null = null;
+          activeMonitorPromise = (async () => {
             try {
               await updateOnServer(monitorPageId, newCaptureData);
             } finally {
-              updatePromise = null;
+              if (activeMonitorPromise && shouldClearAsyncState(updatePromise, activeMonitorPromise)) {
+                updatePromise = null;
+              }
             }
           })();
+
+          updatePromise = activeMonitorPromise;
 
           await updatePromise;
         } catch (error) {
@@ -386,6 +416,8 @@ function initializeArchiver(): void {
     updatePromise = null;
     currentPageId = null;
     initialHTMLSize = 0;
+    currentPageURL = window.location.href;
+    currentPageTitle = document.title;
     if (collectorObserver) {
       collectorObserver.disconnect();
       collectorObserver = null;
@@ -435,8 +467,12 @@ function initializeArchiver(): void {
           return;
         }
         console.log('[Wayback] SPA navigate detected:', e.navigationType);
+        const flushContext = {
+          url: currentPageURL,
+          title: currentPageTitle,
+        };
         // 等待 sendCapture 完成后再重置状态，防止竞态条件
-        flushCurrentPage().then(() => {
+        flushCurrentPage(flushContext).then(() => {
           resetState();
           // Start collector early (after SPA transition completes) to catch virtual scroll removals
           spaCollectorTimerId = nativeSetTimeout(() => {
@@ -464,9 +500,13 @@ function initializeArchiver(): void {
     const newURL = window.location.href;
     if (newURL === lastURL) return;
     console.log('[Wayback] URL changed:', lastURL, '->', newURL);
+    const flushContext = {
+      url: currentPageURL,
+      title: currentPageTitle,
+    };
     lastURL = newURL;
     // 等待 sendCapture 完成后再重置状态，防止竞态条件
-    flushCurrentPage().then(() => {
+    flushCurrentPage(flushContext).then(() => {
       resetState();
       // Start collector early (after SPA transition completes) to catch virtual scroll removals
       spaCollectorTimerId = nativeSetTimeout(() => {

--- a/browser/src/spa-coordinator.ts
+++ b/browser/src/spa-coordinator.ts
@@ -37,3 +37,7 @@ export function choosePendingFlushDependency(input: Pick<FlushDecisionInput, 'se
 export function shouldCommitMonitorUpdate(taskEpoch: number, currentEpoch: number, monitorPageId: number | null, currentPageId: number | null): boolean {
   return taskEpoch === currentEpoch && monitorPageId !== null && monitorPageId === currentPageId;
 }
+
+export function shouldClearAsyncState<T>(currentPromise: Promise<T> | null, settledPromise: Promise<T>): boolean {
+  return currentPromise === settledPromise;
+}

--- a/browser/tests/spa-coordinator.test.js
+++ b/browser/tests/spa-coordinator.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   chooseFlushAction,
   choosePendingFlushDependency,
+  shouldClearAsyncState,
   shouldCommitMonitorUpdate,
 } = require('../dist-test/spa-coordinator.js');
 
@@ -97,4 +98,12 @@ test('shouldCommitMonitorUpdate rejects updates when current page id changed', (
 
 test('shouldCommitMonitorUpdate allows current async work for same page epoch', () => {
   assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 42), true);
+});
+
+test('shouldClearAsyncState only clears the currently tracked promise', async () => {
+  const settledPromise = Promise.resolve();
+  const newerPromise = new Promise(() => {});
+
+  assert.equal(shouldClearAsyncState(settledPromise, settledPromise), true);
+  assert.equal(shouldClearAsyncState(newerPromise, settledPromise), false);
 });

--- a/tests/server/test_cross_origin_frame_placeholder.js
+++ b/tests/server/test_cross_origin_frame_placeholder.js
@@ -1,0 +1,109 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const ARCHIVE_ENDPOINT = 'http://localhost:8080/api/archive';
+
+async function main() {
+  const bundlePath = path.join(__dirname, '../../browser/dist/wayback-puppeteer.js');
+  const bundle = fs.readFileSync(bundlePath, 'utf8');
+  const childURL = 'http://lvh.me:8097/child';
+
+  const parentServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><head><title>Parent Page</title></head><body><h1>Parent</h1><iframe id="cross-origin-frame" src="${childURL}"></iframe></body></html>`);
+  });
+
+  const childServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<!doctype html><html><head><title>Hidden Child</title></head><body style="display: none; visibility: hidden;"><main id="frame-marker">hidden placeholder body</main></body></html>');
+  });
+
+  await new Promise((resolve) => parentServer.listen(8096, '127.0.0.1', resolve));
+  await new Promise((resolve) => childServer.listen(8097, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (text.includes('[Wayback]')) {
+        console.log('[browser]', text);
+      }
+    });
+
+    await page.evaluateOnNewDocument((archiveEndpoint) => {
+      window.__archiveRequests = [];
+      const nativeFetch = window.fetch.bind(window);
+
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string'
+          ? input
+          : (typeof Request !== 'undefined' && input instanceof Request ? input.url : String(input));
+        const method = init?.method || (typeof Request !== 'undefined' && input instanceof Request ? input.method : 'GET');
+
+        if (url === archiveEndpoint && method === 'POST') {
+          window.__archiveRequests.push({
+            url,
+            body: typeof init?.body === 'string' ? init.body : '',
+          });
+
+          return new Response(JSON.stringify({
+            status: 'success',
+            page_id: 1,
+            action: 'created',
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        return nativeFetch(input, init);
+      };
+    }, ARCHIVE_ENDPOINT);
+
+    await page.evaluateOnNewDocument(bundle);
+    await page.goto('http://lvh.me:8096/', { waitUntil: 'networkidle2', timeout: 120000 });
+    await page.waitForFunction(() => !!document.getElementById('cross-origin-frame'), { timeout: 10000 });
+
+    await page.evaluate(() => window.archivePage());
+
+    const capture = await page.evaluate(() => {
+      if (!window.__archiveRequests.length) {
+        throw new Error('archive request was not captured');
+      }
+      return JSON.parse(window.__archiveRequests[0].body);
+    });
+
+    const frame = Array.isArray(capture.frames)
+      ? capture.frames.find((item) => item && item.url === 'http://lvh.me:8097/child')
+      : null;
+
+    if (frame) {
+      throw new Error(`expected hidden cross-origin iframe to be skipped, got ${JSON.stringify(frame)}`);
+    }
+
+    if (!capture.html.includes('data-wayback-frame-status="placeholder"')) {
+      throw new Error(`expected parent HTML to mark iframe as placeholder, got ${capture.html}`);
+    }
+
+    await page.close();
+    console.log('PASS test_cross_origin_frame_placeholder');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => parentServer.close(resolve));
+    await new Promise((resolve) => childServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_page_filter.js
+++ b/tests/server/test_page_filter.js
@@ -65,7 +65,17 @@ function evaluateUserscript(url) {
 }
 
 async function main() {
-  const { shouldSkipURL } = await import('../../browser/dist/page-filter.js');
+  const [{ shouldSkipURL }, archiverModule] = await Promise.all([
+    import('../../browser/dist/page-filter.js'),
+    import('../../browser/dist/archiver.js'),
+  ]);
+
+  if (typeof archiverModule.sendToServer !== 'function' || typeof archiverModule.updateOnServer !== 'function') {
+    console.error('FAIL dist archiver import: expected sendToServer/updateOnServer exports');
+    process.exit(1);
+  }
+
+  console.log('PASS dist archiver import');
 
   const cases = [
     ['localhost', 'http://localhost:8080/', true],
@@ -107,16 +117,17 @@ async function main() {
   }
 
   const bundledCases = [
-    ['bundled localhost', 'http://localhost:8080/'],
-    ['bundled private ipv4', 'http://192.168.1.9/'],
+    ['bundled localhost', 'http://localhost:8080/', true],
+    ['bundled private ipv4', 'http://192.168.1.9/', true],
+    ['bundled public domain', 'https://example.com/', false],
   ];
 
-  for (const [name, url] of bundledCases) {
+  for (const [name, url, expectedSkip] of bundledCases) {
     const logs = evaluateUserscript(url);
     const skipped = logs.some((line) => line.includes('[Wayback] Skipping page:'));
     const loaded = logs.some((line) => line.includes('[Wayback] Script loaded for:'));
 
-    if (!skipped || loaded) {
+    if (skipped !== expectedSkip || loaded === expectedSkip) {
       failed++;
       console.error(`FAIL ${name}: bundled userscript logs = ${JSON.stringify(logs)}`);
     } else {

--- a/tests/server/test_userscript_domcollector_doctype.js
+++ b/tests/server/test_userscript_domcollector_doctype.js
@@ -1,0 +1,113 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+async function preparePage(browser, scriptContent, url) {
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const text = msg.text();
+    if (text.includes('[Wayback]')) {
+      console.log('[browser]', text);
+    }
+  });
+
+  await page.evaluateOnNewDocument(() => {
+    window.__gmCalls = [];
+    window.__gmEvents = [];
+
+    window.GM_cookie = {
+      list(_options, callback) {
+        callback([]);
+      },
+    };
+
+    window.GM_xmlhttpRequest = (options) => {
+      window.__gmCalls.push({
+        method: options.method,
+        url: options.url,
+        data: typeof options.data === 'string' ? options.data : '',
+      });
+
+      if (typeof options.onload === 'function') {
+        window.setTimeout(() => {
+          window.__gmEvents.push(`${options.method.toLowerCase()}-success`);
+          options.onload({
+            status: 200,
+            responseText: JSON.stringify({ status: 'success', page_id: 404, action: 'created' }),
+          });
+        }, 0);
+      }
+    };
+  });
+
+  await page.goto(url, { waitUntil: 'networkidle2', timeout: 120000 });
+  await page.addScriptTag({ content: scriptContent });
+  return page;
+}
+
+async function main() {
+  const scriptPath = path.join(__dirname, '../../browser/dist/wayback-userscript.js');
+  const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+  const targetURL = 'http://lvh.me:8095/domcollector-doctype';
+
+  const fixtureServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<!doctype html><html><head><title>DOMCollector Doctype</title></head><body><main id="feed"></main></body></html>');
+  });
+
+  await new Promise((resolve) => fixtureServer.listen(8095, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await preparePage(browser, scriptContent, targetURL);
+
+    await page.evaluate(() => {
+      const bigText = 'archived content '.repeat(200);
+      const node = document.createElement('article');
+      node.id = 'removed-card';
+      node.textContent = bigText;
+      document.getElementById('feed').appendChild(node);
+
+      window.setTimeout(() => {
+        node.remove();
+      }, 100);
+    });
+
+    await page.waitForFunction(() => window.__gmEvents.includes('post-success'), { timeout: 15000 });
+
+    const payload = await page.evaluate(() => {
+      const postCall = window.__gmCalls.find((call) => call.method === 'POST');
+      if (!postCall) {
+        throw new Error('archive request was not captured');
+      }
+      return JSON.parse(postCall.data);
+    });
+
+    if (!payload.html.startsWith('<!DOCTYPE html>')) {
+      throw new Error(`expected archived HTML to preserve doctype, got: ${payload.html.slice(0, 80)}`);
+    }
+
+    if (!payload.html.includes('removed-card')) {
+      throw new Error('expected merged HTML to contain removed virtual-scroll node');
+    }
+
+    await page.close();
+    console.log('PASS test_userscript_domcollector_doctype');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => fixtureServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_userscript_spa_flush_url.js
+++ b/tests/server/test_userscript_spa_flush_url.js
@@ -1,0 +1,145 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+async function preparePage(browser, scriptContent, url) {
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const text = msg.text();
+    if (text.includes('[Wayback]')) {
+      console.log('[browser]', text);
+    }
+  });
+
+  await page.evaluateOnNewDocument(() => {
+    try {
+      Object.defineProperty(window, 'navigation', {
+        configurable: true,
+        value: undefined,
+      });
+    } catch {
+      // Fall back to the browser's Navigation API if it cannot be redefined.
+    }
+
+    window.__gmCalls = [];
+    window.__gmEvents = [];
+
+    window.GM_cookie = {
+      list(_options, callback) {
+        callback([]);
+      },
+    };
+
+    window.GM_xmlhttpRequest = (options) => {
+      window.__gmCalls.push({
+        method: options.method,
+        url: options.url,
+        data: typeof options.data === 'string' ? options.data : '',
+      });
+
+      const reply = (handler, payload) => {
+        if (typeof handler === 'function') {
+          window.setTimeout(() => handler(payload), 0);
+        }
+      };
+
+      if (options.method === 'POST') {
+        window.__gmEvents.push('post-success');
+        reply(options.onload, {
+          status: 200,
+          responseText: JSON.stringify({ status: 'success', page_id: 303, action: 'created' }),
+        });
+        return;
+      }
+
+      if (options.method === 'PUT') {
+        window.__gmEvents.push('put-success');
+        reply(options.onload, {
+          status: 200,
+          responseText: JSON.stringify({ status: 'success', page_id: 303, action: 'updated' }),
+        });
+        return;
+      }
+
+      window.__gmEvents.push(`unexpected-${options.method}`);
+      reply(options.onerror, { message: `unexpected method ${options.method}` });
+    };
+  });
+
+  await page.goto(url, { waitUntil: 'networkidle2', timeout: 120000 });
+  await page.addScriptTag({ content: scriptContent });
+  return page;
+}
+
+async function main() {
+  const scriptPath = path.join(__dirname, '../../browser/dist/wayback-userscript.js');
+  const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+  const oldURL = 'http://lvh.me:8094/old-route';
+  const newPath = '/new-route';
+
+  const fixtureServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><head><title>Old Title</title></head><body><main id="old-marker">old page body</main></body></html>`);
+  });
+
+  await new Promise((resolve) => fixtureServer.listen(8094, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await preparePage(browser, scriptContent, oldURL);
+    await page.waitForFunction(() => window.__gmEvents.includes('post-success'), { timeout: 15000 });
+
+    await page.evaluate((pathAfterPush) => {
+      history.pushState({}, '', pathAfterPush);
+      document.title = 'New Title';
+      window.setTimeout(() => {
+        document.body.innerHTML = '<main id="new-marker">new page body</main>';
+      }, 200);
+    }, newPath);
+
+    await page.waitForFunction(() => window.__gmEvents.includes('put-success'), { timeout: 15000 });
+
+    const putPayload = await page.evaluate(() => {
+      const putCall = window.__gmCalls.find((call) => call.method === 'PUT');
+      if (!putCall) {
+        throw new Error('update request was not captured');
+      }
+      return JSON.parse(putCall.data);
+    });
+
+    if (putPayload.url !== oldURL) {
+      throw new Error(`expected flush PUT to keep old URL ${oldURL}, got ${putPayload.url}`);
+    }
+
+    if (putPayload.title !== 'Old Title') {
+      throw new Error(`expected flush PUT to keep old title Old Title, got ${putPayload.title}`);
+    }
+
+    if (!putPayload.html.includes('old-marker')) {
+      throw new Error(`expected flush PUT HTML to contain old DOM, got ${putPayload.html}`);
+    }
+
+    if (putPayload.html.includes('new-marker')) {
+      throw new Error(`flush PUT HTML unexpectedly captured new DOM: ${putPayload.html}`);
+    }
+
+    await page.close();
+    console.log('PASS test_userscript_spa_flush_url');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => fixtureServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- preserve the archived page URL and title across SPA flushes, and guard async state cleanup so older send/update completions cannot clear newer in-flight work
- keep merged snapshots in standards mode and correctly classify hidden cross-origin iframe placeholders even when inline styles include spaces
- make `browser/dist` modules importable as native Node ESM and add regression coverage for bundle assembly, DOMCollector merges, SPA flushes, and iframe placeholder handling

## Testing
- cd browser && npm test
- cd browser && npm run build --silent
- node tests/server/test_userscript_spa_flush_url.js
- node tests/server/test_userscript_domcollector_doctype.js
- node tests/server/test_cross_origin_frame_placeholder.js
- node tests/server/test_userscript_state.js
- node tests/server/test_cross_origin_frame_capture.js
- node tests/server/test_frame_bridge_origin.js