### PR TITLE
fix: restore SQLite parity and snapshot time rendering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ DB_PATH=./data/wayback.db
 # PostgreSQL Configuration (when DB_TYPE=postgres)
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=wayback
+# DB_USER defaults to your current system username; falls back to postgres if unavailable
+# DB_USER=
 DB_PASSWORD=
 DB_NAME=wayback
 
@@ -47,7 +48,10 @@ LOG_DIR=./data/logs
 # Concurrent download workers (default: CPU cores × 4, min 2, I/O bound task)
 # RESOURCE_WORKERS=4
 #
-# Resource ID cache size in MB (default: 10% of total memory)
+# Resource metadata cache size in MB (default: 10% of total memory)
+# Used for resource URL metadata plus HTTP freshness/validator reuse and revalidation
+# RESOURCE_METADATA_CACHE_MB=256
+# Legacy alias still supported:
 # RESOURCE_CACHE_MB=256
 #
 # Single resource download timeout in seconds (default: 30)

--- a/README-zh.md
+++ b/README-zh.md
@@ -139,17 +139,24 @@ export https_proxy=http://127.0.0.1:7897
 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
+| `DB_TYPE` | `sqlite` | 数据库类型：`sqlite` 适合本地单文件部署，`postgres` 适合 PostgreSQL |
+| `DB_PATH` | `./data/wayback.db` | SQLite 数据库文件路径（当 `DB_TYPE=sqlite` 时使用） |
 | `DB_HOST` | `localhost` | PostgreSQL 主机 |
 | `DB_PORT` | `5432` | PostgreSQL 端口 |
-| `DB_USER` | `postgres` | 数据库用户 |
+| `DB_USER` | 当前系统用户名 | PostgreSQL 数据库用户。未设置时服务端会优先使用当前系统用户名，不可用时回退到 `postgres` |
 | `DB_PASSWORD` | *（空）* | 数据库密码 |
 | `DB_NAME` | `wayback` | 数据库名称 |
 | `DB_SSLMODE` | `disable` | 服务端连接 PostgreSQL 时使用的 SSL 模式 |
+| `SERVER_HOST` | `127.0.0.1` | 服务绑定地址（`0.0.0.0` 表示监听所有网卡，`127.0.0.1` 表示仅本机访问） |
 | `SERVER_PORT` | `8080` | HTTP 服务端口 |
+| `ALLOWED_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080` | CORS 允许的来源列表（逗号分隔）。远程部署时应加入你的域名 |
 | `DATA_DIR` | `./data` | HTML 和资源的存储目录 |
 | `LOG_DIR` | `./data/logs` | 日志文件目录 |
 | `AUTH_PASSWORD` | *（空）* | HTTP Basic Auth 密码（为空时关闭认证，用户名固定为 `wayback`） |
+| `RESOURCE_WORKERS` | CPU 核心数 × 4（最少 2） | 全局资源下载并发 worker 数量，跨所有页面共享 |
 | `RESOURCE_METADATA_CACHE_MB` | 总内存的 10% | 资源 URL 元数据缓存预算（MB），同时用于基于 freshness/validator 的 HTTP 复用与重校验。旧变量 `RESOURCE_CACHE_MB` 仍作为兼容别名生效。 |
+| `RESOURCE_DOWNLOAD_TIMEOUT` | `30` | 单个资源下载超时（秒） |
+| `RESOURCE_STREAM_THRESHOLD_KB` | `2048` | 大文件转为流式落盘的阈值（KB） |
 | `ENABLE_DEBUG_API` | `false` | 是否启用 `/api/debug/*` 调试接口（`memstats`、`gc`、`pprof`）。仅在排查问题时临时开启。 |
 | `COMPRESSION_LEVEL` | `-1` | 压缩级别：1（最快）到 9（最佳），-1（默认/平衡）。响应压缩始终启用，根据 Accept-Encoding 自动协商 |
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ The server automatically loads `.env` from the working directory if it exists. Y
 
 | Variable | Default | Description |
 |---|---|---|
+| `DB_TYPE` | `sqlite` | Database type: `sqlite` for local single-file storage, `postgres` for PostgreSQL |
+| `DB_PATH` | `./data/wayback.db` | SQLite database path (used when `DB_TYPE=sqlite`) |
 | `DB_HOST` | `localhost` | PostgreSQL host |
 | `DB_PORT` | `5432` | PostgreSQL port |
