### PR TITLE
fix: start quiet-page capture after initial stable window

### DIFF
--- a/browser/src/page-freezer.ts
+++ b/browser/src/page-freezer.ts
@@ -133,14 +133,13 @@ export function waitForDOMStable(
     let resolved = false;
 
     const cleanup = () => {
-      if (timer) nativeClearTimeout(timer);
-      if (timeoutId) nativeClearTimeout(timeoutId);
+      if (timer !== null) nativeClearTimeout(timer);
+      if (timeoutId !== null) nativeClearTimeout(timeoutId);
       observer.disconnect();
     };
 
-    const observer = new MutationObserver(() => {
-      lastMutation = Date.now();
-      if (timer) nativeClearTimeout(timer);
+    const scheduleStabilityCheck = () => {
+      if (timer !== null) nativeClearTimeout(timer);
 
       timer = nativeSetTimeout(() => {
         const elapsed = Date.now() - lastMutation;
@@ -151,6 +150,11 @@ export function waitForDOMStable(
           resolve();
         }
       }, stableTime) as unknown as number;
+    };
+
+    const observer = new MutationObserver(() => {
+      lastMutation = Date.now();
+      scheduleStabilityCheck();
     });
 
     observer.observe(document.body, {
@@ -159,6 +163,9 @@ export function waitForDOMStable(
       attributes: true,
       characterData: true
     });
+
+    // Quiet pages also need an initial no-mutations window.
+    scheduleStabilityCheck();
 
     // Timeout protection
     timeoutId = nativeSetTimeout(() => {

--- a/browser/tests/helpers/fake-browser.js
+++ b/browser/tests/helpers/fake-browser.js
@@ -1,0 +1,261 @@
+function createFakeTimers() {
+  let now = 0;
+  let nextTimerId = 1;
+  const timers = new Map();
+
+  function schedule(callback, delay = 0, interval = null) {
+    const id = nextTimerId++;
+    timers.set(id, {
+      callback,
+      interval,
+      runAt: now + delay,
+    });
+    return id;
+  }
+
+  function setTimeout(callback, delay = 0) {
+    return schedule(callback, delay, null);
+  }
+
+  function clearTimeout(id) {
+    timers.delete(id);
+  }
+
+  function setInterval(callback, delay = 0) {
+    return schedule(callback, delay, delay);
+  }
+
+  function clearInterval(id) {
+    timers.delete(id);
+  }
+
+  function advanceTime(ms) {
+    const targetTime = now + ms;
+
+    while (true) {
+      let nextEntry = null;
+
+      for (const [id, timer] of timers) {
+        if (timer.runAt > targetTime) {
+          continue;
+        }
+
+        if (!nextEntry || timer.runAt < nextEntry.runAt || (timer.runAt === nextEntry.runAt && id < nextEntry.id)) {
+          nextEntry = { id, ...timer };
+        }
+      }
+
+      if (!nextEntry) {
+        break;
+      }
+
+      now = nextEntry.runAt;
+
+      if (nextEntry.interval === null) {
+        timers.delete(nextEntry.id);
+      } else {
+        timers.set(nextEntry.id, {
+          callback: nextEntry.callback,
+          interval: nextEntry.interval,
+          runAt: nextEntry.runAt + nextEntry.interval,
+        });
+      }
+
+      nextEntry.callback();
+    }
+
+    now = targetTime;
+  }
+
+  return {
+    advanceTime,
+    clearInterval,
+    clearTimeout,
+    getNow: () => now,
+    setInterval,
+    setTimeout,
+  };
+}
+
+function createFakeMutationObserverClass() {
+  return class FakeMutationObserver {
+    static instances = [];
+
+    constructor(callback) {
+      this.callback = callback;
+      this.disconnected = false;
+      FakeMutationObserver.instances.push(this);
+    }
+
+    observe(target, options) {
+      this.target = target;
+      this.options = options;
+    }
+
+    disconnect() {
+      this.disconnected = true;
+    }
+
+    trigger(records = [{}]) {
+      if (!this.disconnected) {
+        this.callback(records, this);
+      }
+    }
+  };
+}
+
+function createEventTarget() {
+  const listeners = new Map();
+
+  return {
+    addEventListener(type, handler) {
+      const handlers = listeners.get(type) || [];
+      handlers.push(handler);
+      listeners.set(type, handlers);
+    },
+    dispatchEvent(event) {
+      const handlers = listeners.get(event.type) || [];
+      for (const handler of handlers) {
+        handler(event);
+      }
+    },
+    removeEventListener(type, handler) {
+      const handlers = listeners.get(type) || [];
+      listeners.set(type, handlers.filter((current) => current !== handler));
+    },
+  };
+}
+
+function createFakeDOMEnvironment() {
+  const timers = createFakeTimers();
+  const MutationObserver = createFakeMutationObserverClass();
+
+  return {
+    advanceTime: timers.advanceTime,
+    document: {
+      body: {},
+    },
+    getNow: timers.getNow,
+    MutationObserver,
+    window: {
+      clearTimeout: timers.clearTimeout,
+      setTimeout: timers.setTimeout,
+    },
+  };
+}
+
+function createFakeBrowserEnvironment() {
+  const timers = createFakeTimers();
+  const windowEvents = createEventTarget();
+  const documentEvents = createEventTarget();
+  const location = {
+    href: 'https://example.com/articles/quiet-page',
+    hostname: 'example.com',
+  };
+
+  const MutationObserver = createFakeMutationObserverClass();
+  const document = {
+    ...documentEvents,
+    body: {},
+    title: 'Quiet page',
+    visibilityState: 'visible',
+  };
+
+  const windowObject = {
+    ...windowEvents,
+    clearInterval: timers.clearInterval,
+    clearTimeout: timers.clearTimeout,
+    location,
+    requestAnimationFrame: () => 0,
+    scrollY: 0,
+    setInterval: timers.setInterval,
+    setTimeout: timers.setTimeout,
+  };
+  windowObject.self = windowObject;
+  windowObject.top = windowObject;
+
+  return {
+    MutationObserver,
+    advanceTime: timers.advanceTime,
+    document,
+    getNow: timers.getNow,
+    history: {
+      pushState() {},
+      replaceState() {},
+    },
+    location,
+    navigator: {
+      userAgent: 'test-agent',
+    },
+    window: windowObject,
+  };
+}
+
+async function flushMicrotasks(times = 6) {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function installGlobalBindings(bindings) {
+  const originalDateNow = Date.now;
+  const originalGlobals = new Map();
+
+  for (const [name, value] of Object.entries(bindings)) {
+    if (name === 'DateNow') {
+      continue;
+    }
+
+    originalGlobals.set(name, global[name]);
+    if (value === undefined) {
+      delete global[name];
+    } else {
+      global[name] = value;
+    }
+  }
+
+  if (bindings.DateNow) {
+    Date.now = bindings.DateNow;
+  }
+
+  return () => {
+    for (const [name, value] of originalGlobals.entries()) {
+      if (value === undefined) {
+        delete global[name];
+      } else {
+        global[name] = value;
+      }
+    }
+
+    Date.now = originalDateNow;
+  };
+}
+
+function mockCompiledModule(relativePath, exports) {
+  const resolvedPath = require.resolve(relativePath);
+  const originalModule = require.cache[resolvedPath];
+
+  require.cache[resolvedPath] = {
+    exports,
+    filename: resolvedPath,
+    id: resolvedPath,
+    loaded: true,
+  };
+
+  return () => {
+    if (originalModule) {
+      require.cache[resolvedPath] = originalModule;
+      return;
+    }
+
+    delete require.cache[resolvedPath];
+  };
+}
+
+module.exports = {
+  createFakeBrowserEnvironment,
+  createFakeDOMEnvironment,
+  flushMicrotasks,
+  installGlobalBindings,
+  mockCompiledModule,
+};

--- a/browser/tests/main.integration.test.js
+++ b/browser/tests/main.integration.test.js
@@ -1,0 +1,208 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {
+  createFakeBrowserEnvironment,
+  flushMicrotasks,
+  installGlobalBindings,
+  mockCompiledModule,
+} = require('./helpers/fake-browser.js');
+
+function loadMainWithEnvironment(environment, sendToServer) {
+  const mainPath = require.resolve('../dist-test/main.js');
+  const pageFreezerPath = require.resolve('../dist-test/page-freezer.js');
+  const distTestPath = path.join(__dirname, '../dist-test');
+  const restoreGlobals = installGlobalBindings({
+    window: environment.window,
+    document: environment.document,
+    MutationObserver: environment.MutationObserver,
+    location: environment.location,
+    history: environment.history,
+    navigator: environment.navigator,
+    GM_cookie: undefined,
+    DateNow: environment.getNow,
+  });
+
+  delete require.cache[pageFreezerPath];
+  const restoreMocks = [
+    mockCompiledModule(path.join(distTestPath, 'config.js'), {
+      CONFIG: {
+        AUTH_PASSWORD: '',
+        DOM_STABILITY_DELAY: 5,
+        DOM_STABLE_TIME: 25,
+        ENABLE_COMPRESSION: false,
+        FRAME_CAPTURE_TIMEOUT: 100,
+        FRAME_CONTENT_CHECK_INTERVAL: 10,
+        FRAME_CONTENT_WAIT_TIMEOUT: 100,
+        FRAME_DOM_STABLE_TIME: 25,
+        FRAME_MUTATION_OBSERVER_TIMEOUT: 100,
+        MUTATION_OBSERVER_TIMEOUT: 100,
+        REQUEST_TIMEOUT: 100,
+        SERVER_URL: 'http://localhost:8080/api/archive',
+        SPA_TRANSITION_DELAY: 5,
+        TIMER_CLEAR_RANGE: 100,
+        UPDATE_CHECK_INTERVAL: 100,
+        UPDATE_MIN_MUTATIONS: 10,
+        UPDATE_MONITOR_TIMEOUT: 1000,
+      },
+    }),
+    mockCompiledModule(path.join(distTestPath, 'page-filter.js'), {
+      shouldSkipPage: () => false,
+    }),
+    mockCompiledModule(path.join(distTestPath, 'archiver.js'), {
+      sendToServer,
+      updateOnServer: async () => ({ action: 'updated', page_id: 1, status: 'success' }),
+    }),
+    mockCompiledModule(path.join(distTestPath, 'dom-collector.js'), {
+      DOMCollector: class {
+        constructor() {
+          this.collectedCount = 0;
+          this.reachedLimit = false;
+        }
+
+        clear() {}
+
+        handleMutations() {}
+
+        mergeInto(html) {
+          return html;
+        }
+      },
+    }),
+    mockCompiledModule(path.join(distTestPath, 'frame-capture.js'), {
+      captureDocumentHTMLWithFrames: async () => ({
+        frames: [],
+        html: '<html><body>quiet page</body></html>',
+      }),
+      setupFrameCaptureBridge: () => {},
+    }),
+  ];
+
+  delete require.cache[mainPath];
+  require(mainPath);
+
+  return {
+    restore() {
+      delete require.cache[mainPath];
+      delete require.cache[pageFreezerPath];
+      for (const restoreMock of restoreMocks.reverse()) {
+        restoreMock();
+      }
+      restoreGlobals();
+    },
+  };
+}
+
+test('main starts the initial capture on a quiet page after stableTime instead of waiting for timeout', async () => {
+  const environment = createFakeBrowserEnvironment();
+  const sendCalls = [];
+  const { restore } = loadMainWithEnvironment(environment, async (captureData) => {
+    sendCalls.push(captureData);
+    return { action: 'created', page_id: 1, status: 'success' };
+  });
+
+  try {
+    environment.advanceTime(5);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 0, 'capture should not send before DOM_STABLE_TIME elapses');
+
+    environment.advanceTime(24);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 0, 'quiet pages should still wait for the full stable window');
+
+    environment.advanceTime(1);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 1, 'initial capture should be sent as soon as the quiet page is stable');
+    assert.equal(sendCalls[0].url, 'https://example.com/articles/quiet-page');
+    assert.equal(sendCalls[0].title, 'Quiet page');
+    assert.match(sendCalls[0].html, /quiet page/);
+  } finally {
+    restore();
+  }
+});
+
+test('main archives a short quiet-page visit once before pagehide', async () => {
+  const environment = createFakeBrowserEnvironment();
+  const sendCalls = [];
+  const { restore } = loadMainWithEnvironment(environment, async (captureData) => {
+    sendCalls.push(captureData);
+    return { action: 'created', page_id: 1, status: 'success' };
+  });
+
+  try {
+    environment.advanceTime(5);
+    await flushMicrotasks();
+
+    environment.advanceTime(24);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 0, 'short visits should not archive before the page is actually stable');
+
+    environment.advanceTime(1);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 1, 'quiet pages should archive before a user leaves well before the hard timeout');
+
+    environment.window.dispatchEvent({ type: 'pagehide' });
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 1, 'pagehide should not duplicate the initial archive send');
+  } finally {
+    restore();
+  }
+});
+
+test('main archives a short quiet-page visit once before visibilitychange hidden', async () => {
+  const environment = createFakeBrowserEnvironment();
+  const sendCalls = [];
+  const { restore } = loadMainWithEnvironment(environment, async (captureData) => {
+    sendCalls.push(captureData);
+    return { action: 'created', page_id: 1, status: 'success' };
+  });
+
+  try {
+    environment.advanceTime(5);
+    await flushMicrotasks();
+
+    environment.advanceTime(24);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 0, 'hidden flush should not fire before the page is actually stable');
+
+    environment.advanceTime(1);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 1, 'quiet pages should archive before a user hides the tab well before the hard timeout');
+
+    environment.document.visibilityState = 'hidden';
+    environment.document.dispatchEvent({ type: 'visibilitychange' });
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 1, 'visibilitychange hidden should not duplicate the initial archive send');
+  } finally {
+    restore();
+  }
+});
+
+test('main archives a short quiet-page visit once before beforeunload', async () => {
+  const environment = createFakeBrowserEnvironment();
+  const sendCalls = [];
+  const { restore } = loadMainWithEnvironment(environment, async (captureData) => {
+    sendCalls.push(captureData);
+    return { action: 'created', page_id: 1, status: 'success' };
+  });
+
+  try {
+    environment.advanceTime(5);
+    await flushMicrotasks();
+
+    environment.advanceTime(24);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 0, 'beforeunload should not fire before the page is actually stable');
+
+    environment.advanceTime(1);
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 1, 'quiet pages should archive before a user unloads the page well before the hard timeout');
+
+    environment.window.dispatchEvent({ type: 'beforeunload' });
+    await flushMicrotasks();
+    assert.equal(sendCalls.length, 1, 'beforeunload should not duplicate the initial archive send');
+  } finally {
+    restore();
+  }
+});

