### PR TITLE
fix: respond before archive finalize completes

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,7 +21,7 @@ Chrome + Tampermonkey ──HTTP POST──▶ Go 服务器 ──▶ PostgreSQL
 ```
 
 1. Tampermonkey 用户脚本在浏览器中运行，页面加载完成后自动捕获完整的 DOM 和资源。若后续 DOM 发生显著变化，会自动提交一次更新。
-2. Go 服务器接收快照，下载浏览器因 CORS 限制无法获取的跨域资源，基于内容哈希去重后存储到本地。
+2. Go 服务器在快照元数据落库后会立即响应归档/更新请求；资源下载、去重、URL 重写和快照最终整理会继续在后台完成。
 3. 内置 Web UI 可以浏览、搜索和还原任意归档页面 — 完全离线，不依赖外部服务。
 
 ## 功能特性
@@ -195,10 +195,11 @@ export https_proxy=http://127.0.0.1:7897
 ### POST /api/archive
 
 返回 `{ status, page_id, action }`，其中 `action` 为 `created`（新建）或 `unchanged`（内容未变，仅更新 `last_visited`）。
+当 `action=created` 时，接口会在页面记录和原始 HTML 保存后立即返回；资源下载和 HTML 重写会在后台继续执行。
 
 ### PUT /api/archive/:id
 
-请求体与 POST 相同。会重新处理资源、写入新的临时快照，然后以事务方式替换页面元数据和 `page_resources` 关联。替换成功后，旧 HTML 进入延迟删除队列。返回 `{ status, page_id, action }`，`action` 为 `updated` 或 `unchanged`。
+请求体与 POST 相同。接口会在接受更新请求后立即返回；若内容有变化，资源重新处理和最终快照替换会在后台继续执行。替换成功后，旧 HTML 进入延迟删除队列。返回 `{ status, page_id, action }`，`action` 为 `updated` 或 `unchanged`。
 
 ## 项目结构
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Chrome + Tampermonkey ──HTTP POST──▶ Go Server ──▶ PostgreSQL (m
 ```
 
 1. A Tampermonkey userscript runs in your browser, automatically capturing the full DOM and resources once the page finishes loading. If significant DOM changes occur afterward, it submits one additional update.
-2. The Go server receives the snapshot, downloads any cross-origin resources the browser couldn't fetch, deduplicates everything by content hash, and stores it locally.
+2. The Go server acknowledges archive/update requests as soon as the snapshot metadata is stored. Resource downloading, deduplication, URL rewriting, and snapshot finalization continue in the background.
 3. A built-in Web UI lets you list, search, and replay any archived page — fully offline, no external dependencies.
 
 ## Features
@@ -230,10 +230,11 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 ### POST /api/archive
 
 Returns `{ status, page_id, action }` where `action` is `created` or `unchanged` (content identical, only `last_visited` updated).
+When `action` is `created`, the response is sent immediately after the page row and raw HTML are stored; resource downloads and HTML rewriting continue in the background.
 
 ### PUT /api/archive/:id
 
-Accepts the same body as POST. Re-processes resources, writes a replacement snapshot, then atomically swaps the page metadata and `page_resources` links. Old HTML is queued for delayed deletion after a successful swap. Returns `{ status, page_id, action }` where `action` is `updated` or `unchanged`.
+Accepts the same body as POST. Returns immediately once the server has accepted the update request. If the content changed, resource re-processing and the final snapshot swap continue in the background; old HTML is queued for delayed deletion after a successful swap. Returns `{ status, page_id, action }` where `action` is `updated` or `unchanged`.
 
 ## Project Structure
 

