### PR TITLE
fix: match archived resource cookies to browser rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 **Capture Notes:**
 - `/api/archive` and `/api/archive/:id` reject decompressed JSON bodies larger than 32 MiB with HTTP `413`
 - Cross-origin iframe snapshots remain enabled, but the browser bridge now signs requests and returns frame HTML over a private `MessageChannel` instead of public `window.postMessage`
+- Resource downloads only forward cookies that still match the target URL under browser rules (`hostOnly`, `domain`, `path`, `secure`, expiry, `SameSite`, partition top-level site)
 - The browser script skips local/private targets including `localhost`, `127.0.0.1`, `172.16.0.0/12`, `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`, and `.local`
 
 ## API

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -15,7 +15,7 @@
 // ==/UserScript==
 
 import { CONFIG } from './config';
-import { CaptureData } from './types';
+import { CaptureCookie, CaptureData } from './types';
 import { shouldSkipPage } from './page-filter';
 import { waitForDOMStable } from './page-freezer';
 import { sendToServer, updateOnServer } from './archiver';
@@ -72,6 +72,7 @@ function initializeArchiver(): void {
 
   async function captureSnapshot(
     headers?: Record<string, string>,
+    cookies?: CaptureCookie[],
     expectedEpoch = pageEpoch,
     pageContext?: CapturePageContext,
   ): Promise<CaptureData | null> {
@@ -94,7 +95,47 @@ function initializeArchiver(): void {
       html,
       frames: captured.frames,
       headers,
+      cookies,
     };
+  }
+
+  async function collectCaptureCookies(): Promise<CaptureCookie[] | undefined> {
+    if (typeof GM_cookie === 'undefined' || !GM_cookie.list) {
+      return undefined;
+    }
+
+    try {
+      const cookies = await new Promise<Tampermonkey.Cookie[]>((resolve, reject) => {
+        GM_cookie.list({ domain: location.hostname }, (listedCookies, error) => {
+          if (error) {
+            reject(new Error(error));
+            return;
+          }
+          resolve(listedCookies || []);
+        });
+      });
+
+      if (cookies.length === 0) {
+        return undefined;
+      }
+
+      return cookies.map((cookie) => ({
+        name: cookie.name,
+        value: cookie.value,
+        domain: cookie.domain,
+        path: cookie.path,
+        host_only: cookie.hostOnly,
+        secure: cookie.secure,
+        http_only: cookie.httpOnly,
+        session: cookie.session,
+        same_site: cookie.sameSite,
+        expiration_date: cookie.expirationDate,
+        partition_top_level_site: cookie.partitionKey?.topLevelSite,
+      }));
+    } catch (error) {
+      console.warn('[Wayback] GM_cookie not available:', error);
+      return undefined;
+    }
   }
 
   function shouldAcceptUpdatedHTML(newHTML: string): boolean {
@@ -122,27 +163,17 @@ function initializeArchiver(): void {
         return;
       }
 
-      // Collect cookies (including HttpOnly) via GM_cookie
+      // Collect cookies (including HttpOnly) via GM_cookie so the server can
+      // re-apply browser matching rules per resource URL.
       let headers: Record<string, string> | undefined;
-      if (typeof GM_cookie !== 'undefined' && GM_cookie.list) {
-        try {
-          const cookieStr = await new Promise<string>((resolve) => {
-            GM_cookie.list({ domain: location.hostname }, (cookies: Array<{ name: string; value: string }>) => {
-              resolve(cookies.map(c => `${c.name}=${c.value}`).join('; '));
-            });
-          });
-          if (cookieStr) {
-            headers = {
-              cookie: cookieStr,
-              'user-agent': navigator.userAgent,
-            };
-          }
-        } catch (e) {
-          console.warn('[Wayback] GM_cookie not available:', e);
-        }
+      const cookies = await collectCaptureCookies();
+      if (navigator.userAgent) {
+        headers = {
+          'user-agent': navigator.userAgent,
+        };
       }
 
-      const preparedCapture = await captureSnapshot(headers, expectedEpoch);
+      const preparedCapture = await captureSnapshot(headers, cookies, expectedEpoch);
       if (!preparedCapture) {
         return;
       }
@@ -227,7 +258,7 @@ function initializeArchiver(): void {
     let activeFlushPromise: Promise<void> | null = null;
     activeFlushPromise = (async () => {
       try {
-        const newCaptureData = await captureSnapshot(captureData?.headers, flushEpoch, pageContext);
+        const newCaptureData = await captureSnapshot(captureData?.headers, captureData?.cookies, flushEpoch, pageContext);
         if (!newCaptureData || !shouldAcceptUpdatedHTML(newCaptureData.html)) {
           return;
         }
@@ -346,7 +377,7 @@ function initializeArchiver(): void {
         try {
           console.log(`[Wayback] DOM changed (${currentMutations} mutations), triggering update...`);
 
-          const newCaptureData = await captureSnapshot(captureData?.headers, monitorEpoch);
+          const newCaptureData = await captureSnapshot(captureData?.headers, captureData?.cookies, monitorEpoch);
           if (!newCaptureData || !shouldAcceptUpdatedHTML(newCaptureData.html)) {
             return;
           }

--- a/browser/src/types.ts
+++ b/browser/src/types.ts
@@ -6,6 +6,21 @@ export interface CaptureData {
   html: string;
   frames?: FrameCapture[];
   headers?: Record<string, string>;
+  cookies?: CaptureCookie[];
+}
+
+export interface CaptureCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  host_only: boolean;
+  secure: boolean;
+  http_only: boolean;
+  session: boolean;
+  same_site?: string;
+  expiration_date?: number;
+  partition_top_level_site?: string;
 }
 
 export interface FrameCapture {

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -23,7 +23,8 @@ This directory contains security-related documentation for Wayback Archiver.
 - Prevents cross-site request forgery (CSRF)
 
 ### Cookie Leakage Prevention
-- Only forwards cookies to the same registrable domain
+- Re-applies browser-style cookie matching before each resource request
+- Checks domain / hostOnly / path / secure / expiry / SameSite / partition top-level site
 - Uses the public suffix list to handle multi-segment TLDs correctly
 
 ### Resource Size Limits

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -32,6 +32,21 @@ type CaptureRequest struct {
 	HTML    string            `json:"html" binding:"required"`
 	Frames  []FrameCapture    `json:"frames"`
 	Headers map[string]string `json:"headers"`
+	Cookies []CaptureCookie   `json:"cookies,omitempty"`
+}
+
+type CaptureCookie struct {
+	Name                  string  `json:"name" binding:"required"`
+	Value                 string  `json:"value"`
+	Domain                string  `json:"domain" binding:"required"`
+	Path                  string  `json:"path"`
+	HostOnly              bool    `json:"host_only"`
+	Secure                bool    `json:"secure"`
+	HTTPOnly              bool    `json:"http_only"`
+	Session               bool    `json:"session"`
+	SameSite              string  `json:"same_site,omitempty"`
+	ExpirationDate        float64 `json:"expiration_date,omitempty"`
+	PartitionTopLevelSite string  `json:"partition_top_level_site,omitempty"`
 }
 
 type FrameCapture struct {

--- a/server/internal/storage/cookie_header.go
+++ b/server/internal/storage/cookie_header.go
@@ -1,0 +1,182 @@
+package storage
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"wayback/internal/models"
+)
+
+type matchedCookie struct {
+	name  string
+	value string
+	path  string
+}
+
+func buildCookieHeader(resourceURL, pageURL string, cookies []models.CaptureCookie) string {
+	return buildCookieHeaderAt(resourceURL, pageURL, cookies, time.Now())
+}
+
+func buildCookieHeaderAt(resourceURL, pageURL string, cookies []models.CaptureCookie, now time.Time) string {
+	if len(cookies) == 0 {
+		return ""
+	}
+
+	resourceParsed, err := url.Parse(resourceURL)
+	if err != nil || resourceParsed.Hostname() == "" {
+		return ""
+	}
+
+	requestHost := normalizeHostname(resourceParsed.Hostname())
+	requestPath := resourceParsed.EscapedPath()
+	if requestPath == "" {
+		requestPath = "/"
+	}
+
+	matched := make([]matchedCookie, 0, len(cookies))
+	for _, cookie := range cookies {
+		if !cookieMatchesRequest(cookie, requestHost, requestPath, resourceParsed.Scheme, resourceURL, pageURL, now) {
+			continue
+		}
+		matched = append(matched, matchedCookie{
+			name:  cookie.Name,
+			value: cookie.Value,
+			path:  normalizedCookiePath(cookie.Path),
+		})
+	}
+
+	if len(matched) == 0 {
+		return ""
+	}
+
+	// Browsers send more specific paths first. We do not have creation-time
+	// metadata, so keep the remaining order deterministic by cookie name.
+	sort.SliceStable(matched, func(i, j int) bool {
+		if len(matched[i].path) != len(matched[j].path) {
+			return len(matched[i].path) > len(matched[j].path)
+		}
+		return matched[i].name < matched[j].name
+	})
+
+	parts := make([]string, 0, len(matched))
+	for _, cookie := range matched {
+		parts = append(parts, cookie.name+"="+cookie.value)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func cookieMatchesRequest(cookie models.CaptureCookie, requestHost, requestPath, requestScheme, resourceURL, pageURL string, now time.Time) bool {
+	if cookie.Name == "" || cookie.Domain == "" {
+		return false
+	}
+	if !cookie.Session && cookie.ExpirationDate > 0 && cookie.ExpirationDate <= float64(now.Unix()) {
+		return false
+	}
+	if cookie.Secure && !strings.EqualFold(requestScheme, "https") {
+		return false
+	}
+	if !cookieDomainMatches(cookie, requestHost) {
+		return false
+	}
+	if !cookiePathMatches(normalizedCookiePath(cookie.Path), requestPath) {
+		return false
+	}
+	if !cookiePartitionMatches(cookie, pageURL) {
+		return false
+	}
+	if !cookieSameSiteAllows(cookie, pageURL, resourceURL) {
+		return false
+	}
+	return true
+}
+
+func cookieDomainMatches(cookie models.CaptureCookie, requestHost string) bool {
+	cookieDomain := normalizeCookieDomain(cookie.Domain)
+	if cookieDomain == "" || requestHost == "" {
+		return false
+	}
+	if cookie.HostOnly {
+		return requestHost == cookieDomain
+	}
+	if requestHost == cookieDomain {
+		return true
+	}
+	return strings.HasSuffix(requestHost, "."+cookieDomain)
+}
+
+func cookiePathMatches(cookiePath, requestPath string) bool {
+	if cookiePath == requestPath {
+		return true
+	}
+	if !strings.HasPrefix(requestPath, cookiePath) {
+		return false
+	}
+	if strings.HasSuffix(cookiePath, "/") {
+		return true
+	}
+	if len(requestPath) == len(cookiePath) {
+		return true
+	}
+	return requestPath[len(cookiePath)] == '/'
+}
+
+func cookieSameSiteAllows(cookie models.CaptureCookie, pageURL, resourceURL string) bool {
+	sameSite := strings.ToLower(strings.TrimSpace(cookie.SameSite))
+	switch sameSite {
+	case "strict", "lax":
+		return isSchemefulSameSite(pageURL, resourceURL)
+	default:
+		return true
+	}
+}
+
+func cookiePartitionMatches(cookie models.CaptureCookie, pageURL string) bool {
+	if strings.TrimSpace(cookie.PartitionTopLevelSite) == "" {
+		return true
+	}
+	pageSite, ok := canonicalSiteForCookies(pageURL)
+	if !ok {
+		return false
+	}
+	partitionSite, ok := canonicalSiteForCookies(cookie.PartitionTopLevelSite)
+	if !ok {
+		return false
+	}
+	return pageSite == partitionSite
+}
+
+func isSchemefulSameSite(url1, url2 string) bool {
+	site1, ok1 := canonicalSiteForCookies(url1)
+	site2, ok2 := canonicalSiteForCookies(url2)
+	return ok1 && ok2 && site1 == site2
+}
+
+func canonicalSiteForCookies(raw string) (string, bool) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return "", false
+	}
+	host := normalizeHostname(parsed.Hostname())
+	if host == "" {
+		return "", false
+	}
+	return strings.ToLower(parsed.Scheme) + "://" + getRootDomain(host), true
+}
+
+func normalizeCookieDomain(domain string) string {
+	domain = normalizeHostname(domain)
+	return strings.TrimPrefix(domain, ".")
+}
+
+func normalizeHostname(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}
+
+func normalizedCookiePath(path string) string {
+	if path == "" || path[0] != '/' {
+		return "/"
+	}
+	return path
+}

--- a/server/internal/storage/cookie_header_test.go
+++ b/server/internal/storage/cookie_header_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"wayback/internal/models"
+)
+
+func TestBuildCookieHeaderAt_FiltersByBrowserRules(t *testing.T) {
+	now := time.Unix(1_710_000_000, 0)
+	pageURL := "https://app.example.com/dashboard"
+	resourceURL := "https://cdn.example.com/assets/app.css"
+
+	header := buildCookieHeaderAt(resourceURL, pageURL, []models.CaptureCookie{
+		{Name: "shared", Value: "1", Domain: ".example.com", Path: "/"},
+		{Name: "asset", Value: "1", Domain: ".example.com", Path: "/assets"},
+		{Name: "hostonly", Value: "1", Domain: "app.example.com", Path: "/", HostOnly: true},
+		{Name: "wrongpath", Value: "1", Domain: ".example.com", Path: "/account"},
+		{Name: "expired", Value: "1", Domain: ".example.com", Path: "/", ExpirationDate: float64(now.Unix() - 1)},
+		{Name: "secure", Value: "1", Domain: ".example.com", Path: "/", Secure: true},
+	}, now)
+
+	if header != "asset=1; secure=1; shared=1" {
+		t.Fatalf("cookie header = %q, want %q", header, "asset=1; secure=1; shared=1")
+	}
+}
+
+func TestBuildCookieHeaderAt_RespectsSchemefulSameSite(t *testing.T) {
+	now := time.Unix(1_710_000_000, 0)
+
+	t.Run("blocks lax cookie on cross-scheme subresource", func(t *testing.T) {
+		header := buildCookieHeaderAt(
+			"https://cdn.example.com/app.js",
+			"http://app.example.com/page",
+			[]models.CaptureCookie{{Name: "lax", Value: "1", Domain: ".example.com", Path: "/", SameSite: "lax"}},
+			now,
+		)
+		if header != "" {
+			t.Fatalf("cookie header = %q, want empty header", header)
+		}
+	})
+
+	t.Run("allows strict cookie on same-site subresource", func(t *testing.T) {
+		header := buildCookieHeaderAt(
+			"https://cdn.example.com/app.js",
+			"https://app.example.com/page",
+			[]models.CaptureCookie{{Name: "strict", Value: "1", Domain: ".example.com", Path: "/", SameSite: "strict"}},
+			now,
+		)
+		if header != "strict=1" {
+			t.Fatalf("cookie header = %q, want %q", header, "strict=1")
+		}
+	})
+}
+
+func TestBuildCookieHeaderAt_RespectsPartitionTopLevelSite(t *testing.T) {
+	now := time.Unix(1_710_000_000, 0)
+	header := buildCookieHeaderAt(
+		"https://cdn.example.com/app.js",
+		"https://app.example.com/page",
+		[]models.CaptureCookie{
+			{Name: "match", Value: "1", Domain: ".example.com", Path: "/", PartitionTopLevelSite: "https://example.com"},
+			{Name: "mismatch", Value: "1", Domain: ".example.com", Path: "/", PartitionTopLevelSite: "https://other.com"},
+		},
+		now,
+	)
+
+	if header != "match=1" {
+		t.Fatalf("cookie header = %q, want %q", header, "match=1")
+	}
+}

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -415,7 +415,7 @@ func (d *Deduplicator) cacheStoreWithMetadata(key string, resourceID int64, file
 // ProcessResource 处理单个资源：下载、去重、存储
 // 返回 (resourceID, filePath, data, error)
 // 小文件（≤ streamThreshold）保留在内存供当前调用链使用；缓存只保留元数据
-func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string, headers map[string]string) (int64, string, []byte, error) {
+func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string, headers map[string]string, cookies []models.CaptureCookie) (int64, string, []byte, error) {
 	startTime := time.Now()
 	cached := d.loadCachedResource(url)
 	if resourceID, filePath, reused, err := d.tryReuseFreshCache(url, cached); err != nil {
@@ -439,6 +439,7 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 		url,
 		pageURL,
 		headers,
+		cookies,
 		streamThreshold,
 		cachedETag(cached),
 		cachedLastModified(cached),
@@ -460,7 +461,7 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 		}
 		if resource == nil || resource.FilePath == "" {
 			d.cacheDelete(url)
-			data, hash, tmpPath, metadata, trace, err = d.storage.DownloadResourceWithMetadata(url, pageURL, headers, streamThreshold, "", "")
+			data, hash, tmpPath, metadata, trace, err = d.storage.DownloadResourceWithMetadata(url, pageURL, headers, cookies, streamThreshold, "", "")
 			if err != nil {
 				log.Printf("Download failed for %s after cache revalidation miss: %v", url, err)
 				return d.processResourceFallback(url, err)
@@ -694,7 +695,7 @@ func archiveProxyURL(pageID int64, timestamp, originalURL string) string {
 	return fmt.Sprintf("/archive/%d/%smp_/%s", pageID, timestamp, originalURL)
 }
 
-func (d *Deduplicator) rewriteIframeTagsByKey(htmlContent string, pageID int64, timestamp string, headers map[string]string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) string {
+func (d *Deduplicator) rewriteIframeTagsByKey(htmlContent string, pageID int64, timestamp string, headers map[string]string, cookies []models.CaptureCookie, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) string {
 	if len(frameMap) == 0 {
 		return htmlContent
 	}
@@ -709,7 +710,7 @@ func (d *Deduplicator) rewriteIframeTagsByKey(htmlContent string, pageID int64, 
 			return tag
 		}
 
-		resourceID, _, err := d.archiveFrameCapture(frame, headers, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
+		resourceID, _, err := d.archiveFrameCapture(frame, headers, cookies, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
 		if err != nil {
 			log.Printf("Failed to process iframe capture %s: %v", frame.URL, err)
 			return tag
@@ -767,7 +768,7 @@ func (d *Deduplicator) processInlineResource(url, resourceType string, data []by
 	return resourceID, filePath, data, nil
 }
 
-func (d *Deduplicator) processCSSWorkItems(cssWorkItems []cssWorkItem, pageURL string, headers map[string]string, rewriter *URLRewriter, resourceIDs *[]int64, seen map[int64]struct{}) {
+func (d *Deduplicator) processCSSWorkItems(cssWorkItems []cssWorkItem, pageURL string, headers map[string]string, cookies []models.CaptureCookie, rewriter *URLRewriter, resourceIDs *[]int64, seen map[int64]struct{}) {
 	type cssSubResource struct {
 		absoluteURL string
 	}
@@ -801,7 +802,7 @@ func (d *Deduplicator) processCSSWorkItems(cssWorkItems []cssWorkItem, pageURL s
 			d.globalSem <- struct{}{}
 			defer func() { <-d.globalSem }()
 
-			resID, filePath, _, err := d.ProcessResource(sub.absoluteURL, d.guessResourceType(sub.absoluteURL), pageURL, headers)
+			resID, filePath, _, err := d.ProcessResource(sub.absoluteURL, d.guessResourceType(sub.absoluteURL), pageURL, headers, cookies)
 			resultsCh <- cssSubResult{sub: sub, resID: resID, filePath: filePath, err: err}
 		}(sub)
 	}
@@ -821,7 +822,7 @@ func (d *Deduplicator) processCSSWorkItems(cssWorkItems []cssWorkItem, pageURL s
 	}
 }
 
-func (d *Deduplicator) archiveFrameCapture(frame models.FrameCapture, headers map[string]string, pageID int64, timestamp string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) (int64, string, error) {
+func (d *Deduplicator) archiveFrameCapture(frame models.FrameCapture, headers map[string]string, cookies []models.CaptureCookie, pageID int64, timestamp string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) (int64, string, error) {
 	if cached, ok := archived[frame.URL]; ok {
 		appendUniqueResourceID(resourceIDs, seen, cached.resourceID)
 		return cached.resourceID, cached.filePath, nil
@@ -832,7 +833,7 @@ func (d *Deduplicator) archiveFrameCapture(frame models.FrameCapture, headers ma
 	visiting[frame.URL] = true
 	defer delete(visiting, frame.URL)
 
-	rewrittenHTML, err := d.rewriteCapturedHTML(frame.HTML, frame.URL, headers, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
+	rewrittenHTML, err := d.rewriteCapturedHTML(frame.HTML, frame.URL, headers, cookies, pageID, timestamp, frameMap, resourceIDs, seen, visiting, archived)
 	if err != nil {
 		return 0, "", err
 	}
@@ -847,7 +848,7 @@ func (d *Deduplicator) archiveFrameCapture(frame models.FrameCapture, headers ma
 	return resourceID, filePath, nil
 }
 
-func (d *Deduplicator) rewriteCapturedHTML(htmlContent, baseURL string, headers map[string]string, pageID int64, timestamp string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) (string, error) {
+func (d *Deduplicator) rewriteCapturedHTML(htmlContent, baseURL string, headers map[string]string, cookies []models.CaptureCookie, pageID int64, timestamp string, frameMap map[string]models.FrameCapture, resourceIDs *[]int64, seen map[int64]struct{}, visiting map[string]bool, archived map[string]processedInlineHTML) (string, error) {
 	htmlResources := d.htmlExtractor.ExtractResources(htmlContent, baseURL)
 	frameURLs := buildFrameURLSet(frameMap)
 	rewriter := NewURLRewriter()
@@ -864,7 +865,7 @@ func (d *Deduplicator) rewriteCapturedHTML(htmlContent, baseURL string, headers 
 			}
 		}
 
-		resourceID, filePath, data, err := d.ProcessResource(res.URL, res.Type, baseURL, headers)
+		resourceID, filePath, data, err := d.ProcessResource(res.URL, res.Type, baseURL, headers, cookies)
 		if err != nil {
 			log.Printf("Failed to process resource %s: %v", res.URL, err)
 			continue
@@ -888,10 +889,10 @@ func (d *Deduplicator) rewriteCapturedHTML(htmlContent, baseURL string, headers 
 		}
 	}
 
-	d.processCSSWorkItems(cssWorkItems, baseURL, headers, rewriter, resourceIDs, seen)
+	d.processCSSWorkItems(cssWorkItems, baseURL, headers, cookies, rewriter, resourceIDs, seen)
 
 	normalizedHTML := ResolveRelativeURLs(NormalizeHTMLURLs(htmlContent), baseURL)
-	normalizedHTML = d.rewriteIframeTagsByKey(normalizedHTML, pageID, timestamp, headers, frameMap, resourceIDs, seen, visiting, archived)
+	normalizedHTML = d.rewriteIframeTagsByKey(normalizedHTML, pageID, timestamp, headers, cookies, frameMap, resourceIDs, seen, visiting, archived)
 	return rewriter.RewriteHTML(normalizedHTML), nil
 }
 
@@ -1019,7 +1020,7 @@ func (d *Deduplicator) updateCapture(pageID int64, req *models.CaptureRequest, s
 	var resourceIDs []int64
 	processStart := time.Now()
 	resourceIDSet := make(map[int64]struct{})
-	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
+	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, req.Cookies, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
 	if err != nil {
 		return "", fmt.Errorf("rewrite html failed: %w", err)
 	}
@@ -1071,7 +1072,7 @@ func (d *Deduplicator) finalizeCreateCapture(pageID int64, tempHTMLPath string, 
 	var resourceIDs []int64
 	startTime := time.Now()
 	resourceIDSet := make(map[int64]struct{})
-	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
+	rewrittenHTML, err := d.rewriteCapturedHTML(req.HTML, req.URL, req.Headers, req.Cookies, pageID, timestamp, frameMap, &resourceIDs, resourceIDSet, make(map[string]bool), make(map[string]processedInlineHTML))
 	if err != nil {
 		return fmt.Errorf("rewrite html failed: %w", err)
 	}

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -56,14 +56,14 @@ func TestProcessResource_SameURLChangedContentCreatesNewVersion(t *testing.T) {
 	resourceURL := fmt.Sprintf("%s/app.js?nonce=%d", baseURL, time.Now().UnixNano())
 	pageURL := baseURL + "/page"
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("ProcessResource(v1) failed: %v", err)
 	}
 
 	content = "console.log('v2');"
 
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("ProcessResource(v2) failed: %v", err)
 	}
@@ -117,11 +117,11 @@ func TestProcessResource_FreshCacheSkipsRedownload(t *testing.T) {
 	resourceURL := fmt.Sprintf("%s/style.css?nonce=%d", baseURL, time.Now().UnixNano())
 	pageURL := baseURL + "/page"
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("first ProcessResource failed: %v", err)
 	}
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("second ProcessResource failed: %v", err)
 	}
@@ -161,11 +161,11 @@ func TestProcessResource_ETagRevalidationAvoidsBodyRedownload(t *testing.T) {
 	resourceURL := fmt.Sprintf("%s/etag-style.css?nonce=%d", baseURL, time.Now().UnixNano())
 	pageURL := baseURL + "/page"
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("first ProcessResource failed: %v", err)
 	}
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("second ProcessResource failed: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestProcessResource_304NoCacheDoesNotRestoreOldFreshness(t *testing.T) {
 	resourceURL := fmt.Sprintf("%s/no-cache-304.css?nonce=%d", baseURL, time.Now().UnixNano())
 	pageURL := baseURL + "/page"
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("first ProcessResource failed: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestProcessResource_304NoCacheDoesNotRestoreOldFreshness(t *testing.T) {
 	cached.freshUntil = time.Now().Add(-time.Second)
 	cached.cachedAt = time.Now()
 
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("second ProcessResource failed: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestProcessResource_304NoCacheDoesNotRestoreOldFreshness(t *testing.T) {
 		t.Fatalf("304 with Cache-Control: no-cache should clear freshness window")
 	}
 
-	resourceID3, filePath3, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID3, filePath3, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("third ProcessResource failed: %v", err)
 	}
@@ -270,13 +270,13 @@ func TestProcessResource_DownloadFailureDoesNotFallbackAcrossQueryVariants(t *te
 	resourceURL1 := baseURL + "/style.css?token=one"
 	resourceURL2 := baseURL + "/style.css?token=two"
 
-	if _, _, _, err := dedup.ProcessResource(resourceURL1, "css", pageURL, nil); err != nil {
+	if _, _, _, err := dedup.ProcessResource(resourceURL1, "css", pageURL, nil, nil); err != nil {
 		t.Fatalf("ProcessResource(resourceURL1) failed: %v", err)
 	}
 
 	server.Close()
 
-	if _, _, _, err := dedup.ProcessResource(resourceURL2, "css", pageURL, nil); err == nil {
+	if _, _, _, err := dedup.ProcessResource(resourceURL2, "css", pageURL, nil, nil); err == nil {
 		t.Fatalf("expected download failure for query variant without unsafe fallback")
 	}
 }
@@ -295,14 +295,14 @@ func TestProcessResource_DownloadFailureFallsBackToExactURL(t *testing.T) {
 	pageURL := baseURL + "/page"
 	resourceURL := fmt.Sprintf("%s/style.css?token=%d", baseURL, time.Now().UnixNano())
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("first ProcessResource failed: %v", err)
 	}
 
 	server.Close()
 
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("expected exact URL fallback to succeed, got: %v", err)
 	}
@@ -338,11 +338,11 @@ func TestProcessResource_LastModifiedRevalidationAvoidsBodyRedownload(t *testing
 	resourceURL := fmt.Sprintf("%s/last-modified.js?nonce=%d", baseURL, time.Now().UnixNano())
 	pageURL := baseURL + "/page"
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("first ProcessResource failed: %v", err)
 	}
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "js", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("second ProcessResource failed: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestProcessResource_ExpiredFreshCacheTriggersRedownload(t *testing.T) {
 	resourceURL := fmt.Sprintf("%s/expired-style.css?nonce=%d", baseURL, time.Now().UnixNano())
 	pageURL := baseURL + "/page"
 
-	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID1, filePath1, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("first ProcessResource failed: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestProcessResource_ExpiredFreshCacheTriggersRedownload(t *testing.T) {
 	cached.freshUntil = time.Now().Add(-time.Second)
 	cached.cachedAt = time.Now()
 
-	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil)
+	resourceID2, filePath2, _, err := dedup.ProcessResource(resourceURL, "css", pageURL, nil, nil)
 	if err != nil {
 		t.Fatalf("second ProcessResource failed: %v", err)
 	}

--- a/server/internal/storage/filesystem.go
+++ b/server/internal/storage/filesystem.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"golang.org/x/net/publicsuffix"
+	"wayback/internal/models"
 )
 
 const (
@@ -216,13 +217,13 @@ func (fs *FileStorage) SaveHTML(url, html string, timestamp time.Time) (string, 
 
 // DownloadResource 下载资源并计算哈希，支持可选的认证 headers
 // 小于 streamThreshold 的资源读入内存返回 data；大于的流式写入临时文件返回 tmpPath
-func (fs *FileStorage) DownloadResource(resourceURL string, pageURL string, headers map[string]string, streamThreshold int64) (data []byte, hash string, tmpPath string, err error) {
-	data, hash, tmpPath, _, _, err = fs.DownloadResourceWithMetadata(resourceURL, pageURL, headers, streamThreshold, "", "")
+func (fs *FileStorage) DownloadResource(resourceURL string, pageURL string, headers map[string]string, cookies []models.CaptureCookie, streamThreshold int64) (data []byte, hash string, tmpPath string, err error) {
+	data, hash, tmpPath, _, _, err = fs.DownloadResourceWithMetadata(resourceURL, pageURL, headers, cookies, streamThreshold, "", "")
 	return data, hash, tmpPath, err
 }
 
 // DownloadResourceWithMetadata downloads a resource and returns cache validators/freshness metadata.
-func (fs *FileStorage) DownloadResourceWithMetadata(resourceURL string, pageURL string, headers map[string]string, streamThreshold int64, ifNoneMatch string, ifModifiedSince string) (data []byte, hash string, tmpPath string, metadata downloadMetadata, trace downloadTrace, err error) {
+func (fs *FileStorage) DownloadResourceWithMetadata(resourceURL string, pageURL string, headers map[string]string, cookies []models.CaptureCookie, streamThreshold int64, ifNoneMatch string, ifModifiedSince string) (data []byte, hash string, tmpPath string, metadata downloadMetadata, trace downloadTrace, err error) {
 	validateStart := time.Now()
 	// 防止 SSRF 攻击：拒绝内网地址和云元数据服务
 	if err := validateResourceURL(resourceURL); err != nil {
@@ -252,8 +253,7 @@ func (fs *FileStorage) DownloadResourceWithMetadata(resourceURL string, pageURL 
 		req.Header.Set("If-Modified-Since", ifModifiedSince)
 	}
 
-	// 仅在同根域名时转发 Cookie，防止泄露给第三方
-	if cookie, ok := headers["cookie"]; ok && cookie != "" && isSameRootDomain(resourceURL, pageURL) {
+	if cookie := buildCookieHeader(resourceURL, pageURL, cookies); cookie != "" {
 		req.Header.Set("Cookie", cookie)
 	}
 

--- a/server/internal/storage/filesystem_security_test.go
+++ b/server/internal/storage/filesystem_security_test.go
@@ -222,8 +222,8 @@ func TestIsSameRootDomain(t *testing.T) {
 // TestDownloadResource_CookieLeakage 测试 Cookie 泄露防护
 func TestDownloadResource_CookieLeakage(t *testing.T) {
 	// httptest.Server 使用 127.0.0.1，会被 SSRF 保护拦截
-	// Cookie 泄露防护的逻辑在 isSameRootDomain 中，已通过 TestIsSameRootDomain 测试
-	t.Skip("SSRF protection blocks localhost - Cookie protection tested via TestIsSameRootDomain")
+	// Cookie 过滤逻辑通过 buildCookieHeaderAt 的单元测试覆盖。
+	t.Skip("SSRF protection blocks localhost - cookie matching tested via TestBuildCookieHeaderAt")
 }
 
 // TestDownloadResource_SSRFProtection 测试 SSRF 防护
@@ -231,7 +231,7 @@ func TestDownloadResource_SSRFProtection(t *testing.T) {
 	fs := NewFileStorage(t.TempDir())
 
 	// 尝试访问内网地址
-	_, _, _, err := fs.DownloadResource("http://127.0.0.1:8080/admin", "", nil, 2*1024*1024)
+	_, _, _, err := fs.DownloadResource("http://127.0.0.1:8080/admin", "", nil, nil, 2*1024*1024)
 	if err == nil {
 		t.Fatal("Expected SSRF protection to block localhost")
 	}
@@ -253,7 +253,7 @@ func BenchmarkDownloadResource(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _, err := fs.DownloadResource(server.URL, "", nil, 2*1024*1024)
+		_, _, _, err := fs.DownloadResource(server.URL, "", nil, nil, 2*1024*1024)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/tests/server/test_update_feature.js
+++ b/tests/server/test_update_feature.js
@@ -31,6 +31,22 @@ const SERVER = 'http://localhost:8080';
     }
   }
 
+  async function waitForPageTitle(pageId, expectedTitle, timeoutMs = 5000) {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      const res = await fetch(`${SERVER}/api/pages/${pageId}`);
+      if (res.ok) {
+        const page = await res.json();
+        if (page && page.title === expectedTitle) {
+          return;
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    throw new Error(`Timed out waiting for page ${pageId} title to become ${expectedTitle}`);
+  }
+
   // ============================================================
   // Test 1: POST /api/archive returns page_id and action
   // ============================================================
@@ -139,6 +155,8 @@ h1 { color: #363; }
   check('PUT returns status success', updateData.status === 'success', `got status: ${updateData.status}`);
   check('PUT returns same page_id', updateData.page_id === pageId, `got page_id: ${updateData.page_id}, expected: ${pageId}`);
   check('PUT returns action=updated', updateData.action === 'updated', `got action: ${updateData.action}`);
+
+  await waitForPageTitle(pageId, 'Update Test - Updated');
 
   // ============================================================
   // Test 5: PUT same content returns unchanged


### PR DESCRIPTION
## Summary
- collect structured cookie metadata from the browser capture and re-apply browser-style matching rules per resource request on the server
- only forward cookies whose host, path, scheme, expiry, SameSite, and partition context still match the target resource URL
- stabilize the update feature E2E test by waiting for the first async update to persist before asserting a second identical PUT is unchanged

## Testing
- go test ./...
- npm test --prefix browser
- make test-e2e