### PR TITLE
fix: escape wildcard characters in resource fallback lookup

### DIFF
--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -81,6 +81,15 @@ func quoteConnValue(value string) string {
 	return "'" + escaped + "'"
 }
 
+func escapeLikePattern(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	)
+	return replacer.Replace(value)
+}
+
 func (db *DB) ensureResourcesContentHashNotUnique() error {
 	_, err := db.conn.Exec(`ALTER TABLE resources DROP CONSTRAINT IF EXISTS resources_content_hash_key`)
 	return err
@@ -531,13 +540,15 @@ func (db *DB) GetLinkedResourceByURLAndPageID(url string, pageID int64) (*models
 // GetResourceByURLPrefix 根据 URL 前缀匹配资源（处理 DB 中 URL 带 #fragment 的情况）
 func (db *DB) GetResourceByURLPrefix(urlPrefix string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
+	escapedPrefix := escapeLikePattern(urlPrefix)
 	err := db.conn.QueryRow(`
 		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
-		WHERE pr.page_id = $1 AND (r.url LIKE $2 OR r.url LIKE $3)
+		WHERE pr.page_id = $1 AND (r.url LIKE $2 ESCAPE '\' OR r.url LIKE $3 ESCAPE '\')
+		ORDER BY r.last_seen DESC, r.id DESC
 		LIMIT 1
-	`, pageID, urlPrefix+"#%", urlPrefix+"%23%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, escapedPrefix+"#%", escapedPrefix+"%23%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -551,13 +562,15 @@ func (db *DB) GetResourceByURLPrefix(urlPrefix string, pageID int64) (*models.Re
 // GetResourceByURLPath 根据 URL 路径匹配资源（忽略查询参数，用于同一图片不同 token 的情况）
 func (db *DB) GetResourceByURLPath(urlPath string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
+	escapedPath := escapeLikePattern(urlPath)
 	err := db.conn.QueryRow(`
 		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
-		WHERE pr.page_id = $1 AND (r.url = $2 OR r.url LIKE $3)
+		WHERE pr.page_id = $1 AND (r.url = $2 OR r.url LIKE $3 ESCAPE '\')
+		ORDER BY CASE WHEN r.url = $2 THEN 0 ELSE 1 END, r.last_seen DESC, r.id DESC
 		LIMIT 1
-	`, pageID, urlPath, urlPath+"?%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, urlPath, escapedPath+"?%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
 
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -225,6 +225,100 @@ func TestGetPagesByURL_NoResults(t *testing.T) {
 	}
 }
 
+func TestGetResourceByURLPath_EscapesPercentWildcards(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pageID, err := db.CreatePage(
+		"https://db-url-path.example.com/page-"+suffix,
+		"URL Path Escape",
+		"html/test/url-path-escape.html",
+		strings.Repeat("a", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	correctURL := "https://db-url-path.example.com/assets/report%20done.png?token=good"
+	wrongURL := "https://db-url-path.example.com/assets/reportX20done.png?token=bad"
+
+	correctID, err := db.CreateResource(correctURL, strings.Repeat("b", 64), "image", "resources/test/report-correct.img", 10)
+	if err != nil {
+		t.Fatalf("CreateResource(correct) failed: %v", err)
+	}
+	wrongID, err := db.CreateResource(wrongURL, strings.Repeat("c", 64), "image", "resources/test/report-wrong.img", 10)
+	if err != nil {
+		t.Fatalf("CreateResource(wrong) failed: %v", err)
+	}
+
+	for _, resourceID := range []int64{correctID, wrongID} {
+		if err := db.LinkPageResource(pageID, resourceID); err != nil {
+			t.Fatalf("LinkPageResource(%d) failed: %v", resourceID, err)
+		}
+	}
+
+	resource, err := db.GetResourceByURLPath("https://db-url-path.example.com/assets/report%20done.png", pageID)
+	if err != nil {
+		t.Fatalf("GetResourceByURLPath failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatal("expected matching resource, got nil")
+	}
+	if resource.ID != correctID {
+		t.Fatalf("resource ID = %d, want %d (wrong wildcard match to %q)", resource.ID, correctID, wrongURL)
+	}
+}
+
+func TestGetResourceByURLPrefix_EscapesUnderscoreWildcards(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pageID, err := db.CreatePage(
+		"https://db-url-prefix.example.com/page-"+suffix,
+		"URL Prefix Escape",
+		"html/test/url-prefix-escape.html",
+		strings.Repeat("d", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	correctURL := "https://db-url-prefix.example.com/assets/icon_1.svg#section"
+	wrongURL := "https://db-url-prefix.example.com/assets/iconA1.svg#section"
+
+	correctID, err := db.CreateResource(correctURL, strings.Repeat("e", 64), "image", "resources/test/icon-correct.img", 10)
+	if err != nil {
+		t.Fatalf("CreateResource(correct) failed: %v", err)
+	}
+	wrongID, err := db.CreateResource(wrongURL, strings.Repeat("f", 64), "image", "resources/test/icon-wrong.img", 10)
+	if err != nil {
+		t.Fatalf("CreateResource(wrong) failed: %v", err)
+	}
+
+	for _, resourceID := range []int64{correctID, wrongID} {
+		if err := db.LinkPageResource(pageID, resourceID); err != nil {
+			t.Fatalf("LinkPageResource(%d) failed: %v", resourceID, err)
+		}
+	}
+
+	resource, err := db.GetResourceByURLPrefix("https://db-url-prefix.example.com/assets/icon_1.svg", pageID)
+	if err != nil {
+		t.Fatalf("GetResourceByURLPrefix failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatal("expected matching resource, got nil")
+	}
+	if resource.ID != correctID {
+		t.Fatalf("resource ID = %d, want %d (wrong wildcard match to %q)", resource.ID, correctID, wrongURL)
+	}
+}
+
 func TestGetSnapshotNeighbors(t *testing.T) {
 	db := skipIfNoDB(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- escape `%`, `_`, and `\` before using resource URL fallbacks in SQL `LIKE` queries so archived resources are matched literally
- add deterministic ordering for fallback lookups to avoid unstable matches when multiple linked resources qualify
- add regression tests covering `%20` and `_` URLs that previously matched the wrong resource

## Testing
- make test