--- a/browser/tests/page-freezer.test.js
+++ b/browser/tests/page-freezer.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createFakeDOMEnvironment,
+  flushMicrotasks,
+  installGlobalBindings,
+} = require('./helpers/fake-browser.js');
+
+function loadPageFreezer(environment) {
+  const pageFreezerPath = require.resolve('../dist-test/page-freezer.js');
+  const restoreGlobals = installGlobalBindings({
+    window: environment.window,
+    document: environment.document,
+    MutationObserver: environment.MutationObserver,
+    DateNow: environment.getNow,
+  });
+
+  delete require.cache[pageFreezerPath];
+  const pageFreezer = require(pageFreezerPath);
+
+  return {
+    pageFreezer,
+    restore() {
+      delete require.cache[pageFreezerPath];
+      restoreGlobals();
+    },
+  };
+}
+
+test('waitForDOMStable resolves after stableTime on a quiet page', async () => {
+  const environment = createFakeDOMEnvironment();
+  const { pageFreezer, restore } = loadPageFreezer(environment);
+
+  try {
+    let settled = false;
+    const waitPromise = pageFreezer.waitForDOMStable(100, 25).then(() => {
+      settled = true;
+    });
+
+    assert.equal(environment.MutationObserver.instances.length, 1);
+
+    environment.advanceTime(24);
+    await flushMicrotasks();
+    assert.equal(settled, false, 'promise should stay pending until stableTime has fully elapsed');
+
+    environment.advanceTime(1);
+    await waitPromise;
+    assert.equal(settled, true);
+  } finally {
+    restore();
+  }
+});
+
+test('waitForDOMStable only starts the stability timer after the first mutation', async () => {
+  const environment = createFakeDOMEnvironment();
+  const { pageFreezer, restore } = loadPageFreezer(environment);
+
+  try {
+    let settled = false;
+    const waitPromise = pageFreezer.waitForDOMStable(100, 25).then(() => {
+      settled = true;
+    });
+
+    const observer = environment.MutationObserver.instances[0];
+    environment.advanceTime(10);
+    observer.trigger([{ type: 'childList' }]);
+    await flushMicrotasks();
+
+    environment.advanceTime(24);
+    await flushMicrotasks();
+    assert.equal(settled, false);
+
+    environment.advanceTime(1);
+    await waitPromise;
+    assert.equal(settled, true);
+  } finally {
+    restore();
+  }
+});

