### PR TITLE
fix: skip fragment-only resource URLs during archive finalize

### DIFF
--- a/server/internal/storage/css_parser.go
+++ b/server/internal/storage/css_parser.go
@@ -31,7 +31,7 @@ func (p *CSSParser) ExtractResources(cssContent string) []string {
 	for _, match := range importMatches {
 		if len(match) > 1 {
 			url := strings.TrimSpace(match[1])
-			if url != "" && !seen[url] && !isDataURL(url) {
+			if url != "" && !seen[url] && !isDataURL(url) && !isFragmentOnlyURL(url) {
 				seen[url] = true
 				resources = append(resources, url)
 			}
@@ -43,7 +43,7 @@ func (p *CSSParser) ExtractResources(cssContent string) []string {
 	for _, match := range urlMatches {
 		if len(match) > 1 {
 			url := strings.TrimSpace(match[1])
-			if url != "" && !seen[url] && !isDataURL(url) {
+			if url != "" && !seen[url] && !isDataURL(url) && !isFragmentOnlyURL(url) {
 				seen[url] = true
 				resources = append(resources, url)
 			}
@@ -99,4 +99,8 @@ func (p *CSSParser) RewriteCSS(cssContent string, urlMapping map[string]string) 
 // isDataURL checks if a URL is a data URL (data:...)
 func isDataURL(url string) bool {
 	return strings.HasPrefix(url, "data:")
+}
+
+func isFragmentOnlyURL(url string) bool {
+	return strings.HasPrefix(url, "#")
 }

--- a/server/internal/storage/css_parser_test.go
+++ b/server/internal/storage/css_parser_test.go
@@ -1,0 +1,26 @@
+package storage
+
+import "testing"
+
+func TestCSSParserExtractResources_SkipsFragmentOnlyURLs(t *testing.T) {
+	parser := NewCSSParser()
+	resources := parser.ExtractResources(`.mask{filter:url(#goo)} .bg{background:url("icons.svg#sprite")} @import url("theme.css")`)
+
+	for _, resource := range resources {
+		if resource == "#goo" {
+			t.Fatal("fragment-only CSS url() should not be extracted")
+		}
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 extracted resources, got %d: %#v", len(resources), resources)
+	}
+
+	if resources[0] != "theme.css" && resources[1] != "theme.css" {
+		t.Fatalf("expected theme.css to be preserved, got %#v", resources)
+	}
+
+	if resources[0] != "icons.svg#sprite" && resources[1] != "icons.svg#sprite" {
+		t.Fatalf("expected icons.svg#sprite to be preserved, got %#v", resources)
+	}
+}

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -574,6 +576,101 @@ func TestUpdateCapture_FreshCacheReuseUpdatesLastSeenOnCommit(t *testing.T) {
 	}
 	if linked[0].ID != resource.ID {
 		t.Fatalf("updated page linked resource ID = %d, want %d", linked[0].ID, resource.ID)
+	}
+}
+
+func TestProcessCapture_SkipsFragmentOnlyURLsDuringFinalize(t *testing.T) {
+	dedup, db, fs := newFrameCaptureTestDeduplicator(t)
+	defer db.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/style.css":
+			w.Header().Set("Content-Type", "text/css")
+			_, _ = w.Write([]byte(`.mask{filter:url(#goo)} .icon{background-image:url("icons.svg#sprite")}`))
+		case "/icons.svg":
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(`<svg xmlns="http://www.w3.org/2000/svg"><symbol id="sprite"></symbol></svg>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	baseURL := routeStorageHTTPClientToServer(t, fs, server)
+	cssURL := fmt.Sprintf("%s/style.css?nonce=%d", baseURL, time.Now().UnixNano())
+	expectedSpriteURL := baseURL + "/icons.svg#sprite"
+
+	var requestedMu sync.Mutex
+	requested := make([]string, 0, 2)
+	dedup.testBeforeResourceCreate = func(url string) {
+		requestedMu.Lock()
+		requested = append(requested, url)
+		requestedMu.Unlock()
+	}
+
+	req := &models.CaptureRequest{
+		URL:   fmt.Sprintf("%s/page-%d", baseURL, time.Now().UnixNano()),
+		Title: "fragment-only resources are skipped",
+		HTML:  `<html><head><link rel="stylesheet" href="` + cssURL + `"></head><body><svg><rect style="fill:url(#paint0_linear_0_3)"></rect></svg></body></html>`,
+	}
+
+	pageID, action, err := dedup.ProcessCapture(req)
+	if err != nil {
+		t.Fatalf("ProcessCapture failed: %v", err)
+	}
+	if action != models.ArchiveActionCreated {
+		t.Fatalf("action = %q, want %q", action, models.ArchiveActionCreated)
+	}
+	defer db.DeletePage(pageID)
+
+	requestedMu.Lock()
+	requestedCopy := append([]string(nil), requested...)
+	requestedMu.Unlock()
+
+	foundCSS := false
+	foundSprite := false
+	for _, resourceURL := range requestedCopy {
+		if strings.Contains(resourceURL, "#paint0_linear_0_3") || strings.Contains(resourceURL, "#goo") {
+			t.Fatalf("fragment-only URL should not be processed as a resource: %q", resourceURL)
+		}
+		if resourceURL == cssURL {
+			foundCSS = true
+		}
+		if resourceURL == expectedSpriteURL {
+			foundSprite = true
+		}
+	}
+	if !foundCSS {
+		t.Fatalf("expected stylesheet URL to be processed, got %#v", requestedCopy)
+	}
+	if !foundSprite {
+		t.Fatalf("expected asset URL with fragment to be preserved, got %#v", requestedCopy)
+	}
+
+	linked, err := db.GetResourcesByPageID(pageID)
+	if err != nil {
+		t.Fatalf("GetResourcesByPageID failed: %v", err)
+	}
+	if len(linked) != 2 {
+		t.Fatalf("expected 2 linked resources after skipping fragment-only URLs, got %d", len(linked))
+	}
+
+	linkedCSS := false
+	linkedSprite := false
+	for _, resource := range linked {
+		if resource.URL == cssURL {
+			linkedCSS = true
+		}
+		if resource.URL == expectedSpriteURL {
+			linkedSprite = true
+		}
+		if strings.Contains(resource.URL, "#paint0_linear_0_3") || strings.HasSuffix(resource.URL, "#goo") {
+			t.Fatalf("fragment-only URL should not be linked to the page: %q", resource.URL)
+		}
+	}
+	if !linkedCSS || !linkedSprite {
+		t.Fatalf("expected linked resources to contain stylesheet and sprite asset, got %#v", linked)
 	}
 }
 

--- a/server/internal/storage/html_extractor.go
+++ b/server/internal/storage/html_extractor.go
@@ -251,6 +251,11 @@ func (e *HTMLResourceExtractor) resolveURL(rawURL, baseURL string) string {
 		return rawURL
 	}
 
+	// 跳过同文档 fragment 引用（例如 SVG 的 url(#gradient)）
+	if strings.HasPrefix(rawURL, "#") {
+		return rawURL
+	}
+
 	// 如果已经是完整URL，解析并规范化路径
 	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
 		parsed, err := url.Parse(rawURL)

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -227,3 +227,56 @@ func TestExtractResources_IframeCGIWithoutHTMLExtension(t *testing.T) {
 
 	t.Fatal("should extract iframe CGI resource as html")
 }
+
+func TestExtractResources_SkipsFragmentOnlyCSSURLs(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body><svg><rect style="fill:url(#paint0_linear_0_3)"></rect></svg></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	for _, r := range resources {
+		if r.URL == "https://example.com/page#paint0_linear_0_3" {
+			t.Fatalf("should not extract same-document fragment URL, got %q", r.URL)
+		}
+		if r.URL == "#paint0_linear_0_3" {
+			t.Fatalf("should not extract raw fragment URL, got %q", r.URL)
+		}
+	}
+}
+
+func TestExtractResources_SkipsFragmentOnlyQuotedCSSURLs(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body><div style="filter:url(&quot;#paint0_linear_0_3&quot;)"></div></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	for _, r := range resources {
+		if r.URL == "https://example.com/page#paint0_linear_0_3" {
+			t.Fatalf("should not extract same-document quoted fragment URL, got %q", r.URL)
+		}
+		if r.URL == "#paint0_linear_0_3" {
+			t.Fatalf("should not extract raw quoted fragment URL, got %q", r.URL)
+		}
+	}
+}
+
+func TestExtractResources_PreservesAssetURLsWithFragments(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body><div style="mask:url(icons.svg#sprite)"></div></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/assets/page")
+
+	found := false
+	for _, r := range resources {
+		if r.URL == "https://example.com/assets/icons.svg#sprite" {
+			found = true
+			if r.Type != "image" {
+				t.Fatalf("asset URL with fragment type = %q, want image", r.Type)
+			}
+		}
+	}
+
+	if !found {
+		t.Fatal("should preserve asset URL with fragment suffix")
+	}
+}


### PR DESCRIPTION
## Summary
- skip same-document fragment-only resource references like `url(#foo)` during HTML and CSS resource extraction so archive finalize does not waste time downloading pseudo-URLs
- preserve asset references that legitimately include fragments, such as `icons.svg#sprite`, and add regression coverage for both parser-level and finalize-level behavior
- verify the change with `go test ./internal/storage/...` and `make test`