### PR TITLE
refactor: inline legacy schema upgrades at startup

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -97,6 +97,15 @@ createdb -U postgres wayback
 psql -U postgres wayback < init_db.sql
 ```
 
+> **旧版本升级说明：** 从 **`< 1.1.0`** 升级到 `1.1.0` 或更新版本时，需要补齐 `pages.snapshot_state` 列。当前版本服务启动时会自动补齐这组变更；如果数据库账号没有 `ALTER TABLE` 权限，也可以手动执行下面这组幂等 SQL：
+>
+> ```sql
+> ALTER TABLE pages ADD COLUMN IF NOT EXISTS snapshot_state VARCHAR(16);
+> UPDATE pages SET snapshot_state = 'ready' WHERE snapshot_state IS NULL OR snapshot_state = '';
+> ALTER TABLE pages ALTER COLUMN snapshot_state SET DEFAULT 'pending';
+> ALTER TABLE pages ALTER COLUMN snapshot_state SET NOT NULL;
+> ```
+
 ### 3. 启动服务器
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ createdb wayback
 psql wayback < init_db.sql
 ```
 
+> **Upgrade note for existing installs:** Any installation upgrading from **`< 1.1.0`** to `1.1.0` or later needs the `pages.snapshot_state` column. Current server builds automatically apply this change during startup; if your database user does not have `ALTER TABLE` permission, run the following idempotent SQL manually first:
+>
+> ```sql
+> ALTER TABLE pages ADD COLUMN IF NOT EXISTS snapshot_state VARCHAR(16);
+> UPDATE pages SET snapshot_state = 'ready' WHERE snapshot_state IS NULL OR snapshot_state = '';
+> ALTER TABLE pages ALTER COLUMN snapshot_state SET DEFAULT 'pending';
+> ALTER TABLE pages ALTER COLUMN snapshot_state SET NOT NULL;
+> ```
+
 ### 3. Start the Server
 
 ```bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,7 +105,17 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
    export ALLOWED_ORIGINS=https://your-domain.com
    ```
 
-3. **重启服务**
+3. **执行数据库迁移**（从 **`< 1.1.0`** 升级时必需）
+   如果数据库用户具备 `ALTER TABLE` 权限，可以直接升级并启动新服务，由服务在启动时自动补齐该列。
+   如果没有权限，请先手动执行下面这组幂等 SQL：
+   ```sql
+   ALTER TABLE pages ADD COLUMN IF NOT EXISTS snapshot_state VARCHAR(16);
+   UPDATE pages SET snapshot_state = 'ready' WHERE snapshot_state IS NULL OR snapshot_state = '';
+   ALTER TABLE pages ALTER COLUMN snapshot_state SET DEFAULT 'pending';
+   ALTER TABLE pages ALTER COLUMN snapshot_state SET NOT NULL;
+   ```
+
+4. **重启服务**
    ```bash
    ./wayback-server
    ```

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -58,7 +58,7 @@ Create a `.env` file in the project root:
 
 ```bash
 # Optional: Set version info
-VERSION=v1.0.0
+VERSION=v1.1.0
 BUILD_TIME=2026-03-16
 
 # Optional: Configure CORS

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -44,6 +44,9 @@ func New(host, port, user, password, dbname string, sslmode ...string) (*DB, err
 	}
 
 	db := &DB{conn: conn}
+	if err := db.ensureResourcesContentHashNotUnique(); err != nil {
+		return nil, fmt.Errorf("failed to ensure resources content_hash is not unique: %w", err)
+	}
 	if err := db.ensureDomainColumn(); err != nil {
 		return nil, fmt.Errorf("failed to ensure domain column: %w", err)
 	}
@@ -76,6 +79,11 @@ func quoteConnValue(value string) string {
 	escaped := strings.ReplaceAll(value, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
 	return "'" + escaped + "'"
+}
+
+func (db *DB) ensureResourcesContentHashNotUnique() error {
+	_, err := db.conn.Exec(`ALTER TABLE resources DROP CONSTRAINT IF EXISTS resources_content_hash_key`)
+	return err
 }
 
 // ensureDomainColumn adds the domain column, index, and backfills existing rows if needed.

--- a/server/migrations/006_drop_content_hash_unique.sql
+++ b/server/migrations/006_drop_content_hash_unique.sql
@@ -1,4 +1,0 @@
--- 去掉 content_hash 唯一约束
--- 允许同一内容（相同哈希）对应多个 URL 的资源记录
--- 文件层面仍按哈希去重，不重复存储
-ALTER TABLE resources DROP CONSTRAINT resources_content_hash_key;

--- a/server/migrations/007_drop_created_at.sql
+++ b/server/migrations/007_drop_created_at.sql
@@ -1,2 +1,0 @@
--- Drop created_at column from pages table
-ALTER TABLE pages DROP COLUMN IF EXISTS created_at;

--- a/server/migrations/008_add_page_snapshot_state.sql
+++ b/server/migrations/008_add_page_snapshot_state.sql
@@ -1,8 +1,0 @@
-ALTER TABLE pages ADD COLUMN IF NOT EXISTS snapshot_state VARCHAR(16);
-
-UPDATE pages
-SET snapshot_state = 'ready'
-WHERE snapshot_state IS NULL OR snapshot_state = '';
-
-ALTER TABLE pages ALTER COLUMN snapshot_state SET DEFAULT 'pending';
-ALTER TABLE pages ALTER COLUMN snapshot_state SET NOT NULL;

--- a/skill.md
+++ b/skill.md
@@ -56,6 +56,15 @@ createdb wayback
 psql wayback < init_db.sql
 ```
 