--- a/browser/tests/spa-coordinator.test.js
+++ b/browser/tests/spa-coordinator.test.js
@@ -3,107 +3,30 @@ const assert = require('node:assert/strict');
 
 const {
   chooseFlushAction,
-  choosePendingFlushDependency,
-  shouldClearAsyncState,
-  shouldCommitMonitorUpdate,
 } = require('../dist-test/spa-coordinator.js');
 
-test('chooseFlushAction sends initial capture before first archive', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
+test('unload flush does nothing when initial capture data was never prepared', () => {
+  const action = chooseFlushAction({
+    capturePrepared: false,
     hasArchived: false,
     sendInFlight: false,
-    currentPageId: null,
-  }), 'send-capture');
-});
-
-test('chooseFlushAction flushes current page with update after initial archive', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
-    hasArchived: true,
-    sendInFlight: false,
-    currentPageId: 42,
-  }), 'update-current-page');
-});
-
-test('chooseFlushAction does nothing when archived page has no page id yet', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
-    hasArchived: true,
-    sendInFlight: false,
-    currentPageId: null,
-  }), 'none');
-});
-
-test('chooseFlushAction does not start a second flush while send is in flight', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
-    hasArchived: false,
-    sendInFlight: true,
-    currentPageId: null,
-  }), 'none');
-});
-
-test('chooseFlushAction skips final flush when document is hidden', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
-    hasArchived: true,
-    sendInFlight: false,
-    currentPageId: 42,
-    documentHidden: true,
-  }), 'none');
-});
-
-test('chooseFlushAction still sends initial capture when page hides before first archive', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
-    hasArchived: false,
-    sendInFlight: false,
-    currentPageId: null,
-    documentHidden: true,
-  }), 'send-capture');
-});
-
-test('chooseFlushAction does not start a second update while final flush is in flight', () => {
-  assert.equal(chooseFlushAction({
-    capturePrepared: true,
-    hasArchived: true,
-    sendInFlight: false,
-    currentPageId: 42,
-    updateInFlight: true,
-  }), 'none');
-});
-
-test('choosePendingFlushDependency waits for in-flight initial send', () => {
-  assert.equal(choosePendingFlushDependency({
-    sendInFlight: true,
     updateInFlight: false,
-  }), 'send');
+    documentHidden: false,
+    currentPageId: null,
+  });
+
+  assert.equal(action, 'none');
 });
 
