### PR TITLE
fix: reject opaque null origins in CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,9 @@ COMPRESSION_LEVEL=-1
 
 # CORS Configuration - Comma-separated list of allowed origins
 # For local development:
-ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080,null
+ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080
 # For remote deployment, add your domain:
-# ALLOWED_ORIGINS=https://your-domain.com,http://localhost:8080,null
+# ALLOWED_ORIGINS=https://your-domain.com,http://localhost:8080
 
 # Authentication (REQUIRED for remote deployment)
 AUTH_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The server automatically loads `.env` from the working directory if it exists. Y
 | `DB_SSLMODE` | `disable` | PostgreSQL SSL mode used by the server connection |
 | `SERVER_HOST` | `127.0.0.1` | Server bind address (`0.0.0.0` = all interfaces, `127.0.0.1` = localhost only) |
 | `SERVER_PORT` | `8080` | HTTP server port |
-| `ALLOWED_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080,null` | CORS allowed origins (comma-separated). For remote deployment, add your domain: `https://your-domain.com,null` |
+| `ALLOWED_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080` | CORS allowed origins (comma-separated). For remote deployment, add your domain: `https://your-domain.com` |
 | `DATA_DIR` | `./data` | Storage directory for HTML and resources |
 | `LOG_DIR` | `./data/logs` | Log file directory |
 | `AUTH_PASSWORD` | *(empty)* | HTTP Basic Auth password (disabled when empty, username: `wayback`). **REQUIRED for remote deployment** |
@@ -181,7 +181,7 @@ Quick setup:
 
 ```bash
 # .env configuration
-ALLOWED_ORIGINS=https://your-domain.com,null
+ALLOWED_ORIGINS=https://your-domain.com
 AUTH_PASSWORD=your_secure_password
 SERVER_HOST=0.0.0.0
 
@@ -195,6 +195,7 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 - Always use HTTPS for remote deployment
 - Set a strong `AUTH_PASSWORD`
 - Limit `ALLOWED_ORIGINS` to trusted domains only
+- `Origin: null` is intentionally rejected because it also covers sandboxed iframes and data/file-backed opaque origins
 - Both CORS and Basic Auth are required for security (defense in depth)
 
 **Performance Notes:**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,8 +17,8 @@
 ### 远程部署支持
 
 - 新增 `ALLOWED_ORIGINS` 环境变量，支持配置 CORS 白名单
-- 默认值：`http://localhost:8080,http://127.0.0.1:8080,null`
-- 远程部署时可添加自定义域名：`ALLOWED_ORIGINS=https://your-domain.com,null`
+- 默认值：`http://localhost:8080,http://127.0.0.1:8080`
+- 远程部署时可添加自定义域名：`ALLOWED_ORIGINS=https://your-domain.com`
 
 ### 资源大小限制调整
 
@@ -31,7 +31,7 @@
 
 ```bash
 # CORS 配置（逗号分隔的允许来源列表）
-ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080,null
+ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080
 ```
 
 ### 配置文件
@@ -102,7 +102,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 2. **更新配置**（可选）
    ```bash
    # 如果需要远程部署，添加 ALLOWED_ORIGINS
-   export ALLOWED_ORIGINS=https://your-domain.com,null
+   export ALLOWED_ORIGINS=https://your-domain.com
    ```
 
 3. **重启服务**
@@ -125,6 +125,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 1. ✅ 远程部署时设置 `AUTH_PASSWORD`
 2. ✅ 使用 HTTPS（通过 Nginx/Caddy 反向代理）
 3. ✅ 限制 `ALLOWED_ORIGINS` 仅包含信任的域名
+4. ✅ 拒绝 `Origin: null` 这类 opaque origins（包含 sandbox iframe / data URL / file-backed 页面）
 
 ### 推荐执行
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -62,7 +62,7 @@ VERSION=v1.0.0
 BUILD_TIME=2026-03-16
 
 # Optional: Configure CORS
-ALLOWED_ORIGINS=http://localhost:8080,https://your-domain.com,null
+ALLOWED_ORIGINS=http://localhost:8080,https://your-domain.com
 
 # Optional: Set authentication password
 AUTH_PASSWORD=your-secure-password
@@ -78,7 +78,7 @@ For remote deployment, you MUST set `AUTH_PASSWORD`:
 ```bash
 # In .env file
 AUTH_PASSWORD=your-secure-password
-ALLOWED_ORIGINS=https://your-domain.com,null
+ALLOWED_ORIGINS=https://your-domain.com
 ```
 
 Then update your userscript to include the password:

--- a/docs/REMOTE_DEPLOYMENT.md
+++ b/docs/REMOTE_DEPLOYMENT.md
@@ -52,7 +52,7 @@ SERVER_PORT=8080
 # Security (REQUIRED)
 AUTH_PASSWORD=your_auth_password
 ENABLE_DEBUG_API=false
-ALLOWED_ORIGINS=http://your-server-ip:8080,null
+ALLOWED_ORIGINS=http://your-server-ip:8080
 
 # Storage
 DATA_DIR=/var/wayback/data

--- a/docs/security/FIXES_2026-03-14.md
+++ b/docs/security/FIXES_2026-03-14.md
@@ -14,8 +14,9 @@
 - 配合 Basic Auth，恶意网页可以诱导用户浏览器发起请求
 
 **修复方案**：
