### PR TITLE
fix: harden resource matching and fallback regressions

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -23,8 +23,8 @@ This directory contains security-related documentation for Wayback Archiver.
 - Prevents cross-site request forgery (CSRF)
 
 ### Cookie Leakage Prevention
-- Only forwards cookies to same root domain
-- Supports multi-segment TLDs (co.uk, com.au, etc.)
+- Only forwards cookies to the same registrable domain
+- Uses the public suffix list to handle multi-segment TLDs correctly
 
 ### Resource Size Limits
 - Maximum download size: 200MB

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -602,10 +602,32 @@ func cachedLastModified(cached *resourceCacheEntry) string {
 	return cached.lastMod
 }
 
-// processResourceFallback 下载失败时的兜底逻辑
-// 下载失败时直接返回错误，避免静默复用旧版本资源导致错误归档。
+// processResourceFallback 下载失败时的兜底逻辑。
+// 仅允许复用同一 URL 的历史资源，并要求本地文件仍然存在，避免跨 URL 误复用。
 func (d *Deduplicator) processResourceFallback(url string, downloadErr error) (int64, string, []byte, error) {
-	return 0, "", nil, fmt.Errorf("download failed: %w", downloadErr)
+	resource, err := d.db.GetResourceByURL(url)
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("download failed: %w (fallback lookup failed: %v)", downloadErr, err)
+	}
+	if resource == nil || resource.FilePath == "" {
+		return 0, "", nil, fmt.Errorf("download failed: %w", downloadErr)
+	}
+
+	filePath := filepath.Join(d.storage.baseDir, resource.FilePath)
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			return 0, "", nil, fmt.Errorf("download failed: %w", downloadErr)
+		}
+		return 0, "", nil, fmt.Errorf("download failed: %w (fallback stat failed: %v)", downloadErr, err)
+	}
+
+	if err := d.db.UpdateResourceLastSeen(resource.ID); err != nil {
+		return 0, "", nil, fmt.Errorf("download failed: %w (fallback last_seen update failed: %v)", downloadErr, err)
+	}
+
+	d.cacheStore(url, resource.ID, resource.FilePath, nil)
+	log.Printf("Fallback: reusing previous resource (ID: %d) for: %s", resource.ID, shortURLForLog(url))
+	return resource.ID, resource.FilePath, nil, nil
 }
 
 type cssWorkItem struct {

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -281,6 +281,39 @@ func TestProcessResource_DownloadFailureDoesNotFallbackAcrossQueryVariants(t *te
 	}
 }
 
