### PR TITLE
docs: sync configuration docs with server defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ DB_PATH=./data/wayback.db
 # PostgreSQL Configuration (when DB_TYPE=postgres)
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=wayback
+# DB_USER defaults to your current system username; falls back to postgres if unavailable
+# DB_USER=
 DB_PASSWORD=
 DB_NAME=wayback
 
@@ -47,7 +48,10 @@ LOG_DIR=./data/logs
 # Concurrent download workers (default: CPU cores × 4, min 2, I/O bound task)
 # RESOURCE_WORKERS=4
 #
-# Resource ID cache size in MB (default: 10% of total memory)
+# Resource metadata cache size in MB (default: 10% of total memory)
+# Used for resource URL metadata plus HTTP freshness/validator reuse and revalidation
+# RESOURCE_METADATA_CACHE_MB=256
+# Legacy alias still supported:
 # RESOURCE_CACHE_MB=256
 #
 # Single resource download timeout in seconds (default: 30)

--- a/README-zh.md
+++ b/README-zh.md
@@ -139,17 +139,24 @@ export https_proxy=http://127.0.0.1:7897
 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
+| `DB_TYPE` | `sqlite` | 数据库类型：`sqlite` 适合本地单文件部署，`postgres` 适合 PostgreSQL |
+| `DB_PATH` | `./data/wayback.db` | SQLite 数据库文件路径（当 `DB_TYPE=sqlite` 时使用） |
 | `DB_HOST` | `localhost` | PostgreSQL 主机 |
 | `DB_PORT` | `5432` | PostgreSQL 端口 |
-| `DB_USER` | `postgres` | 数据库用户 |
+| `DB_USER` | 当前系统用户名 | PostgreSQL 数据库用户。未设置时服务端会优先使用当前系统用户名，不可用时回退到 `postgres` |
 | `DB_PASSWORD` | *（空）* | 数据库密码 |
 | `DB_NAME` | `wayback` | 数据库名称 |
 | `DB_SSLMODE` | `disable` | 服务端连接 PostgreSQL 时使用的 SSL 模式 |
+| `SERVER_HOST` | `127.0.0.1` | 服务绑定地址（`0.0.0.0` 表示监听所有网卡，`127.0.0.1` 表示仅本机访问） |
 | `SERVER_PORT` | `8080` | HTTP 服务端口 |
+| `ALLOWED_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080` | CORS 允许的来源列表（逗号分隔）。远程部署时应加入你的域名 |
 | `DATA_DIR` | `./data` | HTML 和资源的存储目录 |
 | `LOG_DIR` | `./data/logs` | 日志文件目录 |
 | `AUTH_PASSWORD` | *（空）* | HTTP Basic Auth 密码（为空时关闭认证，用户名固定为 `wayback`） |
+| `RESOURCE_WORKERS` | CPU 核心数 × 4（最少 2） | 全局资源下载并发 worker 数量，跨所有页面共享 |
 | `RESOURCE_METADATA_CACHE_MB` | 总内存的 10% | 资源 URL 元数据缓存预算（MB），同时用于基于 freshness/validator 的 HTTP 复用与重校验。旧变量 `RESOURCE_CACHE_MB` 仍作为兼容别名生效。 |
+| `RESOURCE_DOWNLOAD_TIMEOUT` | `30` | 单个资源下载超时（秒） |
+| `RESOURCE_STREAM_THRESHOLD_KB` | `2048` | 大文件转为流式落盘的阈值（KB） |
 | `ENABLE_DEBUG_API` | `false` | 是否启用 `/api/debug/*` 调试接口（`memstats`、`gc`、`pprof`）。仅在排查问题时临时开启。 |
 | `COMPRESSION_LEVEL` | `-1` | 压缩级别：1（最快）到 9（最佳），-1（默认/平衡）。响应压缩始终启用，根据 Accept-Encoding 自动协商 |
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ The server automatically loads `.env` from the working directory if it exists. Y
 
 | Variable | Default | Description |
 |---|---|---|
+| `DB_TYPE` | `sqlite` | Database type: `sqlite` for local single-file storage, `postgres` for PostgreSQL |
+| `DB_PATH` | `./data/wayback.db` | SQLite database path (used when `DB_TYPE=sqlite`) |
 | `DB_HOST` | `localhost` | PostgreSQL host |
 | `DB_PORT` | `5432` | PostgreSQL port |
-| `DB_USER` | `postgres` | Database user. PostgreSQL defaults to the current system username, so leaving this unset is usually recommended. |
+| `DB_USER` | current system username | PostgreSQL user. If unset, the server uses your current system username and falls back to `postgres` when unavailable |
 | `DB_PASSWORD` | *(empty)* | Database password |
 | `DB_NAME` | `wayback` | Database name |
 | `DB_SSLMODE` | `disable` | PostgreSQL SSL mode used by the server connection |
@@ -155,7 +157,10 @@ The server automatically loads `.env` from the working directory if it exists. Y
 | `DATA_DIR` | `./data` | Storage directory for HTML and resources |
 | `LOG_DIR` | `./data/logs` | Log file directory |
 | `AUTH_PASSWORD` | *(empty)* | HTTP Basic Auth password (disabled when empty, username: `wayback`). **REQUIRED for remote deployment** |
+| `RESOURCE_WORKERS` | CPU cores × 4 (min 2) | Global concurrent resource download workers across all pages |
 | `RESOURCE_METADATA_CACHE_MB` | 10% of system memory | Metadata cache budget for resource URL lookups plus HTTP freshness/validator reuse and revalidation. `RESOURCE_CACHE_MB` is still accepted as a legacy alias. |
+| `RESOURCE_DOWNLOAD_TIMEOUT` | `30` | Per-resource download timeout in seconds |
+| `RESOURCE_STREAM_THRESHOLD_KB` | `2048` | Stream-to-disk threshold in KB for large resources |
 | `ENABLE_DEBUG_API` | `false` | Enable `/api/debug/*` endpoints (`memstats`, `gc`, `pprof`). Keep disabled unless you are actively debugging. |
 | `COMPRESSION_LEVEL` | `-1` | Compression level: 1 (fastest) to 9 (best), -1 (default/balanced). Response compression always enabled, auto-negotiated via Accept-Encoding |
 

--- a/skill.md
+++ b/skill.md
@@ -238,7 +238,8 @@ DB_PATH=./data/wayback.db  # SQLite database file path (when DB_TYPE=sqlite)
 # PostgreSQL configuration (when DB_TYPE=postgres)
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=postgres  # 可选，PostgreSQL 默认使用系统用户名
+# DB_USER defaults to your current system username; falls back to postgres if unavailable
+# DB_USER=
 DB_PASSWORD=
 DB_NAME=wayback
 DB_SSLMODE=disable


### PR DESCRIPTION
## Summary
- add the missing configuration entries in README.md and README-zh.md, including DB_TYPE, DB_PATH, and resource tuning settings
- align DB_USER and resource cache descriptions with the actual server defaults and legacy alias behavior
- update .env.example and skill.md so the sample configuration matches current runtime behavior

## Testing
- not run (docs-only changes)