### PR TITLE
fix: detect MIME type for archived font files

### DIFF
--- a/server/internal/api/font_mime_regression_test.go
+++ b/server/internal/api/font_mime_regression_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"wayback/internal/storage"
+)
+
+func TestArchivedCSSFontSubresource_PreservesWOFF2ContentType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dataDir := t.TempDir()
+	fs := storage.NewFileStorage(dataDir)
+	hash := strings.Repeat("a", 64)
+
+	// Minimal WOFF2 signature is enough for this regression test.
+	fontData := append([]byte("wOF2"), []byte("test-font-payload")...)
+	relPath, err := fs.SaveResource(fontData, hash, "font")
+	if err != nil {
+		t.Fatalf("SaveResource() error = %v", err)
+	}
+
+	parser := storage.NewCSSParser()
+	css := `@font-face { src: url("../fonts/app.woff2") format("woff2"); }`
+	rewritten := rewriteCSSForPage(parser, css, "https://example.com/assets/css/app.css", func(resourceURL string) (string, bool) {
+		if resourceURL == "https://example.com/assets/fonts/app.woff2" {
+			return relPath, true
+		}
+		return "", false
+	})
+
+	archivedURL := "/archive/" + relPath
+	if !strings.Contains(rewritten, archivedURL) {
+		t.Fatalf("rewritten CSS = %q, want %q", rewritten, archivedURL)
+	}
+	if !strings.HasSuffix(relPath, ".font") {
+		t.Fatalf("saved font path = %q, want synthetic .font extension for reproduction", relPath)
+	}
+
+	handler := &Handler{dataDir: dataDir}
+	router := gin.New()
+	router.GET("/archive/resources/*filepath", handler.ServeLocalResource)
+
+	req := httptest.NewRequest(http.MethodGet, archivedURL, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "font/woff2") {
+		t.Fatalf("Content-Type = %q, want font/woff2 for archived WOFF2 font", contentType)
+	}
+}

--- a/server/internal/api/helpers.go
+++ b/server/internal/api/helpers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -32,4 +33,46 @@ func detectFontType(filePath string) string {
 	default:
 		return "font/woff2"
 	}
+}
+
+// detectArchivedFontType inspects stored .font files to recover the original font MIME type.
+func detectArchivedFontType(filePath string) string {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "application/octet-stream"
+	}
+	defer f.Close()
+
+	header := make([]byte, 36)
+	n, err := f.Read(header)
+	if err != nil || n == 0 {
+		return "application/octet-stream"
+	}
+
+	return detectFontTypeFromHeader(header[:n])
+}
+
+func detectFontTypeFromHeader(header []byte) string {
+	if len(header) >= 4 {
+		switch string(header[:4]) {
+		case "wOFF":
+			return "font/woff"
+		case "wOF2":
+			return "font/woff2"
+		case "OTTO":
+			return "font/otf"
+		case "true":
+			return "font/ttf"
+		}
+
+		if header[0] == 0x00 && header[1] == 0x01 && header[2] == 0x00 && header[3] == 0x00 {
+			return "font/ttf"
+		}
+	}
+
+	if len(header) >= 36 && header[34] == 'L' && header[35] == 'P' {
+		return "application/vnd.ms-fontobject"
+	}
+
+	return "application/octet-stream"
 }

--- a/server/internal/api/helpers_test.go
+++ b/server/internal/api/helpers_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -105,6 +107,59 @@ func TestDetectFontType(t *testing.T) {
 			got := detectFontType(tt.filePath)
 			if got != tt.want {
 				t.Errorf("detectFontType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectArchivedFontType(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{
+			name: "woff",
+			data: []byte("wOFFtest-font"),
+			want: "font/woff",
+		},
+		{
+			name: "woff2",
+			data: []byte("wOF2test-font"),
+			want: "font/woff2",
+		},
+		{
+			name: "ttf",
+			data: []byte{0x00, 0x01, 0x00, 0x00, 't', 'e', 's', 't'},
+			want: "font/ttf",
+		},
+		{
+			name: "otf",
+			data: []byte("OTTOtest-font"),
+			want: "font/otf",
+		},
+		{
+			name: "eot",
+			data: append(make([]byte, 34), 'L', 'P'),
+			want: "application/vnd.ms-fontobject",
+		},
+		{
+			name: "unknown",
+			data: []byte("not-a-font"),
+			want: "application/octet-stream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "font.font")
+			if err := os.WriteFile(filePath, tt.data, 0644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			got := detectArchivedFontType(filePath)
+			if got != tt.want {
+				t.Fatalf("detectArchivedFontType() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/server/internal/api/streaming_test.go
+++ b/server/internal/api/streaming_test.go
@@ -88,13 +88,14 @@ func TestServeFileStreaming_ContentTypes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		filename    string
-		content     string
-		wantType    string
+		filename string
+		content  string
+		wantType string
 	}{
 		{"style.css", "body{}", "text/css"},
 		{"script.js", "var x=1;", "javascript"},
 		{"image.img", "\x89PNG", "application/octet-stream"},
+		{"archived.font", "wOF2", "font/woff2"},
 		{"font.woff2", "\x00\x01", "font/woff2"},
 		{"font.ttf", "\x00\x01", "font/ttf"},
 	}

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -464,6 +464,8 @@ func detectContentTypeByPath(filePath string) string {
 		return "image/svg+xml"
 	case ".ico":
 		return "image/x-icon"
+	case ".font":
+		return detectArchivedFontType(filePath)
 	case ".woff":
 		return "font/woff"
 	case ".woff2":


### PR DESCRIPTION
## Summary
- detect the original MIME type for archived `.font` resources from their file signatures so archived `@font-face` loads no longer fall back to `application/octet-stream`
- add unit coverage for archived font signature detection and streaming content-type handling for `.font` files
- add an end-to-end regression test covering the saved resource, CSS rewrite, and `/archive/resources/...` serving path

## Testing
- make test