-| `DB_USER` | `postgres` | Database user. PostgreSQL defaults to the current system username, so leaving this unset is usually recommended. |
+| `DB_USER` | current system username | PostgreSQL user. If unset, the server uses your current system username and falls back to `postgres` when unavailable |
 | `DB_PASSWORD` | *(empty)* | Database password |
 | `DB_NAME` | `wayback` | Database name |
 | `DB_SSLMODE` | `disable` | PostgreSQL SSL mode used by the server connection |
@@ -155,7 +157,10 @@ The server automatically loads `.env` from the working directory if it exists. Y
 | `DATA_DIR` | `./data` | Storage directory for HTML and resources |
 | `LOG_DIR` | `./data/logs` | Log file directory |
 | `AUTH_PASSWORD` | *(empty)* | HTTP Basic Auth password (disabled when empty, username: `wayback`). **REQUIRED for remote deployment** |
+| `RESOURCE_WORKERS` | CPU cores × 4 (min 2) | Global concurrent resource download workers across all pages |
 | `RESOURCE_METADATA_CACHE_MB` | 10% of system memory | Metadata cache budget for resource URL lookups plus HTTP freshness/validator reuse and revalidation. `RESOURCE_CACHE_MB` is still accepted as a legacy alias. |
+| `RESOURCE_DOWNLOAD_TIMEOUT` | `30` | Per-resource download timeout in seconds |
+| `RESOURCE_STREAM_THRESHOLD_KB` | `2048` | Stream-to-disk threshold in KB for large resources |
 | `ENABLE_DEBUG_API` | `false` | Enable `/api/debug/*` endpoints (`memstats`, `gc`, `pprof`). Keep disabled unless you are actively debugging. |
 | `COMPRESSION_LEVEL` | `-1` | Compression level: 1 (fastest) to 9 (best), -1 (default/balanced). Response compression always enabled, auto-negotiated via Accept-Encoding |
 