--- a/server/internal/api/archive_handler.go
+++ b/server/internal/api/archive_handler.go
@@ -42,7 +42,7 @@ func (h *Handler) ArchivePage(c *gin.Context) {
 	log.Printf("Received archive request: %s (frames: %d)", req.URL, len(req.Frames))
 
 	// 处理捕获
-	pageID, action, err := h.dedup.ProcessCapture(req)
+	pageID, action, err := h.dedup.ProcessCaptureAsync(req)
 	if err != nil {
 		log.Printf("Failed to process capture: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -72,7 +72,7 @@ func (h *Handler) UpdatePage(c *gin.Context) {
 
 	log.Printf("Received update request for page %d: %s", pageID, req.URL)
 
-	action, err := h.dedup.UpdateCapture(pageID, req)
+	action, err := h.dedup.UpdateCaptureAsync(pageID, req)
 	if err != nil {
 		log.Printf("Failed to update capture: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/server/internal/api/archive_handler_test.go
+++ b/server/internal/api/archive_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"wayback/internal/config"
@@ -33,9 +34,31 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 	handler := NewHandler(dedup, db, dataDir, nil)
 
 	cleanup := func() {
+		dedup.WaitForBackgroundTasks()
 		db.Close()
 	}
 	return handler, cleanup
+}
+
+func waitForPageTitle(t *testing.T, handler *Handler, pageID int64, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		page, err := handler.db.GetPageByID(strconv.FormatInt(pageID, 10))
+		if err == nil && page != nil && page.Title == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	page, err := handler.db.GetPageByID(strconv.FormatInt(pageID, 10))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	if page == nil {
+		t.Fatalf("expected page %d to exist", pageID)
+	}
+	t.Fatalf("page title = %q, want %q", page.Title, want)
 }
 
 func setupRouter(handler *Handler) *gin.Engine {
@@ -157,13 +180,7 @@ func TestUpdatePage_UpdatesContent(t *testing.T) {
 	}
 
 	// Verify DB was updated
-	page, err := handler.db.GetPageByID(strconv.FormatInt(createResp.PageID, 10))
-	if err != nil {
-		t.Fatalf("GetPageByID failed: %v", err)
-	}
-	if page.Title != "Updated" {
-		t.Errorf("title = %q, want %q", page.Title, "Updated")
-	}
+	waitForPageTitle(t, handler, createResp.PageID, "Updated")
 }
 
 func TestUpdatePage_SameContentUnchanged(t *testing.T) {

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -48,6 +49,9 @@ type Deduplicator struct {
 	cacheBytes    atomic.Int64  // 当前缓存占用字节数
 	cacheMu       sync.Mutex    // 保护缓存淘汰逻辑，防止并发 cacheStore 导致超限
 	globalSem     chan struct{} // 全局并发下载信号量，跨所有页面共享
+	pageTaskMu    sync.Mutex
+	pageTaskSeq   map[int64]uint64
+	bgTasks       sync.WaitGroup
 
 	// 测试钩子：用于稳定复现页面已创建/新 HTML 已写入后的失败路径。
 	testBeforeCreateFinalize func(pageID int64, htmlPath string, resourceIDs []int64) error
@@ -63,9 +67,146 @@ func NewDeduplicator(db *database.DB, storage *FileStorage, cfg config.ResourceC
 		deletionQueue: NewDeletionQueue(storage.baseDir),
 		config:        cfg,
 		globalSem:     make(chan struct{}, cfg.Workers),
+		pageTaskSeq:   make(map[int64]uint64),
 	}
 	d.startCacheCleanupLoop()
 	return d
+}
+
+var errStalePageTask = errors.New("stale page task")
+
+func cloneCaptureRequest(req *models.CaptureRequest) *models.CaptureRequest {
+	if req == nil {
+		return nil
+	}
+
+	cloned := &models.CaptureRequest{
+		URL:   req.URL,
+		Title: req.Title,
+		HTML:  req.HTML,
+	}
+	if len(req.Frames) > 0 {
+		cloned.Frames = append([]models.FrameCapture(nil), req.Frames...)
+	}
+	if len(req.Headers) > 0 {
+		cloned.Headers = make(map[string]string, len(req.Headers))
+		for k, v := range req.Headers {
+			cloned.Headers[k] = v
+		}
+	}
+	return cloned
+}
+
+func (d *Deduplicator) nextPageTaskSeq(pageID int64) uint64 {
+	d.pageTaskMu.Lock()
+	defer d.pageTaskMu.Unlock()
+	d.pageTaskSeq[pageID] += 1
+	return d.pageTaskSeq[pageID]
+}
+
+func (d *Deduplicator) isLatestPageTask(pageID int64, seq uint64) bool {
+	d.pageTaskMu.Lock()
+	defer d.pageTaskMu.Unlock()
+	return d.pageTaskSeq[pageID] == seq
+}
+
+func (d *Deduplicator) finishPageTask(pageID int64, seq uint64) {
+	d.pageTaskMu.Lock()
+	defer d.pageTaskMu.Unlock()
+	if d.pageTaskSeq[pageID] == seq {
+		delete(d.pageTaskSeq, pageID)
+	}
+}
+
+func (d *Deduplicator) runPageTask(pageID int64, seq uint64, label string, fn func() error) {
+	d.bgTasks.Add(1)
+	go func() {
+		defer d.bgTasks.Done()
+		defer d.finishPageTask(pageID, seq)
+		if err := fn(); err != nil {
+			if errors.Is(err, errStalePageTask) {
+				log.Printf("[%s] Skipped stale background task for page %d", label, pageID)
+				return
+			}
+			log.Printf("[%s] Background task failed for page %d: %v", label, pageID, err)
+		}
+	}()
+}
+
+func (d *Deduplicator) WaitForBackgroundTasks() {
+	d.bgTasks.Wait()
+}
+
+func (d *Deduplicator) ProcessCaptureAsync(req *models.CaptureRequest) (int64, string, error) {
+	capturedAt := time.Now()
+	contentHash := hashCaptureContent(req.HTML, req.Frames)
+
+	existingPage, err := d.db.GetPageByURLAndHash(req.URL, contentHash)
+	if err != nil {
+		return 0, "", fmt.Errorf("check existing page failed: %w", err)
+	}
+	if existingPage != nil {
+		log.Printf("Page content unchanged, updating last visited: %s (ID: %d)", req.URL, existingPage.ID)
+		if err := d.db.UpdatePageLastVisited(existingPage.ID, capturedAt); err != nil {
+			return 0, "", fmt.Errorf("update last visited failed: %w", err)
+		}
+		return existingPage.ID, models.ArchiveActionUnchanged, nil
+	}
+
+	tempHTMLPath, err := d.storage.SaveHTML(req.URL, req.HTML, capturedAt)
+	if err != nil {
+		return 0, "", fmt.Errorf("save temp html failed: %w", err)
+	}
+
+	pageID, err := d.db.CreatePage(req.URL, req.Title, tempHTMLPath, contentHash, capturedAt)
+	if err != nil {
+		if deleteErr := d.storage.DeleteHTML(tempHTMLPath); deleteErr != nil {
+			log.Printf("Failed to delete temporary HTML %s after create page error: %v", tempHTMLPath, deleteErr)
+		}
+		return 0, "", fmt.Errorf("create page failed: %w", err)
+	}
+
+	bodyText := ExtractBodyText(req.HTML)
+	if bodyText != "" {
+		if err := d.db.UpdatePageBodyText(pageID, bodyText); err != nil {
+			log.Printf("Failed to save body text for page %d: %v", pageID, err)
+		}
+	}
+
+	seq := d.nextPageTaskSeq(pageID)
+	clonedReq := cloneCaptureRequest(req)
+	d.runPageTask(pageID, seq, "Create", func() error {
+		staleCheck := func() bool { return !d.isLatestPageTask(pageID, seq) }
+		return d.finalizeCreateCapture(pageID, tempHTMLPath, capturedAt, clonedReq, staleCheck)
+	})
+
+	log.Printf("Page created (ID: %d, hash: %s): %s", pageID, contentHash[:16], req.URL)
+	return pageID, models.ArchiveActionCreated, nil
+}
+
+func (d *Deduplicator) UpdateCaptureAsync(pageID int64, req *models.CaptureRequest) (string, error) {
+	page, err := d.db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil || page == nil {
+		return "", fmt.Errorf("page not found: %d", pageID)
+	}
+
+	newContentHash := hashCaptureContent(req.HTML, req.Frames)
+	if newContentHash == page.ContentHash {
+		if err := d.db.UpdatePageLastVisited(pageID, time.Now()); err != nil {
+			return "", err
+		}
+		return models.ArchiveActionUnchanged, nil
+	}
+
+	seq := d.nextPageTaskSeq(pageID)
+	clonedReq := cloneCaptureRequest(req)
+	d.runPageTask(pageID, seq, "Update", func() error {
+		staleCheck := func() bool { return !d.isLatestPageTask(pageID, seq) }
+		_, err := d.updateCapture(pageID, clonedReq, staleCheck)
+		return err
+	})
+
+	return models.ArchiveActionUpdated, nil
 }
 
 func (d *Deduplicator) startCacheCleanupLoop() {
@@ -735,17 +876,13 @@ func (d *Deduplicator) rewriteCapturedHTML(htmlContent, baseURL string, headers 
 // ProcessCapture 处理完整的页面捕获，返回 (pageID, action, error)
 func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string, error) {
 	capturedAt := time.Now()
-
 	contentHash := hashCaptureContent(req.HTML, req.Frames)
 
-	// 检查是否存在相同 URL 和内容哈希的页面
 	existingPage, err := d.db.GetPageByURLAndHash(req.URL, contentHash)
 	if err != nil {
 		return 0, "", fmt.Errorf("check existing page failed: %w", err)
 	}
-
 	if existingPage != nil {
-		// 内容未变化，只更新最后访问时间
 		log.Printf("Page content unchanged, updating last visited: %s (ID: %d)", req.URL, existingPage.ID)
 		if err := d.db.UpdatePageLastVisited(existingPage.ID, capturedAt); err != nil {
 			return 0, "", fmt.Errorf("update last visited failed: %w", err)
@@ -753,11 +890,6 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 		return existingPage.ID, models.ArchiveActionUnchanged, nil
 	}
 
-	frameMap := buildFrameCaptureMap(req.Frames)
-	log.Printf("Total resources to process: %d (frames: %d)", len(d.htmlExtractor.ExtractResources(req.HTML, req.URL)), len(frameMap))
-
-	// 先创建页面记录以获取 pageID（用于生成正确的资源路径）
-	// 使用临时 HTML 创建页面
 	tempHTMLPath, err := d.storage.SaveHTML(req.URL, req.HTML, capturedAt)
 	if err != nil {
 		return 0, "", fmt.Errorf("save temp html failed: %w", err)
@@ -781,9 +913,7 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 		}
 	}()
 
-	// 提取正文纯文本（在释放 HTML 之前）
 	bodyText := ExtractBodyText(req.HTML)
-
 	pageID, err = d.db.CreatePage(req.URL, req.Title, tempHTMLPath, contentHash, capturedAt)
 	if err != nil {
 		if deleteErr := d.storage.DeleteHTML(tempHTMLPath); deleteErr != nil {
@@ -793,54 +923,33 @@ func (d *Deduplicator) ProcessCapture(req *models.CaptureRequest) (int64, string
 		return 0, "", fmt.Errorf("create page failed: %w", err)
 	}
 
-	// 保存正文纯文本（用于全文搜索）
 	if bodyText != "" {
 		if err := d.db.UpdatePageBodyText(pageID, bodyText); err != nil {
 			log.Printf("Failed to save body text for page %d: %v", pageID, err)
 		}
 	}
-	bodyText = "" // 释放正文文本
 
 	log.Printf("Page created (ID: %d, hash: %s): %s", pageID, contentHash[:16], req.URL)
-
-	// 生成时间戳用于资源路径
-	timestamp := capturedAt.Format("20060102150405")
-
-	var resourceIDs []int64
-	startTime := time.Now()
-	resourceIDSet := make(map[int64]struct{})
-	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
-	if err != nil {
-		return 0, "", fmt.Errorf("rewrite html failed: %w", err)
-	}
-	log.Printf("Resource processing completed: %d linked resources, took %v", len(resourceIDs), time.Since(startTime))
-
-	// 更新保存的 HTML 文件（用重写后的内容替换临时内容）
-	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
-		return 0, "", fmt.Errorf("update html failed: %w", err)
-	}
-	rewrittenHTML = "" // 释放重写后的 HTML
-
-	if d.testBeforeCreateFinalize != nil {
-		if err := d.testBeforeCreateFinalize(pageID, tempHTMLPath, resourceIDs); err != nil {
-			return 0, "", err
-		}
-	}
-
-	if err := d.db.LinkPageResources(pageID, resourceIDs); err != nil {
-		return 0, "", fmt.Errorf("link page resources failed: %w", err)
+	if err := d.finalizeCreateCapture(pageID, tempHTMLPath, capturedAt, req, nil); err != nil {
+		return 0, "", err
 	}
 
 	finalized = true
-
 	return pageID, models.ArchiveActionCreated, nil
 }
 
 // UpdateCapture 更新已存在页面的捕获内容
 // 策略：更新 page 记录的 html_path 和 content_hash，旧 HTML 文件加入删除队列（7 天后自动删除）
 func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (string, error) {
+	return d.updateCapture(pageID, req, nil)
+}
+
+func (d *Deduplicator) updateCapture(pageID int64, req *models.CaptureRequest, staleCheck func() bool) (string, error) {
 	startTime := time.Now()
 	log.Printf("[Update] Starting update for page %d", pageID)
+	if staleCheck != nil && staleCheck() {
+		return "", errStalePageTask
+	}
 
 	// 1. 获取现有页面信息（用于继承 first_visited）
 	page, err := d.db.GetPageByID(fmt.Sprintf("%d", pageID))
@@ -893,6 +1002,9 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 		return "", fmt.Errorf("rewrite html failed: %w", err)
 	}
 	log.Printf("[Update] Processed %d linked resources in %v", len(resourceIDs), time.Since(processStart))
+	if staleCheck != nil && staleCheck() {
+		return "", errStalePageTask
+	}
 
 	// 更新保存的 HTML 文件
 	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
@@ -923,6 +1035,52 @@ func (d *Deduplicator) UpdateCapture(pageID int64, req *models.CaptureRequest) (
 	log.Printf("[Update] Page updated (ID: %d, old_hash: %s, new_hash: %s, old_html: %s, new_html: %s, %d resources, %v)",
 		pageID, page.ContentHash[:16], newContentHash[:16], oldHTMLPath, tempHTMLPath, len(resourceIDs), time.Since(startTime))
 	return models.ArchiveActionUpdated, nil
+}
+
+func (d *Deduplicator) finalizeCreateCapture(pageID int64, tempHTMLPath string, capturedAt time.Time, req *models.CaptureRequest, staleCheck func() bool) error {
+	if staleCheck != nil && staleCheck() {
+		return errStalePageTask
+	}
+
+	frameMap := buildFrameCaptureMap(req.Frames)
+	log.Printf("Total resources to process: %d (frames: %d)", len(d.htmlExtractor.ExtractResources(req.HTML, req.URL)), len(frameMap))
+
+	timestamp := capturedAt.Format("20060102150405")
+	var resourceIDs []int64
+	startTime := time.Now()
+	resourceIDSet := make(map[int64]struct{})
+	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
+	if err != nil {
+		return fmt.Errorf("rewrite html failed: %w", err)
+	}
+	log.Printf("Resource processing completed: %d linked resources, took %v", len(resourceIDs), time.Since(startTime))
+
+	if staleCheck != nil && staleCheck() {
+		return errStalePageTask
+	}
+
+	if err := d.storage.UpdateHTML(tempHTMLPath, rewrittenHTML); err != nil {
+		return fmt.Errorf("update html failed: %w", err)
+	}
+
+	if d.testBeforeCreateFinalize != nil {
+		if err := d.testBeforeCreateFinalize(pageID, tempHTMLPath, resourceIDs); err != nil {
+			return err
+		}
+	}
+
+	if staleCheck != nil && staleCheck() {
+		return errStalePageTask
+	}
+
+	if err := d.db.DeletePageResources(pageID); err != nil {
+		return fmt.Errorf("clear page resources failed: %w", err)
+	}
+	if err := d.db.LinkPageResources(pageID, resourceIDs); err != nil {
+		return fmt.Errorf("link page resources failed: %w", err)
+	}
+
+	return nil
 }
 
 // resolveURL resolves a relative URL against a base URL

--- a/server/internal/storage/deduplicator_async_test.go
+++ b/server/internal/storage/deduplicator_async_test.go
@@ -1,0 +1,280 @@
+package storage
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"wayback/internal/models"
+)
+
+func TestProcessCaptureAsync_ReturnsBeforeResourceDownloadCompletes(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer func() {
+		dedup.WaitForBackgroundTasks()
+		db.Close()
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte("body { color: red; }"))
+	}))
+	defer server.Close()
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	pageURL := fmt.Sprintf("%s/page-%d", baseURL, time.Now().UnixNano())
+	cssURL := baseURL + "/slow.css"
+	req := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "async create",
+		HTML:  `<html><head><link rel="stylesheet" href="` + cssURL + `"></head><body>async create</body></html>`,
+	}
+
+	start := time.Now()
+	pageID, action, err := dedup.ProcessCaptureAsync(req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ProcessCaptureAsync failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	if elapsed >= 150*time.Millisecond {
+		t.Fatalf("ProcessCaptureAsync took %v, expected immediate return before slow download", elapsed)
+	}
+	defer db.DeletePage(pageID)
+
+	dedup.WaitForBackgroundTasks()
+
+	resources, err := db.GetResourcesByPageID(pageID)
+	if err != nil {
+		t.Fatalf("GetResourcesByPageID failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 linked resource after background finalize, got %d", len(resources))
+	}
+
+	page, err := db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	if page == nil {
+		t.Fatalf("expected page %d to exist", pageID)
+	}
+
+	htmlContent, err := os.ReadFile(filepath.Join(fs.baseDir, page.HTMLPath))
+	if err != nil {
+		t.Fatalf("ReadFile page html failed: %v", err)
+	}
+	if !strings.Contains(string(htmlContent), archiveProxyURL(pageID, page.CapturedAt.Format("20060102150405"), cssURL)) {
+		t.Fatalf("background finalize should rewrite CSS URL to archive proxy")
+	}
+}
+
+func TestUpdateCaptureAsync_ReturnsBeforeBackgroundFinalizeCompletes(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer func() {
+		dedup.WaitForBackgroundTasks()
+		db.Close()
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/style-v1.css":
+			w.Header().Set("Content-Type", "text/css")
+			_, _ = w.Write([]byte("body { color: red; }"))
+		case "/style-v2.css":
+			time.Sleep(250 * time.Millisecond)
+			w.Header().Set("Content-Type", "text/css")
+			_, _ = w.Write([]byte("body { color: blue; }"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	pageURL := fmt.Sprintf("%s/page-%d", baseURL, time.Now().UnixNano())
+	createReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "before async update",
+		HTML:  `<html><head><link rel="stylesheet" href="` + baseURL + `/style-v1.css"></head><body>before async update</body></html>`,
+	}
+
+	pageID, action, err := dedup.ProcessCapture(createReq)
+	if err != nil {
+		t.Fatalf("ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID)
+
+	updateReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "after async update",
+		HTML:  `<html><head><link rel="stylesheet" href="` + baseURL + `/style-v2.css"></head><body>after async update</body></html>`,
+	}
+
+	start := time.Now()
+	action, err = dedup.UpdateCaptureAsync(pageID, updateReq)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("UpdateCaptureAsync failed: %v", err)
+	}
+	if action != models.ArchiveActionUpdated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionUpdated)
+	}
+	if elapsed >= 150*time.Millisecond {
+		t.Fatalf("UpdateCaptureAsync took %v, expected immediate return before slow finalize", elapsed)
+	}
+
+	page, err := db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID(before finalize) failed: %v", err)
+	}
+	if page == nil {
+		t.Fatalf("expected page %d to exist", pageID)
+	}
+	if page.Title != "before async update" {
+		t.Fatalf("page title should remain old value until background finalize, got %q", page.Title)
+	}
+
+	dedup.WaitForBackgroundTasks()
+
+	page, err = db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID(after finalize) failed: %v", err)
+	}
+	if page == nil {
+		t.Fatalf("expected page %d to exist after finalize", pageID)
+	}
+	if page.Title != "after async update" {
+		t.Fatalf("page title = %q, want %q", page.Title, "after async update")
+	}
+}
+
+func TestUpdateCaptureAsync_SecondUpdateWinsOverStaleBackgroundTask(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer func() {
+		dedup.WaitForBackgroundTasks()
+		db.Close()
+	}()
+
+	v2Started := make(chan struct{}, 1)
+	releaseV2 := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/style-v1.css":
+			w.Header().Set("Content-Type", "text/css")
+			_, _ = w.Write([]byte("body { color: red; }"))
+		case "/style-v2.css":
+			select {
+			case v2Started <- struct{}{}:
+			default:
+			}
+			<-releaseV2
+			w.Header().Set("Content-Type", "text/css")
+			_, _ = w.Write([]byte("body { color: blue; }"))
+		case "/style-v3.css":
+			w.Header().Set("Content-Type", "text/css")
+			_, _ = w.Write([]byte("body { color: green; }"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	pageURL := fmt.Sprintf("%s/page-%d", baseURL, time.Now().UnixNano())
+	createReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "before async race",
+		HTML:  `<html><head><link rel="stylesheet" href="` + baseURL + `/style-v1.css"></head><body>before async race</body></html>`,
+	}
+
+	pageID, action, err := dedup.ProcessCapture(createReq)
+	if err != nil {
+		t.Fatalf("ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID)
+
+	firstUpdate := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "stale async update",
+		HTML:  `<html><head><link rel="stylesheet" href="` + baseURL + `/style-v2.css"></head><body>first update loses</body></html>`,
+	}
+	secondUpdate := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "winning async update",
+		HTML:  `<html><head><link rel="stylesheet" href="` + baseURL + `/style-v3.css"></head><body>second update wins</body></html>`,
+	}
+
+	action, err = dedup.UpdateCaptureAsync(pageID, firstUpdate)
+	if err != nil {
+		t.Fatalf("first UpdateCaptureAsync failed: %v", err)
+	}
+	if action != models.ArchiveActionUpdated {
+		t.Fatalf("first action = %q, want %q", action, models.ArchiveActionUpdated)
+	}
+
+	select {
+	case <-v2Started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first async update to start slow resource download")
+	}
+
+	action, err = dedup.UpdateCaptureAsync(pageID, secondUpdate)
+	if err != nil {
+		t.Fatalf("second UpdateCaptureAsync failed: %v", err)
+	}
+	if action != models.ArchiveActionUpdated {
+		t.Fatalf("second action = %q, want %q", action, models.ArchiveActionUpdated)
+	}
+
+	close(releaseV2)
+	dedup.WaitForBackgroundTasks()
+
+	page, err := db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	if page == nil {
+		t.Fatalf("expected page %d to exist", pageID)
+	}
+	if page.Title != "winning async update" {
+		t.Fatalf("page title = %q, want %q", page.Title, "winning async update")
+	}
+
+	resources, err := db.GetResourcesByPageID(pageID)
+	if err != nil {
+		t.Fatalf("GetResourcesByPageID failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 linked resource after competing updates, got %d", len(resources))
+	}
+	if resources[0].URL != baseURL+"/style-v3.css" {
+		t.Fatalf("linked resource URL = %q, want %q", resources[0].URL, baseURL+"/style-v3.css")
+	}
+
+	htmlContent, err := os.ReadFile(filepath.Join(fs.baseDir, page.HTMLPath))
+	if err != nil {
+		t.Fatalf("ReadFile page html failed: %v", err)
+	}
+	html := string(htmlContent)
+	if !strings.Contains(html, "second update wins") {
+		t.Fatalf("final HTML should contain winning update body, got: %s", html)
+	}
+	if strings.Contains(html, "first update loses") {
+		t.Fatalf("stale async update should not overwrite final HTML, got: %s", html)
+	}
+}


### PR DESCRIPTION
## Summary
- return archive create/update responses as soon as page metadata is stored, while resource downloads and snapshot finalization continue in the background
- prevent stale background update tasks from overwriting newer snapshots for the same page
- add async regression coverage for immediate responses and competing updates, and document the new API behavior

## Testing
- make test