-- 限制 CORS 仅允许本地来源：`http://localhost:8080`, `http://127.0.0.1:8080`, `null` (file://)
+- 限制 CORS 仅允许显式白名单中的可信来源，默认仅包含：`http://localhost:8080`, `http://127.0.0.1:8080`
 - 添加 `Access-Control-Allow-Credentials: true` 支持认证
+- 拒绝 `Origin: null` 这类 opaque origins（包含 sandbox iframe、data URL 与 file-backed 页面）
 - 拒绝所有外部来源的跨域请求
 
 **测试验证**：✓ 所有 CORS 测试通过

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -19,7 +19,8 @@ This directory contains security-related documentation for Wayback Archiver.
 
 ### CORS Protection
 - Configurable origin whitelist via `ALLOWED_ORIGINS`
-- Default: localhost and file:// protocol only
+- Default: localhost only (`http://localhost:8080`, `http://127.0.0.1:8080`)
+- Rejects `Origin: null` because it also includes sandboxed iframes and data/file-backed opaque origins
 - Prevents cross-site request forgery (CSRF)
 
 ### Cookie Leakage Prevention

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -53,12 +53,17 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 		allowedOrigins[trimmed] = struct{}{}
 	}
 
-	// CORS 中间件 - 仅允许本地来源，防止 CSRF 攻击
+	// CORS 中间件 - 仅允许显式白名单中的 http(s) 来源；拒绝 Origin: null 这类 opaque origin
 	r.Use(func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
-		if _, ok := allowedOrigins[origin]; ok {
-			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
-			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		if origin != "" {
+			c.Writer.Header().Add("Vary", "Origin")
+		}
+		if origin != "null" {
+			if _, ok := allowedOrigins[origin]; ok {
+				c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+				c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
 		}
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, PUT, GET, DELETE, OPTIONS")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")

--- a/server/internal/api/routes_test.go
+++ b/server/internal/api/routes_test.go
@@ -138,6 +138,24 @@ func TestRoutes_CORS_AllowedOriginsEnvOverridesDefaultLocalhostSet(t *testing.T)
 	}
 }
 
+func TestRoutes_CORS_NullOriginIsRejectedEvenIfConfigured(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{
+		AllowedOrigins: []string{"null", "http://localhost:8080"},
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/api/archive", nil)
+	req.Header.Set("Origin", "null")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want null origin blocked", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("Access-Control-Allow-Credentials = %q, want null origin blocked", got)
+	}
+}
+
 func TestRoutes_DebugAPI_DisabledByDefault(t *testing.T) {
 	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -39,11 +39,29 @@ type ServerConfig struct {
 var defaultAllowedOrigins = []string{
 	"http://localhost:8080",
 	"http://127.0.0.1:8080",
-	"null",
 }
 
 func DefaultAllowedOrigins() []string {
 	return append([]string(nil), defaultAllowedOrigins...)
+}
+
+// sanitizeAllowedOrigins removes unsupported opaque origins such as Origin: null.
+// `null` is sent not only by file:// pages, but also by sandboxed iframes and data URLs.
+func sanitizeAllowedOrigins(origins []string) []string {
+	result := make([]string, 0, len(origins))
+	seen := make(map[string]struct{}, len(origins))
+	for _, origin := range origins {
+		trimmed := strings.TrimSpace(origin)
+		if trimmed == "" || trimmed == "null" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
 }
 
 // StorageConfig holds storage settings
@@ -92,7 +110,7 @@ func LoadFromEnv() (*Config, error) {
 		Server: ServerConfig{
 			Host:             getEnv("SERVER_HOST", "127.0.0.1"),
 			Port:             getEnvInt("SERVER_PORT", 8080),
-			AllowedOrigins:   getEnvCSV("ALLOWED_ORIGINS", defaultAllowedOrigins),
+			AllowedOrigins:   sanitizeAllowedOrigins(getEnvCSV("ALLOWED_ORIGINS", defaultAllowedOrigins)),
 			EnableDebugAPI:   getEnvBool("ENABLE_DEBUG_API", false),
 			CompressionLevel: getEnvInt("COMPRESSION_LEVEL", -1), // -1 = DefaultCompression
 		},

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -239,7 +239,7 @@ func TestLoadFromEnv_DefaultAllowedOrigins(t *testing.T) {
 		t.Fatalf("LoadFromEnv() error = %v", err)
 	}
 
-	want := []string{"http://localhost:8080", "http://127.0.0.1:8080", "null"}
+	want := []string{"http://localhost:8080", "http://127.0.0.1:8080"}
 	if len(cfg.Server.AllowedOrigins) != len(want) {
 		t.Fatalf("AllowedOrigins len = %d, want %d (%v)", len(cfg.Server.AllowedOrigins), len(want), cfg.Server.AllowedOrigins)
 	}
@@ -258,7 +258,7 @@ func TestLoadFromEnv_CustomAllowedOrigins(t *testing.T) {
 		t.Fatalf("LoadFromEnv() error = %v", err)
 	}
 
-	want := []string{"https://allowed.example.com", "https://admin.example.com", "null"}
+	want := []string{"https://allowed.example.com", "https://admin.example.com"}
 	if len(cfg.Server.AllowedOrigins) != len(want) {
 		t.Fatalf("AllowedOrigins len = %d, want %d (%v)", len(cfg.Server.AllowedOrigins), len(want), cfg.Server.AllowedOrigins)
 	}


### PR DESCRIPTION
## Summary
- remove `null` from the default CORS allowlist and sanitize `ALLOWED_ORIGINS` so opaque origins are never accepted
- explicitly reject `Origin: null` in the API CORS middleware and add regression coverage for both config parsing and preflight handling
- update README and deployment/security docs so examples no longer recommend `null` and explain why it is blocked

## Testing
- `make test`