--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -4,30 +4,28 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"time"
 
 	"wayback/internal/models"
 )
 
 // injectArchiveHeader 在页面顶部注入归档信息栏
 func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next *models.Page, snapshotTotal int, nonce string) string {
-	// 格式化时间
-	capturedTime := page.CapturedAt.Format("2006-01-02 15:04:05")
-
 	// 构建快照导航 HTML
 	var navHTML string
 	if snapshotTotal > 1 {
 		prevLink := ""
 		if prev != nil {
-			prevLink = fmt.Sprintf(`<a href="/view/%d" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" title="%s">◀ %s</a>`,
-				prev.ID, prev.FirstVisited.Format("2006-01-02 15:04:05"), prev.FirstVisited.Format("01-02 15:04"))
+			prevLink = fmt.Sprintf(`<a href="/view/%d" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" data-time-title="true" title="%s">◀ %s</a>`,
+				prev.ID, archiveTimeFallback(prev.FirstVisited, "full"), archiveTimeElement(prev.FirstVisited, "nav"))
 		} else {
 			prevLink = `<span style="padding:4px 10px;font-size:12px;opacity:0.3;">◀</span>`
 		}
 
 		nextLink := ""
 		if next != nil {
-			nextLink = fmt.Sprintf(`<a href="/view/%d" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" title="%s">%s ▶</a>`,
-				next.ID, next.FirstVisited.Format("2006-01-02 15:04:05"), next.FirstVisited.Format("01-02 15:04"))
+			nextLink = fmt.Sprintf(`<a href="/view/%d" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:3px;font-size:12px;background:rgba(255,255,255,0.1);" data-time-title="true" title="%s">%s ▶</a>`,
+				next.ID, archiveTimeFallback(next.FirstVisited, "full"), archiveTimeElement(next.FirstVisited, "nav"))
 		} else {
 			nextLink = `<span style="padding:4px 10px;font-size:12px;opacity:0.3;">▶</span>`
 		}
@@ -141,6 +139,44 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 <script nonce="%s">
 (function() {
 	'use strict';
+	function formatArchiveTime(date, format) {
+		if (format === 'nav') {
+			return date.toLocaleString('zh-CN', {
+				month: '2-digit',
+				day: '2-digit',
+				hour: '2-digit',
+				minute: '2-digit'
+			});
+		}
+
+		return date.toLocaleString('zh-CN', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit'
+		});
+	}
+
+	function localizeArchiveTimes() {
+		document.querySelectorAll('.wayback-local-time').forEach(function(el) {
+			const isoTime = el.getAttribute('datetime');
+			if (!isoTime) return;
+
+			const date = new Date(isoTime);
+			if (Number.isNaN(date.getTime())) return;
+
+			const format = el.getAttribute('data-format') || 'full';
+			el.textContent = formatArchiveTime(date, format);
+
+			const titleTarget = el.closest('[data-time-title="true"]');
+			if (titleTarget) {
+				titleTarget.title = formatArchiveTime(date, 'full');
+			}
+		});
+	}
+
 	// 修复所有 fixed/sticky 定位的顶部元素，避免被归档 header 遮挡
 	function fixPositionedElements() {
 		const HEADER_HEIGHT = 48;
@@ -203,23 +239,28 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 	// 页面加载完成后执行
 	if (document.readyState === 'loading') {
 		document.addEventListener('DOMContentLoaded', function() {
+			localizeArchiveTimes();
 			fixPositionedElements();
 			forceEnableInteraction();
 		});
 	} else {
+		localizeArchiveTimes();
 		fixPositionedElements();
 		forceEnableInteraction();
 	}
 
 	// 延迟执行，确保动态加载的元素也被处理
+	setTimeout(localizeArchiveTimes, 0);
 	setTimeout(fixPositionedElements, 100);
 	setTimeout(forceEnableInteraction, 100);
+	setTimeout(localizeArchiveTimes, 100);
 	setTimeout(fixPositionedElements, 500);
 	setTimeout(forceEnableInteraction, 500);
+	setTimeout(localizeArchiveTimes, 500);
 
 })();
 </script>
-`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), capturedTime, navHTML, nonce)
+`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, nonce)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {
@@ -230,6 +271,22 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 	}
 
 	return html
+}
+
+func archiveTimeElement(ts time.Time, format string) string {
+	return fmt.Sprintf(`<time class="wayback-local-time" data-format="%s" datetime="%s">%s</time>`,
+		escapeHTML(format),
+		escapeHTML(ts.UTC().Format(time.RFC3339)),
+		archiveTimeFallback(ts, format),
+	)
+}
+
+func archiveTimeFallback(ts time.Time, format string) string {
+	if format == "nav" {
+		return escapeHTML(ts.UTC().Format("01-02 15:04 UTC"))
+	}
+
+	return escapeHTML(ts.UTC().Format("2006-01-02 15:04:05 UTC"))
 }
 
 // removeExternalResources 移除HTML中的外部资源引用

--- a/server/internal/api/injector_test.go
+++ b/server/internal/api/injector_test.go
@@ -26,3 +26,27 @@ func TestInjectArchiveHeader_EscapesHeaderLinkHref(t *testing.T) {
 		t.Fatalf("header link href missing escaped URL, want substring %q in %s", wantHref, got)
 	}
 }