-test('choosePendingFlushDependency does not wait for in-flight page update during navigation reset', () => {
-  assert.equal(choosePendingFlushDependency({
+test('unload flush sends the initial capture once data is ready', () => {
+  const action = chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
     sendInFlight: false,
-    updateInFlight: true,
-  }), 'none');
-});
+    updateInFlight: false,
+    documentHidden: false,
+    currentPageId: null,
+  });
 
-test('shouldCommitMonitorUpdate rejects stale async work after SPA reset', () => {
-  assert.equal(shouldCommitMonitorUpdate(3, 4, 42, 42), false);
-});
-
-test('shouldCommitMonitorUpdate rejects updates when current page id changed', () => {
-  assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 43), false);
-});
-
-test('shouldCommitMonitorUpdate allows current async work for same page epoch', () => {
-  assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 42), true);
-});
-
-test('shouldClearAsyncState only clears the currently tracked promise', async () => {
-  const settledPromise = Promise.resolve();
-  const newerPromise = new Promise(() => {});
-
-  assert.equal(shouldClearAsyncState(settledPromise, settledPromise), true);
-  assert.equal(shouldClearAsyncState(newerPromise, settledPromise), false);
+  assert.equal(action, 'send-capture');
 });

--- a/browser/tests/spa-coordinator.test.js
+++ b/browser/tests/spa-coordinator.test.js
@@ -3,7 +3,66 @@ const assert = require('node:assert/strict');
 
 const {
   chooseFlushAction,
+  choosePendingFlushDependency,
+  shouldClearAsyncState,
+  shouldCommitMonitorUpdate,
 } = require('../dist-test/spa-coordinator.js');
