### PR TITLE
fix: preserve media sources during HTML sanitization

### DIFF
--- a/server/internal/api/patterns.go
+++ b/server/internal/api/patterns.go
@@ -44,6 +44,7 @@ var (
 	embedTagRe       = regexp.MustCompile(`(?is)<embed\b[^>]*/?>`)
 	autoplayAttrRe   = regexp.MustCompile(`(?i)\s+autoplay(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?`)
 	controlsAttrRe   = regexp.MustCompile(`(?i)\s+controls(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?`)
+	pictureBlockRe   = regexp.MustCompile(`(?is)<picture\b[^>]*>.*?</picture>`)
 	sourceTagRe      = regexp.MustCompile(`(?is)<source[^>]*>`)
 	videoBlockRe     = regexp.MustCompile(`(?is)<video\b([^>]*)>(.*?)</video>|<video\b([^>]*)/>`)
 )

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -666,10 +666,12 @@ func serveFileStreaming(c *gin.Context, filePath string) {
 // 早期归档的页面 srcset 属性未被重写，这里在渲染时补偿处理
 // 策略：删除 <picture> 中的 <source> 元素，让浏览器回退到 <img> 标签（已被正确重写）
 func fixUnrewrittenSrcset(html string) string {
-	// 删除 <picture> 标签内的 <source> 元素
-	// <source> 提供 avif/webp 等现代格式，但 srcset 未重写会导致加载失败
-	// <img> 的 src 已被正确重写，删除 <source> 后浏览器会回退到 <img>
-	html = sourceTagRe.ReplaceAllString(html, "")
+	// 仅删除 <picture> 标签内的 <source> 元素，避免误伤 video/audio 的可播放资源。
+	html = pictureBlockRe.ReplaceAllStringFunc(html, func(match string) string {
+		// <source> 提供 avif/webp 等现代格式，但 srcset 未重写会导致加载失败。
+		// <img> 的 src 已被正确重写，删除 <source> 后浏览器会回退到 <img>。
+		return sourceTagRe.ReplaceAllString(match, "")
+	})
 
 	return html
 }

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -628,6 +628,48 @@ func TestHideVideoElements_PreservesExistingControlsValue(t *testing.T) {
 	}
 }
 
+func TestFixUnrewrittenSrcset_OnlyRemovesPictureSources(t *testing.T) {
+	html := `<picture><source srcset="/img.avif" type="image/avif"><source srcset="/img.webp" type="image/webp"><img src="/img.jpg"></picture><video><source src="/video.mp4" type="video/mp4"></video><audio><source src="/audio.mp3" type="audio/mpeg"></audio>`
+	result := fixUnrewrittenSrcset(html)
+
+	if strings.Contains(result, `<picture><source`) {
+		t.Fatalf("picture source tags should be removed, got: %s", result)
+	}
+	if !strings.Contains(result, `<img src="/img.jpg">`) {
+		t.Fatalf("picture fallback img should be preserved, got: %s", result)
+	}
+	if !strings.Contains(result, `<video><source src="/video.mp4" type="video/mp4"></video>`) {
+		t.Fatalf("video source should be preserved, got: %s", result)
+	}
+	if !strings.Contains(result, `<audio><source src="/audio.mp3" type="audio/mpeg"></audio>`) {
+		t.Fatalf("audio source should be preserved, got: %s", result)
+	}
+}
+
+func TestSanitizeArchivedHTML_PreservesMediaSourcesOutsidePicture(t *testing.T) {
+	html := `<picture><source srcset="/img.avif" type="image/avif"><img src="/img.jpg"></picture><video autoplay><source src="/video.mp4" type="video/mp4"></video><audio><source src="/audio.mp3" type="audio/mpeg"></audio>`
+	result := sanitizeArchivedHTML(html)
+
+	if strings.Contains(result, `<picture><source`) {
+		t.Fatalf("picture source tags should be removed during sanitize, got: %s", result)
+	}
+	if !strings.Contains(result, `<img src="/img.jpg">`) {
+		t.Fatalf("picture fallback img should remain after sanitize, got: %s", result)
+	}
+	if strings.Contains(strings.ToLower(result), "autoplay") {
+		t.Fatalf("video autoplay should be removed during sanitize, got: %s", result)
+	}
+	if !strings.Contains(strings.ToLower(result), "<video controls>") {
+		t.Fatalf("video should remain playable with controls after sanitize, got: %s", result)
+	}
+	if !strings.Contains(result, `<source src="/video.mp4" type="video/mp4">`) {
+		t.Fatalf("video source should remain after sanitize, got: %s", result)
+	}
+	if !strings.Contains(result, `<audio><source src="/audio.mp3" type="audio/mpeg"></audio>`) {
+		t.Fatalf("audio source should remain after sanitize, got: %s", result)
+	}
+}
+
 func TestRemoveUnsupportedEmbeddedContent_RemovesObjectEmbedButKeepsIframe(t *testing.T) {
 	html := `<div><iframe src="https://example.com/app"></iframe><object data="//cdn.example.com/plugin.swf"><param name="wmode" value="transparent"></object><embed src="https://example.com/movie.swf"><img src="/archive/1/20260414mp_/https://example.com/logo.png"></div>`
 	result := removeUnsupportedEmbeddedContent(html)


### PR DESCRIPTION
## Summary
- limit `fixUnrewrittenSrcset()` to removing `<source>` tags only inside `<picture>` blocks
- preserve `<video><source>` and `<audio><source>` media sources during archived HTML sanitization
- add regression coverage for both the helper and the full `sanitizeArchivedHTML()` flow

## Testing
- `go test ./internal/api`
- `make test`