+> **Upgrade note for existing installs:** Any installation upgrading from **`< 1.1.0`** to `1.1.0` or later needs the `pages.snapshot_state` column. The server applies this automatically during startup when the database user has sufficient privileges. Otherwise, run the following idempotent SQL manually first:
+>
+> ```sql
+> ALTER TABLE pages ADD COLUMN IF NOT EXISTS snapshot_state VARCHAR(16);
+> UPDATE pages SET snapshot_state = 'ready' WHERE snapshot_state IS NULL OR snapshot_state = '';
+> ALTER TABLE pages ALTER COLUMN snapshot_state SET DEFAULT 'pending';
+> ALTER TABLE pages ALTER COLUMN snapshot_state SET NOT NULL;
+> ```
+
 ### 3. Start Server
 
 ```bash

--- a/tests/server/scripts/check_recent.go
+++ b/tests/server/scripts/check_recent.go
@@ -19,9 +19,9 @@ func main() {
 
 	// 查询最近的页面记录
 	rows, err := db.Query(`
-		SELECT id, url, title, captured_at, created_at
+		SELECT id, url, title, captured_at, last_visited
 		FROM pages
-		ORDER BY created_at DESC
+		ORDER BY COALESCE(last_visited, captured_at) DESC
 		LIMIT 5
 	`)
 	if err != nil {
@@ -33,14 +33,17 @@ func main() {
 	for rows.Next() {
 		var id int64
 		var url, title string
-		var capturedAt, createdAt time.Time
-		if err := rows.Scan(&id, &url, &title, &capturedAt, &createdAt); err != nil {
+		var capturedAt time.Time
+		var lastVisited sql.NullTime
+		if err := rows.Scan(&id, &url, &title, &capturedAt, &lastVisited); err != nil {
 			log.Fatal(err)
 		}
 		fmt.Printf("\nID: %d\n", id)
 		fmt.Printf("URL: %s\n", url)
 		fmt.Printf("Title: %s\n", title)
 		fmt.Printf("Captured: %s\n", capturedAt.Format("2006-01-02 15:04:05"))
-		fmt.Printf("Created: %s\n", createdAt.Format("2006-01-02 15:04:05"))
+		if lastVisited.Valid {
+			fmt.Printf("Last visited: %s\n", lastVisited.Time.Format("2006-01-02 15:04:05"))
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- move legacy schema compatibility for `resources.content_hash` and `pages.snapshot_state` into startup-time database checks so pre-`1.1.0` installs keep working without standalone migration files
- remove the now-redundant SQL files under `server/migrations` and update upgrade docs to describe the startup behavior plus the manual fallback SQL for limited DB users
- update the recent-pages debug script to stop querying the removed `created_at` column

## Testing
- make test