+func TestProcessResource_DownloadFailureFallsBackToExactURL(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer db.Close()
+	cssToken := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte("body { color: red; } /* " + cssToken + " */"))
+	}))
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	pageURL := baseURL + "/page"
+	resourceURL := fmt.Sprintf("%s/style.css?token=%d", baseURL, time.Now().UnixNano())
+
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	if err != nil {
+		t.Fatalf("first ProcessResource failed: %v", err)
+	}
+
+	server.Close()
+
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	if err != nil {
+		t.Fatalf("expected exact URL fallback to succeed, got: %v", err)
+	}
+	if resourceID2 != resourceID1 {
+		t.Fatalf("fallback should reuse exact URL resource ID, got %d want %d", resourceID2, resourceID1)
+	}
+	if filePath2 != filePath1 {
+		t.Fatalf("fallback should reuse exact URL file path, got %q want %q", filePath2, filePath1)
+	}
+}
+
 func TestProcessResource_LastModifiedRevalidationAvoidsBodyRedownload(t *testing.T) {
 	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
 	defer db.Close()

--- a/server/internal/storage/filesystem.go
+++ b/server/internal/storage/filesystem.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 const (
@@ -471,37 +473,23 @@ func isSameRootDomain(url1, url2 string) bool {
 	return getRootDomain(parsed1.Hostname()) == getRootDomain(parsed2.Hostname())
 }
 
-// getRootDomain extracts the root domain using public suffix list logic
+// getRootDomain extracts the registrable domain using the public suffix list.
 // e.g. "kp.m-team.cc" -> "m-team.cc", "img.example.co.uk" -> "example.co.uk"
 func getRootDomain(hostname string) string {
-	// 使用简化的公共后缀列表（常见的多段 TLD）
-	multiSegmentTLDs := map[string]bool{
-		"co.uk": true, "co.jp": true, "co.kr": true, "co.nz": true, "co.za": true,
-		"com.au": true, "com.br": true, "com.cn": true, "com.hk": true, "com.tw": true,
-		"net.au": true, "org.uk": true, "gov.uk": true, "ac.uk": true,
-		"ne.jp": true, "or.jp": true, "go.jp": true,
+	hostname = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(hostname)), ".")
+	if hostname == "" {
+		return ""
 	}
-
-	parts := strings.Split(hostname, ".")
-	if len(parts) <= 1 {
+	if ip := net.ParseIP(hostname); ip != nil {
 		return hostname
 	}
 
-	// 检查是否为多段 TLD（如 co.uk）
-	if len(parts) >= 3 {
-		twoSegmentSuffix := strings.Join(parts[len(parts)-2:], ".")
-		if multiSegmentTLDs[twoSegmentSuffix] {
-			// 返回 domain + TLD（如 example.co.uk）
-			return strings.Join(parts[len(parts)-3:], ".")
-		}
+	root, err := publicsuffix.EffectiveTLDPlusOne(hostname)
+	if err != nil {
+		return hostname
 	}
 
-	// 默认返回最后两段（如 example.com）
-	if len(parts) >= 2 {
-		return strings.Join(parts[len(parts)-2:], ".")
-	}
-
-	return hostname
+	return root
 }
 
 // SaveResource 保存资源文件，按哈希组织目录

--- a/server/internal/storage/security_test.go
+++ b/server/internal/storage/security_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"net"
 	"testing"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 func TestValidateResourceURL(t *testing.T) {
@@ -69,9 +71,9 @@ func TestValidateResourceURL(t *testing.T) {
 
 func TestIsPrivateIP(t *testing.T) {
 	tests := []struct {
-		name    string
-		ip      string
-		isPriv  bool
+		name   string
+		ip     string
+		isPriv bool
 	}{
 		// Private IPv4
 		{"10.0.0.1", "10.0.0.1", true},
@@ -163,5 +165,51 @@ func TestGetRootDomain(t *testing.T) {
 				t.Errorf("getRootDomain(%s) = %s, want %s", tt.hostname, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetRootDomain_PublicSuffixCoverage(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+	}{
+		{name: "com.sg subdomain", hostname: "foo.example.com.sg"},
+		{name: "com.sg sibling site", hostname: "bar.other.com.sg"},
+		{name: "net.cn subdomain", hostname: "img.example.net.cn"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, err := publicsuffix.EffectiveTLDPlusOne(tt.hostname)
+			if err != nil {
+				t.Fatalf("EffectiveTLDPlusOne(%s) failed: %v", tt.hostname, err)
+			}
+
+			got := getRootDomain(tt.hostname)
+			if got != want {
+				t.Fatalf("getRootDomain(%s) = %s, want %s", tt.hostname, got, want)
+			}
+		})
+	}
+}
+
+func TestIsSameRootDomain_PublicSuffixSeparation(t *testing.T) {
+	pageURL := "https://foo.example.com.sg/page"
+	resourceURL := "https://bar.other.com.sg/static/app.css"
+
+	pageRoot, err := publicsuffix.EffectiveTLDPlusOne("foo.example.com.sg")
+	if err != nil {
+		t.Fatalf("page EffectiveTLDPlusOne failed: %v", err)
+	}
+	resourceRoot, err := publicsuffix.EffectiveTLDPlusOne("bar.other.com.sg")
+	if err != nil {
+		t.Fatalf("resource EffectiveTLDPlusOne failed: %v", err)
+	}
+	if pageRoot == resourceRoot {
+		t.Fatalf("test setup invalid: %s and %s should not share registrable domain", pageRoot, resourceRoot)
+	}
+
+	if isSameRootDomain(pageURL, resourceURL) {
+		t.Fatalf("isSameRootDomain(%q, %q) = true, want false", pageURL, resourceURL)
 	}
 }

--- a/tests/server/test_download_fallback.js
+++ b/tests/server/test_download_fallback.js
@@ -1,5 +1,6 @@
 const puppeteer = require('puppeteer');
 const { execSync } = require('child_process');
+const path = require('path');
 
 /**
  * 测试下载失败兜底逻辑：
@@ -8,9 +9,12 @@ const { execSync } = require('child_process');
  * 3. 验证页面渲染正常
  */
 
-const WAYBACK = 'http://localhost:8080';
+const WAYBACK = process.env.WAYBACK || 'http://localhost:8080';
 const FAKE_URL = 'https://fallback-test-unreachable.invalid/fallback-style.css';
 const CSS_CONTENT = 'body { background-color: #ff6600 !important; color: white; }';
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const DATA_DIR = process.env.WAYBACK_DATA_DIR || path.join(ROOT_DIR, 'data');
+const DB_USER = process.env.DB_USER || process.env.USER || 'postgres';
 
 let passed = 0, failed = 0;
 const failures = [];
@@ -25,26 +29,23 @@ async function test() {
 
   const crypto = require('crypto');
   const fs = require('fs');
-  const path = require('path');
 
   // 计算 CSS 内容哈希
   const hash = crypto.createHash('sha256').update(CSS_CONTENT).digest('hex');
 
   // 写入资源文件到磁盘
-  const os = require('os');
-  const dataDir = path.join(os.homedir(), 'IdeaProjects/wayback/server/data');
-  const resDir = path.join(dataDir, 'resources', hash.slice(0, 2), hash.slice(2, 4));
+  const resDir = path.join(DATA_DIR, 'resources', hash.slice(0, 2), hash.slice(2, 4));
   fs.mkdirSync(resDir, { recursive: true });
   const filePath = path.join(resDir, hash + '.css');
   fs.writeFileSync(filePath, CSS_CONTENT);
-  const relPath = path.relative(dataDir, filePath);
+  const relPath = path.relative(DATA_DIR, filePath);
   console.log(`Step 1: Wrote resource file to disk: ${relPath}`);
 
   // 直接插入 DB 记录
   const insertSQL = `INSERT INTO resources (url, content_hash, resource_type, file_path, file_size, first_seen, last_seen)
     VALUES ('${FAKE_URL}', '${hash}', 'css', '${relPath}', ${CSS_CONTENT.length}, NOW(), NOW())
     ON CONFLICT DO NOTHING`;
-  execSync(`psql -U postgres -d wayback -c "${insertSQL}"`);
+  execSync(`psql -U ${DB_USER} -d wayback -c "${insertSQL}"`);
   console.log('  Inserted resource record into DB');
 
   // Step 2: 归档页面，引用该不可达 URL
@@ -85,6 +86,19 @@ async function test() {
     failures.push('Could not find page in search');
     console.log('  [FAIL] Could not find page. Results:', JSON.stringify(searchData));
   } else {
+    const rewrittenDeadline = Date.now() + 15000;
+    let rewrittenHTML = '';
+    while (Date.now() < rewrittenDeadline) {
+      const viewRes = await fetch(`${WAYBACK}/view/${pageInfo.id}`);
+      rewrittenHTML = await viewRes.text();
+      if (rewrittenHTML.includes('/archive/') && rewrittenHTML.includes(FAKE_URL)) {
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+    assert('Archived HTML rewritten before render', rewrittenHTML.includes('/archive/'),
+      'timed out waiting for async finalize to rewrite resource URLs');
+
     const browser = await puppeteer.launch({
       headless: true,
       executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',


### PR DESCRIPTION
## Summary
- switch same-site cookie forwarding to public suffix based registrable-domain matching and add regression coverage for public suffix edge cases
- restore exact-URL resource fallback when a download fails, while still rejecting cross-query fallback and requiring the archived file to exist locally
- make the download fallback E2E test use the current workspace data directory and wait for async archive finalize before asserting rewritten output

## Testing
- make test
- go test ./internal/storage -run 'TestProcessResource_(DownloadFailureDoesNotFallbackAcrossQueryVariants|DownloadFailureFallsBackToExactURL)'
- WAYBACK=http://127.0.0.1:18080 node tests/server/test_download_fallback.js