+
+test('chooseFlushAction sends initial capture before first archive', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
+    sendInFlight: false,
+    currentPageId: null,
+  }), 'send-capture');
+});
+
+test('chooseFlushAction flushes current page with update after initial archive', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: 42,
+  }), 'update-current-page');
+});
+
+test('chooseFlushAction does nothing when archived page has no page id yet', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: null,
+  }), 'none');
+});
+
+test('chooseFlushAction does not start a second flush while send is in flight', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
+    sendInFlight: true,
+    currentPageId: null,
+  }), 'none');
+});
+
+test('chooseFlushAction skips final flush when document is hidden', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: 42,
+    documentHidden: true,
+  }), 'none');
+});
+
+test('chooseFlushAction still sends initial capture when page hides before first archive', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: false,
+    sendInFlight: false,
+    currentPageId: null,
+    documentHidden: true,
+  }), 'send-capture');
+});
 
 test('unload flush does nothing when initial capture data was never prepared', () => {
   const action = chooseFlushAction({
@@ -29,4 +88,48 @@ test('unload flush sends the initial capture once data is ready', () => {
   });
 
   assert.equal(action, 'send-capture');
+});
+
+test('chooseFlushAction does not start a second update while final flush is in flight', () => {
+  assert.equal(chooseFlushAction({
+    capturePrepared: true,
+    hasArchived: true,
+    sendInFlight: false,
+    currentPageId: 42,
+    updateInFlight: true,
+  }), 'none');
+});
+
+test('choosePendingFlushDependency waits for in-flight initial send', () => {
+  assert.equal(choosePendingFlushDependency({
+    sendInFlight: true,
+    updateInFlight: false,
+  }), 'send');
+});
+
+test('choosePendingFlushDependency does not wait for in-flight page update during navigation reset', () => {
+  assert.equal(choosePendingFlushDependency({
+    sendInFlight: false,
+    updateInFlight: true,
+  }), 'none');
+});
+
+test('shouldCommitMonitorUpdate rejects stale async work after SPA reset', () => {
+  assert.equal(shouldCommitMonitorUpdate(3, 4, 42, 42), false);
+});
+
+test('shouldCommitMonitorUpdate rejects updates when current page id changed', () => {
+  assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 43), false);
+});
+
+test('shouldCommitMonitorUpdate allows current async work for same page epoch', () => {
+  assert.equal(shouldCommitMonitorUpdate(3, 3, 42, 42), true);
+});
+
+test('shouldClearAsyncState only clears the currently tracked promise', async () => {
+  const settledPromise = Promise.resolve();
+  const newerPromise = new Promise(() => {});
+
+  assert.equal(shouldClearAsyncState(settledPromise, settledPromise), true);
+  assert.equal(shouldClearAsyncState(newerPromise, settledPromise), false);
 });

--- a/browser/tsconfig.test.json
+++ b/browser/tsconfig.test.json
@@ -5,6 +5,6 @@
     "outDir": "./dist-test",
     "rootDir": "./src"
   },
-  "include": ["src/spa-coordinator.ts"],
+  "include": ["src/spa-coordinator.ts", "src/page-freezer.ts", "src/main.ts"],
   "exclude": ["node_modules", "dist", "dist-test"]
 }


### PR DESCRIPTION
## Summary
- start the DOM stability timer immediately so quiet pages can prepare and send the first archive after the initial stable window instead of waiting for the hard timeout
- add browser unit and integration coverage for quiet-page initial capture timing plus beforeunload, pagehide, and visibilitychange flush paths
- extract shared fake browser test helpers and restore the broader flush coordinator assertions while keeping the new regression coverage

## Testing
- npm test