### PR TITLE
fix: cover iframe and DOM collector regressions

### DIFF
--- a/browser/src/dom-collector.ts
+++ b/browser/src/dom-collector.ts
@@ -1,8 +1,9 @@
 // DOMCollector tracks nodes removed by virtual scrolling and merges them
 // back into the snapshot so we capture the union of all visible content.
 //
-// Uses arrays (not Sets) to preserve genuinely duplicated nodes
-// (e.g. two retweets with identical outerHTML).
+// Dedup uses textKey on purpose: if multiple removed nodes have identical
+// visible content, we keep only one archived copy. This is an intentional
+// snapshot-size tradeoff, not a bug.
 
 const MAX_COLLECTED_SIZE = 10 * 1024 * 1024; // 10MB cap
 const MIN_NODE_SIZE = 2 * 1024; // Only collect nodes >= 2KB (filters out loading skeletons)
@@ -22,8 +23,8 @@ export class DOMCollector {
 
   handleMutations(mutations: MutationRecord[]): void {
     for (const mutation of mutations) {
-      // When a node is re-added (user scrolled back), remove ONE matching
-      // entry from collected — not all of them, since duplicates are distinct items.
+      // When a node is re-added (user scrolled back), remove one collected entry.
+      // textKey-based dedup is intentional, so one re-added copy is enough.
       for (const node of Array.from(mutation.addedNodes)) {
         if (node.nodeType !== Node.ELEMENT_NODE) continue;
         const html = (node as Element).outerHTML;
@@ -108,8 +109,9 @@ export class DOMCollector {
           continue;
         }
 
-        // Only allow merging this key once — increment existing but NOT skipped,
-        // so subsequent duplicates see existCount > skippedSoFar and get skipped
+        // Intentionally keep only one archived copy for the same textKey.
+        // If the page shows multiple visually identical items, the snapshot may
+        // collapse them to one representative copy to reduce archive size.
         globalExisting.set(key, existCount + 1);
 
         const tpl = doc.createElement('template');

--- a/browser/src/frame-capture.ts
+++ b/browser/src/frame-capture.ts
@@ -85,26 +85,30 @@ function assessFrameDocument(doc: Document, url: string): FrameCaptureStatus {
   return 'ok';
 }
 
-async function waitForFrameReady(url: string): Promise<void> {
+async function waitForFrameReady(url: string): Promise<boolean> {
   const deadline = Date.now() + CONFIG.FRAME_CONTENT_WAIT_TIMEOUT;
 
   while (Date.now() < deadline) {
     if (assessFrameDocument(document, url) === 'ok') {
-      return;
+      return true;
     }
     await new Promise((resolve) => window.setTimeout(resolve, CONFIG.FRAME_CONTENT_CHECK_INTERVAL));
   }
+
+  return false;
 }
 
-async function waitForMeaningfulBodyContent(): Promise<void> {
+async function waitForMeaningfulBodyContent(): Promise<boolean> {
   const deadline = Date.now() + CONFIG.FRAME_CONTENT_WAIT_TIMEOUT;
 
   while (Date.now() < deadline) {
     if (hasMeaningfulBodyContent(document)) {
-      return;
+      return true;
     }
     await new Promise((resolve) => window.setTimeout(resolve, CONFIG.FRAME_CONTENT_CHECK_INTERVAL));
   }
+
+  return false;
 }
 
 function isMeaningfulCapturedHTML(html: string): boolean {
@@ -228,16 +232,20 @@ async function requestFrameCapture(frame: HTMLIFrameElement): Promise<FrameCaptu
       resolve(null);
     }, CONFIG.FRAME_CAPTURE_TIMEOUT);
 
-    function handleMessage(event: MessageEvent): void {
-      if (!isCaptureResult(event.data) || event.data.requestId !== requestId) {
-        return;
-      }
+      function handleMessage(event: MessageEvent): void {
+        if (!isCaptureResult(event.data) || event.data.requestId !== requestId) {
+          return;
+        }
 
-      window.clearTimeout(timeoutId);
-      responsePort.removeEventListener('message', handleMessage);
-      responsePort.close();
-      resolve(isMeaningfulCapturedHTML(event.data.html) ? event.data : null);
-    }
+        window.clearTimeout(timeoutId);
+        responsePort.removeEventListener('message', handleMessage);
+        responsePort.close();
+        if (event.data.status === 'ok' && !isMeaningfulCapturedHTML(event.data.html)) {
+          resolve(null);
+          return;
+        }
+        resolve(event.data);
+      }
 
     responsePort.addEventListener('message', handleMessage);
     responsePort.start();
@@ -329,11 +337,9 @@ export function setupFrameCaptureBridge(): void {
           // Fall through and capture best-effort current DOM.
         }
 
-        try {
-          await waitForMeaningfulBodyContent();
+        const hasBodyContent = await waitForMeaningfulBodyContent();
+        if (hasBodyContent) {
           await waitForFrameReady(window.location.href);
-        } catch {
-          // Fall through and capture best-effort current DOM.
         }
 
         const captured = await captureDocumentHTMLWithFrames();

--- a/browser/tests/main.integration.test.js
+++ b/browser/tests/main.integration.test.js
@@ -8,10 +8,15 @@ const {
   mockCompiledModule,
 } = require('./helpers/fake-browser.js');
 
-function loadMainWithEnvironment(environment, sendToServer) {
+function loadMainWithEnvironment(environment, sendToServer, options = {}) {
   const mainPath = require.resolve('../dist-test/main.js');
   const pageFreezerPath = require.resolve('../dist-test/page-freezer.js');
   const distTestPath = path.join(__dirname, '../dist-test');
+  const updateOnServer = options.updateOnServer || (async () => ({ action: 'updated', page_id: 1, status: 'success' }));
+  const captureDocumentHTMLWithFrames = options.captureDocumentHTMLWithFrames || (async () => ({
+    frames: [],
+    html: '<html><body>quiet page</body></html>',
+  }));
   const restoreGlobals = installGlobalBindings({
     window: environment.window,
     document: environment.document,
@@ -51,7 +56,7 @@ function loadMainWithEnvironment(environment, sendToServer) {
     }),
     mockCompiledModule(path.join(distTestPath, 'archiver.js'), {
       sendToServer,
-      updateOnServer: async () => ({ action: 'updated', page_id: 1, status: 'success' }),
+      updateOnServer,
     }),
     mockCompiledModule(path.join(distTestPath, 'dom-collector.js'), {
       DOMCollector: class {
@@ -70,10 +75,7 @@ function loadMainWithEnvironment(environment, sendToServer) {
       },
     }),
     mockCompiledModule(path.join(distTestPath, 'frame-capture.js'), {
-      captureDocumentHTMLWithFrames: async () => ({
-        frames: [],
-        html: '<html><body>quiet page</body></html>',
-      }),
+      captureDocumentHTMLWithFrames,
       setupFrameCaptureBridge: () => {},
     }),
   ];
@@ -203,6 +205,80 @@ test('main archives a short quiet-page visit once before beforeunload', async ()
     await flushMicrotasks();
     assert.equal(sendCalls.length, 1, 'beforeunload should not duplicate the initial archive send');
   } finally {
+    restore();
+  }
+});
+
+test('main ignores stale in-flight update when SPA navigation resets state', async () => {
+  const environment = createFakeBrowserEnvironment();
+  const sendCalls = [];
+  const updateCalls = [];
+  let resolveUpdate;
+
+  environment.history.pushState = function pushState(_state, _title, url) {
+    const nextURL = new URL(url, environment.location.href);
+    environment.location.href = nextURL.href;
+    environment.location.hostname = nextURL.hostname;
+  };
+
+  const { restore } = loadMainWithEnvironment(
+    environment,
+    async (captureData) => {
+      sendCalls.push(captureData);
+      return { action: sendCalls.length === 1 ? 'created' : 'created', page_id: sendCalls.length, status: 'success' };
+    },
+    {
+      captureDocumentHTMLWithFrames: async () => ({
+        frames: [],
+        html: `<html><body>${environment.location.href}</body></html>`,
+      }),
+      updateOnServer: async (pageId, captureData) => {
+        updateCalls.push({ pageId, captureData });
+        await new Promise((resolve) => {
+          resolveUpdate = resolve;
+        });
+        return { action: 'updated', page_id: pageId, status: 'success' };
+      },
+    },
+  );
+
+  try {
+    environment.advanceTime(5);
+    await flushMicrotasks();
+    environment.advanceTime(25);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 1, 'initial capture should complete before update test starts');
+
+    const activeObserver = environment.MutationObserver.instances.at(-1);
+    activeObserver.trigger(Array.from({ length: 10 }, () => ({ type: 'childList' })));
+    environment.advanceTime(100);
+    await flushMicrotasks();
+
+    assert.equal(updateCalls.length, 1, 'DOM monitor should start one update');
+    assert.equal(updateCalls[0].pageId, 1, 'update should target the original archived page');
+
+    environment.document.title = 'Next page';
+    environment.history.pushState({}, '', '/articles/next-page');
+    await flushMicrotasks();
+
+    resolveUpdate();
+    await flushMicrotasks();
+
+    environment.advanceTime(5);
+    await flushMicrotasks();
+    environment.advanceTime(25);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 2, 'new SPA page should still archive after stale update settles');
+    assert.equal(sendCalls[0].url, 'https://example.com/articles/quiet-page');
+    assert.equal(sendCalls[1].url, 'https://example.com/articles/next-page');
+    assert.equal(sendCalls[1].title, 'Next page');
+    assert.equal(updateCalls.length, 1, 'stale update completion should not trigger extra updates');
+  } finally {
+    if (resolveUpdate) {
+      resolveUpdate();
+    }
     restore();
   }
 });

--- a/server/internal/api/proxy_resource_integration_test.go
+++ b/server/internal/api/proxy_resource_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"wayback/internal/database"
 )
 
 func TestProxyResource_RewritesCSSForCurrentPage(t *testing.T) {
@@ -229,6 +230,92 @@ func TestProxyResource_EncodedCSSSubresourceDoesNotLeakAcrossPages(t *testing.T)
 	}
 	if !strings.Contains(w2.Body.String(), `url("../img/icon space.png")`) {
 		t.Fatalf("page2 should keep original encoded relative URL source, got: %s", w2.Body.String())
+	}
+}
+
+func TestProxyResource_SamePageVersionedQueryResourcesDoNotCrossRewrite(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "wayback.db")
+	db, err := database.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLite failed: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewHandler(nil, db, dataDir, nil)
+
+	router := gin.New()
+	router.GET("/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pageID, err := handler.db.CreatePage("https://versioned-query-test.example.com/page-"+suffix, "Versioned Query", "html/test/versioned-query.html", strings.Repeat("b", 64), time.Now())
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer handler.db.DeletePage(pageID)
+
+	cssV1URL := "https://versioned-query-test.example.com/assets/css/app.css?v=1"
+	cssV2URL := "https://versioned-query-test.example.com/assets/css/app.css?v=2"
+	imgV1URL := "https://versioned-query-test.example.com/assets/img/logo.png?v=1"
+	imgV2URL := "https://versioned-query-test.example.com/assets/img/logo.png?v=2"
+
+	cssV1Path := "resources/51/61/app-v1.css"
+	cssV2Path := "resources/52/62/app-v2.css"
+	imgV1Path := "resources/53/63/logo-v1.img"
+	imgV2Path := "resources/54/64/logo-v2.img"
+
+	writeTestResourceFile(t, handler.dataDir, cssV1Path, []byte(`.hero{background:url("../img/logo.png?v=1")}`))
+	writeTestResourceFile(t, handler.dataDir, cssV2Path, []byte(`.hero{background:url("../img/logo.png?v=2")}`))
+	writeTestResourceFile(t, handler.dataDir, imgV1Path, []byte("img-v1"))
+	writeTestResourceFile(t, handler.dataDir, imgV2Path, []byte("img-v2"))
+
+	cssV1ID, err := handler.db.CreateResource(cssV1URL, strings.Repeat("c", 64), "css", cssV1Path, 32)
+	if err != nil {
+		t.Fatalf("CreateResource css v1 failed: %v", err)
+	}
+	cssV2ID, err := handler.db.CreateResource(cssV2URL, strings.Repeat("d", 64), "css", cssV2Path, 32)
+	if err != nil {
+		t.Fatalf("CreateResource css v2 failed: %v", err)
+	}
+	imgV1ID, err := handler.db.CreateResource(imgV1URL, strings.Repeat("e", 64), "image", imgV1Path, 6)
+	if err != nil {
+		t.Fatalf("CreateResource img v1 failed: %v", err)
+	}
+	imgV2ID, err := handler.db.CreateResource(imgV2URL, strings.Repeat("f", 64), "image", imgV2Path, 6)
+	if err != nil {
+		t.Fatalf("CreateResource img v2 failed: %v", err)
+	}
+
+	for _, resourceID := range []int64{cssV1ID, cssV2ID, imgV1ID, imgV2ID} {
+		if err := handler.db.LinkPageResource(pageID, resourceID); err != nil {
+			t.Fatalf("LinkPageResource(%d) failed: %v", resourceID, err)
+		}
+	}
+
+	reqV1 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/archive/%d/20260410122500mp_/%s", pageID, cssV1URL), nil)
+	wV1 := httptest.NewRecorder()
+	router.ServeHTTP(wV1, reqV1)
+	if wV1.Code != http.StatusOK {
+		t.Fatalf("css v1 expected 200, got %d: %s", wV1.Code, wV1.Body.String())
+	}
+	if !strings.Contains(wV1.Body.String(), `url("/archive/resources/53/63/logo-v1.img")`) {
+		t.Fatalf("css v1 should rewrite to image v1, got: %s", wV1.Body.String())
+	}
+	if strings.Contains(wV1.Body.String(), "/archive/resources/54/64/logo-v2.img") {
+		t.Fatalf("css v1 should not rewrite to image v2, got: %s", wV1.Body.String())
+	}
+
+	reqV2 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/archive/%d/20260410122500mp_/%s", pageID, cssV2URL), nil)
+	wV2 := httptest.NewRecorder()
+	router.ServeHTTP(wV2, reqV2)
+	if wV2.Code != http.StatusOK {
+		t.Fatalf("css v2 expected 200, got %d: %s", wV2.Code, wV2.Body.String())
+	}
+	if !strings.Contains(wV2.Body.String(), `url("/archive/resources/54/64/logo-v2.img")`) {
+		t.Fatalf("css v2 should rewrite to image v2, got: %s", wV2.Body.String())
+	}
+	if strings.Contains(wV2.Body.String(), "/archive/resources/53/63/logo-v1.img") {
+		t.Fatalf("css v2 should not rewrite to image v1, got: %s", wV2.Body.String())
 	}
 }
 

--- a/server/internal/api/view_handler_test.go
+++ b/server/internal/api/view_handler_test.go
@@ -670,6 +670,27 @@ func TestSanitizeArchivedHTML_PreservesMediaSourcesOutsidePicture(t *testing.T) 
 	}
 }
 
+func TestSanitizeArchivedHTML_HidesEmptyVideoButPreservesPlayableMediaSources(t *testing.T) {
+	html := `<picture><source srcset="/fallback.avif"><img src="/fallback.jpg"></picture><video autoplay></video><video autoplay><source src="/kept-video.mp4" type="video/mp4"></video><audio controls><source src="/kept-audio.mp3" type="audio/mpeg"></audio>`
+	result := sanitizeArchivedHTML(html)
+
+	if strings.Contains(result, `<picture><source`) {
+		t.Fatalf("picture source tags should be removed during sanitize, got: %s", result)
+	}
+	if !strings.Contains(result, `<img src="/fallback.jpg">`) {
+		t.Fatalf("picture fallback img should remain after sanitize, got: %s", result)
+	}
+	if !strings.Contains(result, `<video style="display:none!important"></video>`) {
+		t.Fatalf("empty video should be hidden during sanitize, got: %s", result)
+	}
+	if !strings.Contains(strings.ToLower(result), `<video controls><source src="/kept-video.mp4" type="video/mp4"></video>`) {
+		t.Fatalf("playable video source should remain during sanitize, got: %s", result)
+	}
+	if !strings.Contains(result, `<audio controls><source src="/kept-audio.mp3" type="audio/mpeg"></audio>`) {
+		t.Fatalf("audio source should remain during sanitize, got: %s", result)
+	}
+}
+
 func TestRemoveUnsupportedEmbeddedContent_RemovesObjectEmbedButKeepsIframe(t *testing.T) {
 	html := `<div><iframe src="https://example.com/app"></iframe><object data="//cdn.example.com/plugin.swf"><param name="wmode" value="transparent"></object><embed src="https://example.com/movie.swf"><img src="/archive/1/20260414mp_/https://example.com/logo.png"></div>`
 	result := removeUnsupportedEmbeddedContent(html)

--- a/tests/server/test_frame_capture_status_rewrite.js
+++ b/tests/server/test_frame_capture_status_rewrite.js
@@ -1,0 +1,136 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const ARCHIVE_ENDPOINT = 'http://localhost:8080/api/archive';
+
+async function main() {
+  const bundlePath = path.join(__dirname, '../../browser/dist/wayback-puppeteer.js');
+  const bundle = fs.readFileSync(bundlePath, 'utf8');
+  const emptyURL = 'http://lvh.me:8102/empty';
+  const placeholderURL = 'http://lvh.me:8103/placeholder';
+
+  const parentServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><head><title>Parent Page</title></head><body><iframe id="empty-frame" src="${emptyURL}"></iframe><iframe id="placeholder-frame" src="${placeholderURL}"></iframe></body></html>`);
+  });
+
+  const emptyServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<!doctype html><html><head><title>Empty Child</title></head><body></body></html>');
+  });
+
+  const placeholderServer = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<!doctype html><html><head><title>Placeholder Child</title></head><body style="display:none;visibility:hidden"><main>placeholder body</main></body></html>');
+  });
+
+  await new Promise((resolve) => parentServer.listen(8101, '127.0.0.1', resolve));
+  await new Promise((resolve) => emptyServer.listen(8102, '127.0.0.1', resolve));
+  await new Promise((resolve) => placeholderServer.listen(8103, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (text.includes('[Wayback]')) {
+        console.log('[browser]', text);
+      }
+    });
+
+    await page.evaluateOnNewDocument((archiveEndpoint) => {
+      window.__archiveRequests = [];
+      const nativeFetch = window.fetch.bind(window);
+
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string'
+          ? input
+          : (typeof Request !== 'undefined' && input instanceof Request ? input.url : String(input));
+        const method = init?.method || (typeof Request !== 'undefined' && input instanceof Request ? input.method : 'GET');
+
+        if (url === archiveEndpoint && method === 'POST') {
+          window.__archiveRequests.push({
+            url,
+            body: typeof init?.body === 'string' ? init.body : '',
+          });
+
+          return new Response(JSON.stringify({
+            status: 'success',
+            page_id: 1,
+            action: 'created',
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        return nativeFetch(input, init);
+      };
+    }, ARCHIVE_ENDPOINT);
+
+    await page.evaluateOnNewDocument(bundle);
+    await page.goto('http://lvh.me:8101/', { waitUntil: 'networkidle2', timeout: 120000 });
+    await page.evaluate(() => window.archivePage());
+
+    const capture = await page.evaluate(() => {
+      if (!window.__archiveRequests.length) {
+        throw new Error('archive request was not captured');
+      }
+      return JSON.parse(window.__archiveRequests[0].body);
+    });
+
+    if (Array.isArray(capture.frames) && capture.frames.length !== 0) {
+      throw new Error(`expected empty/placeholder frames to be skipped from frames payload, got ${JSON.stringify(capture.frames)}`);
+    }
+
+    const html = capture.html;
+    const emptyTagMatch = html.match(/<iframe[^>]*id="empty-frame"[^>]*>/i);
+    if (!emptyTagMatch) {
+      throw new Error(`missing empty iframe tag in parent HTML: ${html}`);
+    }
+    if (!emptyTagMatch[0].includes('data-wayback-frame-status="empty"')) {
+      throw new Error(`empty iframe should be marked as empty: ${emptyTagMatch[0]}`);
+    }
+    if (!emptyTagMatch[0].includes(`data-wayback-original-src="${emptyURL}"`)) {
+      throw new Error(`empty iframe should preserve original src: ${emptyTagMatch[0]}`);
+    }
+    if (/\ssrc=|\ssrcdoc=/i.test(emptyTagMatch[0])) {
+      throw new Error(`empty iframe should have src/srcdoc removed: ${emptyTagMatch[0]}`);
+    }
+
+    const placeholderTagMatch = html.match(/<iframe[^>]*id="placeholder-frame"[^>]*>/i);
+    if (!placeholderTagMatch) {
+      throw new Error(`missing placeholder iframe tag in parent HTML: ${html}`);
+    }
+    if (!placeholderTagMatch[0].includes('data-wayback-frame-status="placeholder"')) {
+      throw new Error(`placeholder iframe should be marked as placeholder: ${placeholderTagMatch[0]}`);
+    }
+    if (!placeholderTagMatch[0].includes(`data-wayback-original-src="${placeholderURL}"`)) {
+      throw new Error(`placeholder iframe should preserve original src: ${placeholderTagMatch[0]}`);
+    }
+    if (/\ssrc=|\ssrcdoc=/i.test(placeholderTagMatch[0])) {
+      throw new Error(`placeholder iframe should have src/srcdoc removed: ${placeholderTagMatch[0]}`);
+    }
+
+    await page.close();
+    console.log('PASS test_frame_capture_status_rewrite');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => parentServer.close(resolve));
+    await new Promise((resolve) => emptyServer.close(resolve));
+    await new Promise((resolve) => placeholderServer.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/server/test_userscript_domcollector_duplicate.js
+++ b/tests/server/test_userscript_domcollector_duplicate.js
@@ -1,0 +1,104 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const ARCHIVE_ENDPOINT = 'http://localhost:8080/api/archive';
+
+async function main() {
+  const bundlePath = path.join(__dirname, '../../browser/dist/wayback-puppeteer.js');
+  const bundle = fs.readFileSync(bundlePath, 'utf8');
+  const repeatedText = 'duplicate-node-content '.repeat(180);
+
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!doctype html><html><head><title>Duplicate Collector</title></head><body><main id="feed"><article class="dup-item"><h2>duplicate sentinel</h2><p>${repeatedText}</p></article><article class="dup-item"><h2>duplicate sentinel</h2><p>${repeatedText}</p></article></main></body></html>`);
+  });
+
+  await new Promise((resolve) => server.listen(8104, '127.0.0.1', resolve));
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (text.includes('[Wayback]')) {
+        console.log('[browser]', text);
+      }
+    });
+
+    await page.evaluateOnNewDocument((archiveEndpoint) => {
+      window.__archiveRequests = [];
+      const nativeFetch = window.fetch.bind(window);
+
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string'
+          ? input
+          : (typeof Request !== 'undefined' && input instanceof Request ? input.url : String(input));
+        const method = init?.method || (typeof Request !== 'undefined' && input instanceof Request ? input.method : 'GET');
+
+        if (url === archiveEndpoint && method === 'POST') {
+          window.__archiveRequests.push({
+            url,
+            body: typeof init?.body === 'string' ? init.body : '',
+          });
+
+          return new Response(JSON.stringify({
+            status: 'success',
+            page_id: 1,
+            action: 'created',
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        return nativeFetch(input, init);
+      };
+    }, ARCHIVE_ENDPOINT);
+
+    await page.evaluateOnNewDocument(bundle);
+    await page.goto('http://lvh.me:8104/', { waitUntil: 'networkidle2', timeout: 120000 });
+    await page.waitForFunction(() => document.querySelectorAll('.dup-item').length === 2, { timeout: 10000 });
+
+    await page.evaluate(async () => {
+      const items = Array.from(document.querySelectorAll('.dup-item'));
+      const archivePromise = window.archivePage();
+      setTimeout(() => {
+        for (const item of items) {
+          item.remove();
+        }
+      }, 0);
+      await archivePromise;
+    });
+
+    const capture = await page.evaluate(() => {
+      if (!window.__archiveRequests.length) {
+        throw new Error('archive request was not captured');
+      }
+      return JSON.parse(window.__archiveRequests[0].body);
+    });
+
+    const duplicateMatches = capture.html.match(/<article class="dup-item">/g) || [];
+    if (duplicateMatches.length !== 1) {
+      throw new Error(`expected identical duplicate nodes to collapse to one archived copy, got ${duplicateMatches.length}\n${capture.html}`);
+    }
+
+    await page.close();
+    console.log('PASS test_userscript_domcollector_duplicate');
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add regression coverage for skipped iframe statuses, SPA navigation/update races, and DOMCollector duplicate-content behavior
- fix frame capture so empty and placeholder iframes report status back to the parent snapshot instead of timing out
- add server-side regression tests for media sanitization and same-page query-versioned resource rewriting

## Testing
- make test
- make test-e2e