### PR TITLE
fix: batch resource last_seen updates on cache reuse

### DIFF
--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"wayback/internal/models"
 )
 
@@ -215,6 +215,14 @@ func (db *DB) CreateResource(url, hash, resourceType, filePath string, fileSize 
 // UpdateResourceLastSeen 更新资源最后见到时间
 func (db *DB) UpdateResourceLastSeen(id int64) error {
 	_, err := db.conn.Exec("UPDATE resources SET last_seen = NOW() WHERE id = $1", id)
+	return err
+}
+
+func touchResourcesLastSeen(tx *sql.Tx, resourceIDs []int64) error {
+	if len(resourceIDs) == 0 {
+		return nil
+	}
+	_, err := tx.Exec("UPDATE resources SET last_seen = NOW() WHERE id = ANY($1)", pq.Array(resourceIDs))
 	return err
 }
 
@@ -617,6 +625,9 @@ func (db *DB) ReplacePageSnapshot(id int64, htmlPath, contentHash, title string,
 	if _, err := tx.Exec("DELETE FROM page_resources WHERE page_id = $1", id); err != nil {
 		return err
 	}
+	if err := touchResourcesLastSeen(tx, resourceIDs); err != nil {
+		return err
+	}
 
 	for _, resourceID := range resourceIDs {
 		if _, err := tx.Exec(
@@ -664,6 +675,9 @@ func (db *DB) FinalizePageCreate(id int64, resourceIDs []int64) error {
 		return err
 	}
 	if _, err := tx.Exec("DELETE FROM page_resources WHERE page_id = $1", id); err != nil {
+		return err
+	}
+	if err := touchResourcesLastSeen(tx, resourceIDs); err != nil {
 		return err
 	}
 	for _, resourceID := range resourceIDs {

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -393,3 +393,146 @@ func TestGetSnapshotNeighbors(t *testing.T) {
 		t.Errorf("newest snapshot should have no next, got ID %d", next.ID)
 	}
 }
+
+func TestFinalizePageCreate_UpdatesResourceLastSeen(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pageID, err := db.CreatePage(
+		"https://finalize-last-seen.example.com/page-"+suffix,
+		"Pending Page",
+		"html/test/finalize-last-seen.html",
+		strings.Repeat("a", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	resourceID, err := db.CreateResource(
+		"https://finalize-last-seen.example.com/style.css?"+suffix,
+		strings.Repeat("b", 64),
+		"css",
+		"resources/test/finalize-last-seen.css",
+		123,
+	)
+	if err != nil {
+		t.Fatalf("CreateResource failed: %v", err)
+	}
+	defer db.conn.Exec("DELETE FROM resources WHERE id = $1", resourceID)
+
+	before := time.Now().Add(-2 * time.Hour)
+	if _, err := db.conn.Exec("UPDATE resources SET last_seen = $1 WHERE id = $2", before, resourceID); err != nil {
+		t.Fatalf("seed last_seen failed: %v", err)
+	}
+
+	if err := db.FinalizePageCreate(pageID, []int64{resourceID}); err != nil {
+		t.Fatalf("FinalizePageCreate failed: %v", err)
+	}
+
+	resource, err := db.GetResourceByID(resourceID)
+	if err != nil {
+		t.Fatalf("GetResourceByID failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatal("resource should exist after finalize")
+	}
+	if !resource.LastSeen.After(before) {
+		t.Fatalf("resource last_seen = %v, want after %v", resource.LastSeen, before)
+	}
+
+	var count int
+	if err := db.conn.QueryRow("SELECT COUNT(*) FROM page_resources WHERE page_id = $1 AND resource_id = $2", pageID, resourceID).Scan(&count); err != nil {
+		t.Fatalf("page_resources count failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 page-resource link, got %d", count)
+	}
+}
+
+func TestReplacePageSnapshot_UpdatesResourceLastSeen(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pageID, err := db.CreatePage(
+		"https://replace-last-seen.example.com/page-"+suffix,
+		"Before Replace",
+		"html/test/replace-last-seen-before.html",
+		strings.Repeat("a", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	oldResourceID, err := db.CreateResource(
+		"https://replace-last-seen.example.com/old.css?"+suffix,
+		strings.Repeat("b", 64),
+		"css",
+		"resources/test/replace-last-seen-old.css",
+		111,
+	)
+	if err != nil {
+		t.Fatalf("CreateResource(old) failed: %v", err)
+	}
+	defer db.conn.Exec("DELETE FROM resources WHERE id = $1", oldResourceID)
+
+	newResourceID, err := db.CreateResource(
+		"https://replace-last-seen.example.com/new.css?"+suffix,
+		strings.Repeat("c", 64),
+		"css",
+		"resources/test/replace-last-seen-new.css",
+		222,
+	)
+	if err != nil {
+		t.Fatalf("CreateResource(new) failed: %v", err)
+	}
+	defer db.conn.Exec("DELETE FROM resources WHERE id = $1", newResourceID)
+
+	if err := db.LinkPageResource(pageID, oldResourceID); err != nil {
+		t.Fatalf("LinkPageResource failed: %v", err)
+	}
+
+	before := time.Now().Add(-2 * time.Hour)
+	if _, err := db.conn.Exec("UPDATE resources SET last_seen = $1 WHERE id = $2", before, newResourceID); err != nil {
+		t.Fatalf("seed new resource last_seen failed: %v", err)
+	}
+
+	bodyText := "updated body text"
+	if err := db.ReplacePageSnapshot(
+		pageID,
+		"html/test/replace-last-seen-after.html",
+		strings.Repeat("d", 64),
+		"After Replace",
+		&bodyText,
+		[]int64{newResourceID},
+	); err != nil {
+		t.Fatalf("ReplacePageSnapshot failed: %v", err)
+	}
+
+	resource, err := db.GetResourceByID(newResourceID)
+	if err != nil {
+		t.Fatalf("GetResourceByID failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatal("new resource should exist after replace")
+	}
+	if !resource.LastSeen.After(before) {
+		t.Fatalf("new resource last_seen = %v, want after %v", resource.LastSeen, before)
+	}
+
+	linked, err := db.GetResourcesByPageID(pageID)
+	if err != nil {
+		t.Fatalf("GetResourcesByPageID failed: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected 1 linked resource after replace, got %d", len(linked))
+	}
+	if linked[0].ID != newResourceID {
+		t.Fatalf("linked resource ID = %d, want %d", linked[0].ID, newResourceID)
+	}
+}

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -405,31 +405,22 @@ func (d *Deduplicator) loadCachedResource(url string) *resourceCacheEntry {
 	return cached
 }
 
-func (d *Deduplicator) tryReuseFreshCache(url string, cached *resourceCacheEntry) (int64, string, bool, error) {
+func (d *Deduplicator) tryReuseFreshCache(url string, cached *resourceCacheEntry) (int64, string, bool) {
 	if cached == nil || cached.freshUntil.IsZero() || !time.Now().Before(cached.freshUntil) {
-		return 0, "", false, nil
+		return 0, "", false
 	}
-
-	resource, err := d.db.GetResourceByID(cached.resourceID)
-	if err != nil {
-		return 0, "", false, fmt.Errorf("db query hot cached resource failed: %w", err)
-	}
-	if resource == nil || resource.FilePath == "" {
+	if cached.filePath == "" {
 		d.cacheDelete(url)
-		return 0, "", false, nil
+		return 0, "", false
 	}
 
-	if err := d.db.UpdateResourceLastSeen(resource.ID); err != nil {
-		return 0, "", false, err
-	}
-
-	d.cacheStoreWithMetadata(url, resource.ID, resource.FilePath, downloadMetadata{
+	d.cacheStoreWithMetadata(url, cached.resourceID, cached.filePath, downloadMetadata{
 		etag:       cached.etag,
 		lastMod:    cached.lastMod,
 		freshUntil: cached.freshUntil,
 	}, nil)
 	log.Printf("[cache] fresh reuse: %s", shortURLForLog(url))
-	return resource.ID, resource.FilePath, true, nil
+	return cached.resourceID, cached.filePath, true
 }
 
 func shortURLForLog(raw string) string {
@@ -565,9 +556,7 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 
 	startTime := time.Now()
 	cached := d.loadCachedResource(url)
-	if resourceID, filePath, reused, err := d.tryReuseFreshCache(url, cached); err != nil {
-		return 0, "", nil, err
-	} else if reused {
+	if resourceID, filePath, reused := d.tryReuseFreshCache(url, cached); reused {
 		return resourceID, filePath, nil, nil
 	}
 
@@ -599,14 +588,7 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 		if cached == nil {
 			return 0, "", nil, fmt.Errorf("received 304 without cache entry for %s", url)
 		}
-
-		dbStart := time.Now()
-		resource, err := d.db.GetResourceByID(cached.resourceID)
-		dbDuration += time.Since(dbStart)
-		if err != nil {
-			return 0, "", nil, fmt.Errorf("db query revalidated resource failed: %w", err)
-		}
-		if resource == nil || resource.FilePath == "" {
+		if cached.filePath == "" {
 			d.cacheDelete(url)
 			data, hash, tmpPath, metadata, trace, err = d.storage.DownloadResourceWithMetadata(url, pageURL, headers, cookies, streamThreshold, "", "")
 			if err != nil {
@@ -614,12 +596,6 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 				return d.processResourceFallback(url, err)
 			}
 		} else {
-			dbStart = time.Now()
-			if err := d.db.UpdateResourceLastSeen(resource.ID); err != nil {
-				dbDuration += time.Since(dbStart)
-				return 0, "", nil, err
-			}
-			dbDuration += time.Since(dbStart)
 			if !metadata.hasFreshness {
 				metadata.freshUntil = cached.freshUntil
 			}
@@ -629,9 +605,9 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 			if metadata.lastMod == "" {
 				metadata.lastMod = cached.lastMod
 			}
-			d.cacheStoreWithMetadata(url, resource.ID, resource.FilePath, metadata, nil)
+			d.cacheStoreWithMetadata(url, cached.resourceID, cached.filePath, metadata, nil)
 			log.Printf("[cache] revalidated 304: %s (%v)", shortURLForLog(url), time.Since(startTime))
-			return resource.ID, resource.FilePath, nil, nil
+			return cached.resourceID, cached.filePath, nil, nil
 		}
 	}
 	if data != nil {

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -407,6 +407,176 @@ func TestProcessResource_ExpiredFreshCacheTriggersRedownload(t *testing.T) {
 	}
 }
 
+func TestProcessCapture_FreshCacheReuseUpdatesLastSeenOnFinalize(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer db.Close()
+
+	cssToken := fmt.Sprintf("%d", time.Now().UnixNano())
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/css")
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		_, _ = w.Write([]byte("body { color: red; } /* " + cssToken + " */"))
+	}))
+	defer server.Close()
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	cssURL := fmt.Sprintf("%s/style.css?nonce=%d", baseURL, time.Now().UnixNano())
+
+	firstReq := &models.CaptureRequest{
+		URL:   fmt.Sprintf("%s/page-a-%d", baseURL, time.Now().UnixNano()),
+		Title: "first fresh cache page",
+		HTML:  `<html><head><link rel="stylesheet" href="` + cssURL + `"></head><body>first</body></html>`,
+	}
+
+	pageID1, action, err := dedup.ProcessCapture(firstReq)
+	if err != nil {
+		t.Fatalf("first ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("first action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID1)
+
+	resource, err := db.GetResourceByURL(cssURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL after first capture failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatalf("expected resource record for %s", cssURL)
+	}
+	beforeLastSeen := resource.LastSeen
+
+	time.Sleep(20 * time.Millisecond)
+
+	secondReq := &models.CaptureRequest{
+		URL:   fmt.Sprintf("%s/page-b-%d", baseURL, time.Now().UnixNano()),
+		Title: "second fresh cache page",
+		HTML:  `<html><head><link rel="stylesheet" href="` + cssURL + `"></head><body>second</body></html>`,
+	}
+
+	pageID2, action, err := dedup.ProcessCapture(secondReq)
+	if err != nil {
+		t.Fatalf("second ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("second action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID2)
+
+	if hits.Load() != 1 {
+		t.Fatalf("fresh cache reuse should avoid a second upstream request, got %d", hits.Load())
+	}
+
+	resource, err = db.GetResourceByURL(cssURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL after second capture failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatalf("expected resource record after second capture")
+	}
+	if !resource.LastSeen.After(beforeLastSeen) {
+		t.Fatalf("resource last_seen = %v, want after %v", resource.LastSeen, beforeLastSeen)
+	}
+
+	linked, err := db.GetResourcesByPageID(pageID2)
+	if err != nil {
+		t.Fatalf("GetResourcesByPageID(second page) failed: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected 1 linked resource on second page, got %d", len(linked))
+	}
+	if linked[0].ID != resource.ID {
+		t.Fatalf("second page linked resource ID = %d, want %d", linked[0].ID, resource.ID)
+	}
+}
+
+func TestUpdateCapture_FreshCacheReuseUpdatesLastSeenOnCommit(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer db.Close()
+
+	cssToken := fmt.Sprintf("%d", time.Now().UnixNano())
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/css")
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		_, _ = w.Write([]byte("body { color: blue; } /* " + cssToken + " */"))
+	}))
+	defer server.Close()
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	cssURL := fmt.Sprintf("%s/style.css?nonce=%d", baseURL, time.Now().UnixNano())
+	pageURL := fmt.Sprintf("%s/update-page-%d", baseURL, time.Now().UnixNano())
+
+	createReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "before cached update",
+		HTML:  `<html><head><link rel="stylesheet" href="` + cssURL + `"></head><body>before</body></html>`,
+	}
+
+	pageID, action, err := dedup.ProcessCapture(createReq)
+	if err != nil {
+		t.Fatalf("ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("create action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID)
+
+	resource, err := db.GetResourceByURL(cssURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL before update failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatalf("expected resource record before update")
+	}
+	beforeLastSeen := resource.LastSeen
+
+	time.Sleep(20 * time.Millisecond)
+
+	updateReq := &models.CaptureRequest{
+		URL:   pageURL,
+		Title: "after cached update",
+		HTML:  `<html><head><link rel="stylesheet" href="` + cssURL + `"></head><body>after</body></html>`,
+	}
+
+	action, err = dedup.UpdateCapture(pageID, updateReq)
+	if err != nil {
+		t.Fatalf("UpdateCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionUpdated {
+		t.Fatalf("update action = %q, want %q", action, models.ArchiveActionUpdated)
+	}
+
+	if hits.Load() != 1 {
+		t.Fatalf("fresh cache reuse during update should avoid a second upstream request, got %d", hits.Load())
+	}
+
+	resource, err = db.GetResourceByURL(cssURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL after update failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatalf("expected resource record after update")
+	}
+	if !resource.LastSeen.After(beforeLastSeen) {
+		t.Fatalf("resource last_seen = %v, want after %v", resource.LastSeen, beforeLastSeen)
+	}
+
+	linked, err := db.GetResourcesByPageID(pageID)
+	if err != nil {
+		t.Fatalf("GetResourcesByPageID after update failed: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected 1 linked resource after update, got %d", len(linked))
+	}
+	if linked[0].ID != resource.ID {
+		t.Fatalf("updated page linked resource ID = %d, want %d", linked[0].ID, resource.ID)
+	}
+}
+
 func TestProcessCapture_RollsBackPageOnFinalizeFailure(t *testing.T) {
 	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- remove per-resource `GetResourceByID` and `UpdateResourceLastSeen` calls from fresh cache reuse and 304 revalidation so hot cache hits stay on the in-memory path
- batch resource `last_seen` updates inside `FinalizePageCreate` and `ReplacePageSnapshot` transactions to preserve the same semantics with one SQL update per page
- add database and deduplicator regression coverage for create/update flows that reuse cached resources and verify `last_seen` still advances

## Testing
- `go test ./...`
- local perf repro against `localhost:8080` with a warmed 49-resource page: `Resource processing completed` dropped to ~3ms and `[Update] Processed 49 linked resources` dropped to ~5ms