+
+func TestInjectArchiveHeader_LocalizesSnapshotTimesInBrowser(t *testing.T) {
+	page := &models.Page{
+		ID:         1,
+		URL:        "https://example.com/page",
+		CapturedAt: time.Date(2026, 4, 15, 12, 34, 56, 0, time.UTC),
+	}
+	prev := &models.Page{ID: 2, FirstVisited: time.Date(2026, 4, 14, 1, 2, 3, 0, time.UTC)}
+	next := &models.Page{ID: 3, FirstVisited: time.Date(2026, 4, 16, 4, 5, 6, 0, time.UTC)}
+
+	got := injectArchiveHeader(`<html><body><main>hello</main></body></html>`, page, prev, next, 3, "nonce")
+
+	for _, want := range []string{
+		`<time class="wayback-local-time" data-format="full" datetime="2026-04-15T12:34:56Z">2026-04-15 12:34:56 UTC</time>`,
+		`<time class="wayback-local-time" data-format="nav" datetime="2026-04-14T01:02:03Z">04-14 01:02 UTC</time>`,
+		`<time class="wayback-local-time" data-format="nav" datetime="2026-04-16T04:05:06Z">04-16 04:05 UTC</time>`,
+		`function localizeArchiveTimes()`,
+		`data-time-title="true"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing localized time markup %q in %s", want, got)
+		}
+	}
+}

--- a/server/internal/database/migrations/sqlite/init_db.sql
+++ b/server/internal/database/migrations/sqlite/init_db.sql
@@ -36,11 +36,12 @@ CREATE TRIGGER IF NOT EXISTS pages_fts_insert AFTER INSERT ON pages BEGIN
 END;
 
 CREATE TRIGGER IF NOT EXISTS pages_fts_update AFTER UPDATE ON pages BEGIN
-    UPDATE pages_fts SET body_text = new.body_text, title = new.title WHERE rowid = new.id;
+    INSERT INTO pages_fts(pages_fts, rowid, body_text, title) VALUES ('delete', old.id, old.body_text, old.title);
+    INSERT INTO pages_fts(rowid, body_text, title) VALUES (new.id, new.body_text, new.title);
 END;
 
 CREATE TRIGGER IF NOT EXISTS pages_fts_delete AFTER DELETE ON pages BEGIN
-    DELETE FROM pages_fts WHERE rowid = old.id;
+    INSERT INTO pages_fts(pages_fts, rowid, body_text, title) VALUES ('delete', old.id, old.body_text, old.title);
 END;
 
 -- 资源表（去重）

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -105,6 +105,41 @@ func (db *SQLiteDB) ensureMigrations() error {
 		return err
 	}
 
+	if err := db.ensureFTSConsistency(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (db *SQLiteDB) ensureFTSConsistency() error {
+	const recreateFTSTriggers = `
+DROP TRIGGER IF EXISTS pages_fts_insert;
+DROP TRIGGER IF EXISTS pages_fts_update;
+DROP TRIGGER IF EXISTS pages_fts_delete;
+
+CREATE TRIGGER pages_fts_insert AFTER INSERT ON pages BEGIN
+	INSERT INTO pages_fts(rowid, body_text, title) VALUES (new.id, new.body_text, new.title);
+END;
+
+CREATE TRIGGER pages_fts_update AFTER UPDATE ON pages BEGIN
+	INSERT INTO pages_fts(pages_fts, rowid, body_text, title) VALUES ('delete', old.id, old.body_text, old.title);
+	INSERT INTO pages_fts(rowid, body_text, title) VALUES (new.id, new.body_text, new.title);
+END;
+
+CREATE TRIGGER pages_fts_delete AFTER DELETE ON pages BEGIN
+	INSERT INTO pages_fts(pages_fts, rowid, body_text, title) VALUES ('delete', old.id, old.body_text, old.title);
+END;
+`
+
+	if _, err := db.conn.Exec(recreateFTSTriggers); err != nil {
+		return fmt.Errorf("failed to recreate SQLite FTS triggers: %w", err)
+	}
+
+	if _, err := db.conn.Exec("INSERT INTO pages_fts(pages_fts) VALUES ('rebuild')"); err != nil {
+		return fmt.Errorf("failed to rebuild SQLite FTS index: %w", err)
+	}
+
 	return nil
 }
 
@@ -460,11 +495,13 @@ func (db *SQLiteDB) GetPageByID(id string) (*models.Page, error) {
 
 // SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
 func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
-	// SQLite 使用 FTS5 全文搜索
-	query := `SELECT ` + pageSelectColumns + ` FROM pages WHERE id IN (
-		SELECT rowid FROM pages_fts WHERE pages_fts MATCH ?
-	)`
-	args := []interface{}{keyword + "*"} // FTS5 前缀匹配
+	query := `SELECT ` + pageSelectColumns + ` FROM pages WHERE (` +
+		`LOWER(COALESCE(url, '')) LIKE LOWER(?) OR ` +
+		`LOWER(COALESCE(title, '')) LIKE LOWER(?) OR ` +
+		`LOWER(COALESCE(body_text, '')) LIKE LOWER(?)` +
+		`)`
+	pattern := "%" + keyword + "%"
+	args := []interface{}{pattern, pattern, pattern}
 
 	// 追加时间过滤条件
 	if from != nil {

--- a/server/internal/database/sqlite_test.go
+++ b/server/internal/database/sqlite_test.go
@@ -1,0 +1,124 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newSQLiteTestDB(t *testing.T) *SQLiteDB {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "wayback.db")
+	database, err := NewSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLite failed: %v", err)
+	}
+
+	sqliteDB, ok := database.(*SQLiteDB)
+	if !ok {
+		t.Fatalf("expected *SQLiteDB, got %T", database)
+	}
+
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	return sqliteDB
+}
+
+func TestSQLiteFTSUpdatePageBodyText(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	pageID, err := db.CreatePage("https://example.com/fts-update", "Original Title", "html/test/original.html", "hash-1", now)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+
+	if err := db.UpdatePageBodyText(pageID, "hello archived world"); err != nil {
+		t.Fatalf("UpdatePageBodyText failed: %v", err)
+	}
+
+	pages, err := db.SearchPages("archived", nil, nil, "")
+	if err != nil {
+		t.Fatalf("SearchPages failed: %v", err)
+	}
+	if len(pages) != 1 || pages[0].ID != pageID {
+		t.Fatalf("SearchPages returned %+v, want page %d", pages, pageID)
+	}
+}
+
+func TestSQLiteSearchPages_MatchesURLTitleAndBodyText(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	pageID, err := db.CreatePage("https://test-update-feature.example.com/page-1", "Update Test - Original", "html/test/original.html", "hash-search", now)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	if err := db.UpdatePageBodyText(pageID, "This archived body includes dynamic content."); err != nil {
+		t.Fatalf("UpdatePageBodyText failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		keyword string
+	}{
+		{name: "URL substring", keyword: "test-update-feature.example.com"},
+		{name: "title substring", keyword: "Update Test - Original"},
+		{name: "body text substring", keyword: "dynamic content"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pages, err := db.SearchPages(tt.keyword, nil, nil, "")
+			if err != nil {
+				t.Fatalf("SearchPages failed: %v", err)
+			}
+			if len(pages) != 1 || pages[0].ID != pageID {
+				t.Fatalf("SearchPages(%q) returned %+v, want page %d", tt.keyword, pages, pageID)
+			}
+		})
+	}
+}
+
+func TestSQLiteReplacePageSnapshotWithBodyText(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	pageID, err := db.CreatePage("https://example.com/replace", "Original Title", "html/test/original.html", "hash-1", now)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+
+	bodyText := "snapshot body text"
+	if err := db.ReplacePageSnapshot(pageID, "html/test/updated.html", "hash-2", "Updated Title", &bodyText, nil); err != nil {
+		t.Fatalf("ReplacePageSnapshot failed: %v", err)
+	}
+
+	page, err := db.GetPageByID(idStr(pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	if page == nil {
+		t.Fatal("page should exist after ReplacePageSnapshot")
+	}
+	if page.HTMLPath != "html/test/updated.html" {
+		t.Fatalf("HTMLPath = %q, want %q", page.HTMLPath, "html/test/updated.html")
+	}
+	if page.ContentHash != "hash-2" {
+		t.Fatalf("ContentHash = %q, want %q", page.ContentHash, "hash-2")
+	}
+	if page.Title != "Updated Title" {
+		t.Fatalf("Title = %q, want %q", page.Title, "Updated Title")
+	}
+
+	pages, err := db.SearchPages("snapshot", nil, nil, "")
+	if err != nil {
+		t.Fatalf("SearchPages failed: %v", err)
+	}
+	if len(pages) != 1 || pages[0].ID != pageID {
+		t.Fatalf("SearchPages returned %+v, want page %d", pages, pageID)
+	}
+}

--- a/skill.md
+++ b/skill.md
@@ -238,7 +238,8 @@ DB_PATH=./data/wayback.db  # SQLite database file path (when DB_TYPE=sqlite)
 # PostgreSQL configuration (when DB_TYPE=postgres)
 DB_HOST=localhost
 DB_PORT=5432
-DB_USER=postgres  # 可选，PostgreSQL 默认使用系统用户名
+# DB_USER defaults to your current system username; falls back to postgres if unavailable
+# DB_USER=
 DB_PASSWORD=
 DB_NAME=wayback
 DB_SSLMODE=disable

--- a/tests/server/test_download_fallback.js
+++ b/tests/server/test_download_fallback.js
@@ -1,6 +1,7 @@
 const puppeteer = require('puppeteer');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 
 /**
  * 测试下载失败兜底逻辑：
@@ -13,8 +14,45 @@ const WAYBACK = process.env.WAYBACK || 'http://localhost:8080';
 const FAKE_URL = 'https://fallback-test-unreachable.invalid/fallback-style.css';
 const CSS_CONTENT = 'body { background-color: #ff6600 !important; color: white; }';
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
-const DATA_DIR = process.env.WAYBACK_DATA_DIR || path.join(ROOT_DIR, 'data');
-const DB_USER = process.env.DB_USER || process.env.USER || 'postgres';
+
+function loadEnvFile(envPath) {
+  if (!fs.existsSync(envPath)) {
+    return {};
+  }
+
+  const parsed = {};
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    parsed[key] = value;
+  }
+
+  return parsed;
+}
+
+const fileEnv = loadEnvFile(path.join(ROOT_DIR, '.env'));
+const readConfig = (key, fallback = '') => process.env[key] || fileEnv[key] || fallback;
+const DATA_DIR = process.env.WAYBACK_DATA_DIR || readConfig('DATA_DIR', path.join(ROOT_DIR, 'data'));
+const DB_TYPE = readConfig('DB_TYPE', 'sqlite').toLowerCase();
+const DB_PATH = readConfig('DB_PATH', path.join(DATA_DIR, 'wayback.db'));
+const DB_USER = readConfig('DB_USER', process.env.USER || 'postgres');
+const DB_NAME = readConfig('DB_NAME', 'wayback');
+const DB_HOST = readConfig('DB_HOST', 'localhost');
+const DB_PORT = readConfig('DB_PORT', '5432');
+const DB_PASSWORD = readConfig('DB_PASSWORD', '');
 
 let passed = 0, failed = 0;
 const failures = [];
@@ -24,11 +62,34 @@ function assert(name, cond, msg) {
   else { failed++; failures.push(`${name}: ${msg}`); console.log(`  [FAIL] ${name}: ${msg}`); }
 }
 
+function sqlQuote(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function insertResourceRecord({ url, hash, relPath, fileSize }) {
+  const insertSQL = `INSERT INTO resources (url, content_hash, resource_type, file_path, file_size, first_seen, last_seen)
+    VALUES (${sqlQuote(url)}, ${sqlQuote(hash)}, 'css', ${sqlQuote(relPath)}, ${fileSize}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`;
+
+  if (DB_TYPE === 'sqlite') {
+    execFileSync('sqlite3', [DB_PATH, insertSQL], { stdio: 'inherit' });
+    return;
+  }
+
+  if (DB_TYPE === 'postgres' || DB_TYPE === 'postgresql') {
+    execFileSync('psql', ['-U', DB_USER, '-d', DB_NAME, '-h', DB_HOST, '-p', DB_PORT, '-c', insertSQL], {
+      stdio: 'inherit',
+      env: { ...process.env, PGPASSWORD: DB_PASSWORD }
+    });
+    return;
+  }
+
+  throw new Error(`Unsupported DB_TYPE for test_download_fallback.js: ${DB_TYPE}`);
+}
+
 async function test() {
   console.log('=== Download Fallback Test ===\n');
 
   const crypto = require('crypto');
-  const fs = require('fs');
 
   // 计算 CSS 内容哈希
   const hash = crypto.createHash('sha256').update(CSS_CONTENT).digest('hex');
@@ -42,10 +103,12 @@ async function test() {
   console.log(`Step 1: Wrote resource file to disk: ${relPath}`);
 
   // 直接插入 DB 记录
-  const insertSQL = `INSERT INTO resources (url, content_hash, resource_type, file_path, file_size, first_seen, last_seen)
-    VALUES ('${FAKE_URL}', '${hash}', 'css', '${relPath}', ${CSS_CONTENT.length}, NOW(), NOW())
-    ON CONFLICT DO NOTHING`;
-  execSync(`psql -U ${DB_USER} -d wayback -c "${insertSQL}"`);
+  insertResourceRecord({
+    url: FAKE_URL,
+    hash,
+    relPath,
+    fileSize: CSS_CONTENT.length
+  });
   console.log('  Inserted resource record into DB');
 
   // Step 2: 归档页面，引用该不可达 URL


### PR DESCRIPTION
## Summary
- sync config docs with the current server defaults for database and resource settings
- localize snapshot header timestamps in the browser so archive pages follow the viewer's timezone like the list and timeline pages
- fix SQLite FTS/search behavior and make the download fallback e2e test work on SQLite so archive updates and SQLite test coverage stop failing

## Testing
- make test
- make test-e2e