### PR TITLE
fix: stabilize archive replay and timestamp handling

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -60,6 +60,7 @@ const userscriptModules = [
   'bridge-auth.js',
   'spa-coordinator.js',
   'frame-capture.js',
+  'viewport-meta.js',
   'archiver.js',
   'main.js',
 ];
@@ -74,6 +75,7 @@ const puppeteerModules = [
   'html-url-normalizer.js',
   'bridge-auth.js',
   'frame-capture.js',
+  'viewport-meta.js',
   'puppeteer.js',
 ];
 

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -22,6 +22,7 @@ import { sendToServer, updateOnServer } from './archiver';
 import { DOMCollector } from './dom-collector';
 import { captureDocumentHTMLWithFrames, setupFrameCaptureBridge } from './frame-capture';
 import { chooseFlushAction, choosePendingFlushDependency, shouldClearAsyncState, shouldCommitMonitorUpdate } from './spa-coordinator';
+import { captureViewportMeta, injectViewportMeta } from './viewport-meta';
 
 // Early exit check before any initialization
 if (shouldSkipPage()) {
@@ -88,6 +89,8 @@ function initializeArchiver(): void {
       console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes into snapshot...`);
       html = domCollector.mergeInto(html);
     }
+
+    html = injectViewportMeta(html, captureViewportMeta());
 
     return {
       url: snapshotURL,

--- a/browser/src/puppeteer.ts
+++ b/browser/src/puppeteer.ts
@@ -7,6 +7,7 @@ import { shouldSkipPage } from './page-filter';
 import { waitForDOMStable } from './page-freezer';
 import { DOMCollector } from './dom-collector';
 import { captureDocumentHTMLWithFrames, setupFrameCaptureBridge } from './frame-capture';
+import { captureViewportMeta, injectViewportMeta } from './viewport-meta';
 
 // pako is loaded via script tag in Puppeteer
 declare const pako: any;
@@ -122,6 +123,8 @@ export async function archivePage(): Promise<void> {
     console.log(`[Wayback] Merging ${domCollector.collectedCount} collected nodes`);
     html = domCollector.mergeInto(html);
   }
+
+  html = injectViewportMeta(html, captureViewportMeta());
 
   collectorObserver.disconnect();
 

--- a/browser/src/style-inliner.ts
+++ b/browser/src/style-inliner.ts
@@ -43,6 +43,8 @@ const SVG_GRAPHIC_TAGS = new Set([
 const GSAP_ANIM_RE = /translate:\s*none|rotate:\s*none|scale:\s*none/;
 const ANIM_STYLE_CLEANUP_RE = /\b(?:opacity:\s*0|transform:\s*[^;]+|translate:\s*[^;]+|rotate:\s*[^;]+|scale:\s*[^;]+|stroke-dashoffset:\s*[^;]+)\s*;?/g;
 const MULTI_SEMI_RE = /;\s*;+/g;
+const TRANSFORM_IDENTITY_EPSILON = 0.001;
+const TRANSLATE_ZERO_EPSILON = 0.5;
 
 function neutralizeClonedMedia(cloneRoot: ParentNode): void {
   for (const node of Array.from(cloneRoot.querySelectorAll('video, audio'))) {
@@ -147,6 +149,198 @@ const TABLE_DISPLAY_TAGS: Record<string, string> = {
 };
 const LIST_ITEM_TAG = 'LI';
 
+export interface FixedLayoutMetrics {
+  position: string;
+  elementLeft: number;
+  elementWidth: number;
+  parentLeft: number;
+  parentWidth: number;
+  childWidth: number;
+}
+
+export function shouldNormalizeDetachedFixedLayout(metrics: FixedLayoutMetrics): boolean {
+  if (metrics.position !== 'fixed') {
+    return false;
+  }
+
+  if (metrics.childWidth < 200 || metrics.parentWidth <= 1 || metrics.parentWidth + 1 < metrics.childWidth) {
+    return false;
+  }
+
+  const widthCollapsed = metrics.elementWidth + 1 < metrics.childWidth;
+  const detachedFromParent = Math.abs(metrics.elementLeft - metrics.parentLeft) > 1 || Math.abs(metrics.elementWidth - metrics.parentWidth) > 1;
+  return widthCollapsed || detachedFromParent;
+}
+
+function approximatelyEqual(value: number, expected: number, epsilon: number): boolean {
+  return Math.abs(value - expected) <= epsilon;
+}
+
+function parseTransformNumbers(transform: string, prefix: 'matrix' | 'matrix3d', expectedLength: number): number[] | null {
+  const match = transform.match(new RegExp(`^${prefix}\\(([^)]+)\\)$`, 'i'));
+  if (!match) {
+    return null;
+  }
+
+  const values = match[1].split(',').map((part) => Number.parseFloat(part.trim()));
+  if (values.length !== expectedLength || values.some((value) => !Number.isFinite(value))) {
+    return null;
+  }
+
+  return values;
+}
+
+function parseSingleTransformValue(transform: string, fnName: string): number | null {
+  const match = transform.match(new RegExp(`^${fnName}\\(\\s*([^)]+?)\\s*\\)$`, 'i'));
+  if (!match) {
+    return null;
+  }
+
+  const value = Number.parseFloat(match[1].trim());
+  return Number.isFinite(value) ? value : null;
+}
+
+function parseTranslateValues(transform: string): [number, number] | null {
+  const match = transform.match(/^translate\(\s*([^,)]+?)\s*(?:,\s*([^)]+?)\s*)?\)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const x = Number.parseFloat(match[1].trim());
+  if (!Number.isFinite(x)) {
+    return null;
+  }
+
+  if (!match[2]) {
+    return [x, 0];
+  }
+
+  const y = Number.parseFloat(match[2].trim());
+  if (!Number.isFinite(y)) {
+    return null;
+  }
+
+  return [x, y];
+}
+
+function parseTranslate3dValues(transform: string): [number, number, number] | null {
+  const match = transform.match(/^translate3d\(\s*([^,)]+?)\s*,\s*([^,)]+?)\s*,\s*([^)]+?)\s*\)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const values = match.slice(1).map((part) => Number.parseFloat(part.trim()));
+  if (values.some((value) => !Number.isFinite(value))) {
+    return null;
+  }
+
+  return [values[0], values[1], values[2]];
+}
+
+export function shouldResetDetachedFixedTransform(transform: string): boolean {
+  const normalized = transform.trim();
+  if (!normalized || normalized === 'none') {
+    return false;
+  }
+
+  const matrix = parseTransformNumbers(normalized, 'matrix', 6);
+  if (matrix) {
+    const [a, b, c, d, tx, ty] = matrix;
+    return approximatelyEqual(a, 1, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(b, 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(c, 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(d, 1, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(ty, 0, TRANSLATE_ZERO_EPSILON) &&
+      Math.abs(tx) > TRANSLATE_ZERO_EPSILON;
+  }
+
+  const matrix3d = parseTransformNumbers(normalized, 'matrix3d', 16);
+  if (matrix3d) {
+    return approximatelyEqual(matrix3d[0], 1, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[1], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[2], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[3], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[4], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[5], 1, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[6], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[7], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[8], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[9], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[10], 1, TRANSFORM_IDENTITY_EPSILON) &&
+      approximatelyEqual(matrix3d[11], 0, TRANSFORM_IDENTITY_EPSILON) &&
+      Math.abs(matrix3d[12]) > TRANSLATE_ZERO_EPSILON &&
+      approximatelyEqual(matrix3d[13], 0, TRANSLATE_ZERO_EPSILON) &&
+      approximatelyEqual(matrix3d[14], 0, TRANSLATE_ZERO_EPSILON) &&
+      approximatelyEqual(matrix3d[15], 1, TRANSFORM_IDENTITY_EPSILON);
+  }
+
+  const translateX = parseSingleTransformValue(normalized, 'translateX');
+  if (translateX !== null) {
+    return Math.abs(translateX) > TRANSLATE_ZERO_EPSILON;
+  }
+
+  const translate = parseTranslateValues(normalized);
+  if (translate) {
+    return Math.abs(translate[0]) > TRANSLATE_ZERO_EPSILON && approximatelyEqual(translate[1], 0, TRANSLATE_ZERO_EPSILON);
+  }
+
+  const translate3d = parseTranslate3dValues(normalized);
+  if (translate3d) {
+    return Math.abs(translate3d[0]) > TRANSLATE_ZERO_EPSILON &&
+      approximatelyEqual(translate3d[1], 0, TRANSLATE_ZERO_EPSILON) &&
+      approximatelyEqual(translate3d[2], 0, TRANSLATE_ZERO_EPSILON);
+  }
+
+  return false;
+}
+
+function appendInlineStyle(el: Element, cssText: string): void {
+  const existing = el.getAttribute('style') || '';
+  el.setAttribute('style', existing ? `${existing};${cssText}` : cssText);
+}
+
+function normalizeDetachedFixedLayouts(pairs: Array<{ origEl: Element; cloneEl: Element }>): number {
+  let normalizedCount = 0;
+
+  // Capture-time normalization is the single source of truth.
+  // Replay should not run a second drifting copy of this fix.
+  for (const { origEl, cloneEl } of pairs) {
+    const origParent = origEl.parentElement;
+    const cloneParent = cloneEl.parentElement;
+    const firstChild = origEl.firstElementChild;
+    if (!origParent || !cloneParent || !firstChild) continue;
+
+    const computed = window.getComputedStyle(origEl);
+    const rect = origEl.getBoundingClientRect();
+    const parentRect = origParent.getBoundingClientRect();
+    const childRect = firstChild.getBoundingClientRect();
+
+    if (!shouldNormalizeDetachedFixedLayout({
+      position: computed.position,
+      elementLeft: rect.left,
+      elementWidth: rect.width,
+      parentLeft: parentRect.left,
+      parentWidth: parentRect.width,
+      childWidth: childRect.width,
+    })) {
+      continue;
+    }
+
+    if (window.getComputedStyle(origParent).position === 'static') {
+      appendInlineStyle(cloneParent, 'position:relative');
+    }
+
+    const transformReset = shouldResetDetachedFixedTransform(computed.transform) ? ';transform:none' : '';
+    appendInlineStyle(
+      cloneEl,
+      `position:sticky;top:0px;left:auto;right:auto;bottom:auto;width:100%;height:auto;pointer-events:auto${transformReset}`
+    );
+    normalizedCount++;
+  }
+
+  return normalizedCount;
+}
+
 /**
  * 在克隆的 DOM 上内联布局样式，返回带内联样式的 outerHTML。
  * 不修改原始 DOM，避免影响页面显示。
@@ -157,6 +351,7 @@ const LIST_ITEM_TAG = 'LI';
 export function inlineLayoutStyles(): string {
   const startTime = performance.now();
   let count = 0;
+  const elementPairs: Array<{ origEl: Element; cloneEl: Element }> = [];
 
   // 视口尺寸 — 用于跳过 width/height 接近视口的值（来自 100%/100vh）
   const vw = window.innerWidth;
@@ -182,6 +377,7 @@ export function inlineLayoutStyles(): string {
     const origEl = origNode as Element;
     const cloneEl = cloneNode as Element;
     if (SKIP_TAGS.has(origEl.tagName)) continue;
+    elementPairs.push({ origEl, cloneEl });
 
     // 从原始 DOM 读取 computed style（克隆节点不在文档中，无法 getComputedStyle）
     const computed = window.getComputedStyle(origEl);
@@ -306,8 +502,13 @@ export function inlineLayoutStyles(): string {
     count++;
   }
 
+  const normalizedFixedCount = normalizeDetachedFixedLayouts(elementPairs);
+
   const elapsed = (performance.now() - startTime).toFixed(0);
   console.log(`[Wayback] Inlined layout styles for ${count} elements in ${elapsed}ms`);
+  if (normalizedFixedCount > 0) {
+    console.log(`[Wayback] Normalized ${normalizedFixedCount} detached fixed layout containers`);
+  }
 
   return clone.outerHTML;
 }

--- a/browser/src/viewport-meta.ts
+++ b/browser/src/viewport-meta.ts
@@ -1,0 +1,42 @@
+const VIEWPORT_META_NAME = 'wayback-viewport';
+const HEAD_TAG_RE = /<head([^>]*)>/i;
+const VIEWPORT_META_RE = /<meta\b[^>]*\bname\s*=\s*["']wayback-viewport["'][^>]*>/i;
+const VIEWPORT_STYLE_RE = /<style\b[^>]*\bid\s*=\s*["']wayback-captured-viewport-style["'][^>]*>[\s\S]*?<\/style>/i;
+
+export interface CapturedViewportMeta {
+  width: number;
+  height: number;
+  dpr: number;
+}
+
+export function captureViewportMeta(): CapturedViewportMeta {
+  return {
+    width: Math.max(0, Math.round(window.innerWidth || 0)),
+    height: Math.max(0, Math.round(window.innerHeight || 0)),
+    dpr: Math.max(1, Math.round((window.devicePixelRatio || 1) * 1000) / 1000),
+  };
+}
+
+export function injectViewportMeta(html: string, viewport: CapturedViewportMeta): string {
+  if (!html || viewport.width <= 0 || viewport.height <= 0) {
+    return html;
+  }
+
+  const metaTag = `<meta name="${VIEWPORT_META_NAME}" content="width=${viewport.width},height=${viewport.height},dpr=${viewport.dpr}">`;
+  let result = html;
+
+  // Capture viewport dimensions as metadata only; replay should not rewrite page layout here.
+  if (VIEWPORT_STYLE_RE.test(result)) {
+    result = result.replace(VIEWPORT_STYLE_RE, '');
+  }
+
+  if (VIEWPORT_META_RE.test(result)) {
+    result = result.replace(VIEWPORT_META_RE, metaTag);
+  } else if (HEAD_TAG_RE.test(result)) {
+    result = result.replace(HEAD_TAG_RE, `<head$1>${metaTag}`);
+  } else {
+    result = metaTag + result;
+  }
+
+  return result;
+}

--- a/browser/tests/main.integration.test.js
+++ b/browser/tests/main.integration.test.js
@@ -124,6 +124,37 @@ test('main starts the initial capture on a quiet page after stableTime instead o
   }
 });
 
+test('main injects captured viewport metadata before upload without overriding layout', async () => {
+  const environment = createFakeBrowserEnvironment();
+  environment.window.innerWidth = 1733;
+  environment.window.innerHeight = 977;
+  environment.window.devicePixelRatio = 1.25;
+  const sendCalls = [];
+  const { restore } = loadMainWithEnvironment(environment, async (captureData) => {
+    sendCalls.push(captureData);
+    return { action: 'created', page_id: 1, status: 'success' };
+  }, {
+    captureDocumentHTMLWithFrames: async () => ({
+      frames: [],
+      html: '<html><head><title>Viewport test</title></head><body>quiet page</body></html>',
+    }),
+  });
+
+  try {
+    environment.advanceTime(5);
+    await flushMicrotasks();
+    environment.advanceTime(25);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 1);
+    assert.match(sendCalls[0].html, /name="wayback-viewport" content="width=1733,height=977,dpr=1.25"/);
+    assert.doesNotMatch(sendCalls[0].html, /id="wayback-captured-viewport-style"/);
+    assert.doesNotMatch(sendCalls[0].html, /max-width:1733px !important/);
+  } finally {
+    restore();
+  }
+});
+
 test('main archives a short quiet-page visit once before pagehide', async () => {
   const environment = createFakeBrowserEnvironment();
   const sendCalls = [];

--- a/browser/tests/style-inliner.test.js
+++ b/browser/tests/style-inliner.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  shouldNormalizeDetachedFixedLayout,
+  shouldResetDetachedFixedTransform,
+} = require('../dist-test/style-inliner.js');
+
+test('normalizes collapsed fixed containers that are narrower than their content column', () => {
+  assert.equal(shouldNormalizeDetachedFixedLayout({
+    position: 'fixed',
+    elementLeft: 321,
+    elementWidth: 168,
+    parentLeft: 60,
+    parentWidth: 275,
+    childWidth: 275,
+  }), true);
+});
+
+test('normalizes fixed containers detached from their parent even when width is not collapsed', () => {
+  assert.equal(shouldNormalizeDetachedFixedLayout({
+    position: 'fixed',
+    elementLeft: 321,
+    elementWidth: 768,
+    parentLeft: 60,
+    parentWidth: 275,
+    childWidth: 275,
+  }), true);
+});
+
+test('ignores small floating fixed widgets', () => {
+  assert.equal(shouldNormalizeDetachedFixedLayout({
+    position: 'fixed',
+    elementLeft: 1400,
+    elementWidth: 56,
+    parentLeft: 0,
+    parentWidth: 1440,
+    childWidth: 56,
+  }), false);
+});
+
+test('ignores containers when the parent column is narrower than the child', () => {
+  assert.equal(shouldNormalizeDetachedFixedLayout({
+    position: 'fixed',
+    elementLeft: 321,
+    elementWidth: 168,
+    parentLeft: 60,
+    parentWidth: 180,
+    childWidth: 275,
+  }), false);
+});
+
+test('ignores fixed containers that remain aligned with their parent', () => {
+  assert.equal(shouldNormalizeDetachedFixedLayout({
+    position: 'fixed',
+    elementLeft: 60,
+    elementWidth: 275,
+    parentLeft: 60,
+    parentWidth: 275,
+    childWidth: 275,
+  }), false);
+});
+
+test('ignores non-fixed elements', () => {
+  assert.equal(shouldNormalizeDetachedFixedLayout({
+    position: 'sticky',
+    elementLeft: 321,
+    elementWidth: 168,
+    parentLeft: 60,
+    parentWidth: 275,
+    childWidth: 275,
+  }), false);
+});
+
+test('resets translateX transforms on normalized fixed containers', () => {
+  assert.equal(shouldResetDetachedFixedTransform('translateX(-50%)'), true);
+});
+
+test('resets matrix transforms that only translate on X axis', () => {
+  assert.equal(shouldResetDetachedFixedTransform('matrix(1, 0, 0, 1, -384, 0)'), true);
+});
+
+test('preserves transforms with vertical translation', () => {
+  assert.equal(shouldResetDetachedFixedTransform('translateY(24px)'), false);
+  assert.equal(shouldResetDetachedFixedTransform('matrix(1, 0, 0, 1, -384, 24)'), false);
+});
+
+test('preserves transforms with scaling', () => {
+  assert.equal(shouldResetDetachedFixedTransform('scale(0.95)'), false);
+  assert.equal(shouldResetDetachedFixedTransform('matrix(0.95, 0, 0, 0.95, -384, 0)'), false);
+});

--- a/browser/tsconfig.test.json
+++ b/browser/tsconfig.test.json
@@ -5,6 +5,6 @@
     "outDir": "./dist-test",
     "rootDir": "./src"
   },
-  "include": ["src/spa-coordinator.ts", "src/page-freezer.ts", "src/main.ts"],
+  "include": ["src/spa-coordinator.ts", "src/page-freezer.ts", "src/style-inliner.ts", "src/main.ts"],
   "exclude": ["node_modules", "dist", "dist-test"]
 }

--- a/docs/technical/snapshot-and-update.md
+++ b/docs/technical/snapshot-and-update.md
@@ -39,7 +39,7 @@ initializeArchiver()
 
 1. **不冻结页面**：初次捕获只调用 `serializeCSSOMToDOM()`，不调用 `freezePageState()`。这样定时器、WebSocket 等保持运行，后续 DOM 监听器才能观察到变化。
 
-2. **克隆 DOM 写入**：`inlineLayoutStyles()` 克隆整个 DOM 树，从原始 DOM 读取 computed style，写入克隆节点。原始 DOM 不受影响。
+2. **克隆 DOM 写入**：`inlineLayoutStyles()` 克隆整个 DOM 树，从原始 DOM 读取 computed style，写入克隆节点。原始 DOM 不受影响。某些脱离父列的 `position: fixed` 容器也会在这个阶段直接归一化为 `sticky`；如果该容器的 `transform` 只是纯横向平移（常见于 `translateX(-50%)` 居中），会一并清掉，避免在改为 `sticky` 后继续把容器推出父列。客户端捕获结果就是唯一真相，服务端回放不再重复跑一份易漂移的补丁。
 
 3. **虚拟滚动收集**：`DOMCollector` 在页面加载时立即启动，早于捕获流程，确保不遗漏任何被虚拟滚动移除的节点。详见 [virtual-scroll-capture.md](virtual-scroll-capture.md)。
 

--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -260,7 +260,7 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 
 })();
 </script>
-`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, nonce)
+	`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, nonce)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {

--- a/server/internal/api/injector_test.go
+++ b/server/internal/api/injector_test.go
@@ -50,3 +50,24 @@ func TestInjectArchiveHeader_LocalizesSnapshotTimesInBrowser(t *testing.T) {
 		}
 	}
 }
+
+func TestInjectArchiveHeader_DoesNotIncludeCollapsedFixedLayoutRepair(t *testing.T) {
+	page := &models.Page{
+		ID:         1,
+		URL:        "https://example.com/page",
+		CapturedAt: time.Date(2026, 4, 15, 12, 34, 56, 0, time.UTC),
+	}
+
+	got := injectArchiveHeader(`<html><body><main>hello</main></body></html>`, page, nil, nil, 1, "nonce")
+
+	for _, unwanted := range []string{
+		`function fixCollapsedFixedElements()`,
+		`const widthCollapsed = rect.width+1 < childRect.width`,
+		`el.style.setProperty('position', 'sticky', 'important')`,
+		`setTimeout(fixCollapsedFixedElements, 100);`,
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("unexpected collapsed fixed repair marker %q in %s", unwanted, got)
+		}
+	}
+}

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -37,6 +37,36 @@ func serveEmbeddedFile(webFS fs.FS, name string) gin.HandlerFunc {
 	}
 }
 
+type headResponseWriter struct {
+	gin.ResponseWriter
+}
+
+func (w *headResponseWriter) Write(data []byte) (int, error) {
+	if !w.ResponseWriter.Written() {
+		w.ResponseWriter.WriteHeaderNow()
+	}
+	return len(data), nil
+}
+
+func (w *headResponseWriter) WriteString(s string) (int, error) {
+	if !w.ResponseWriter.Written() {
+		w.ResponseWriter.WriteHeaderNow()
+	}
+	return len(s), nil
+}
+
+func suppressHeadBody() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Writer = &headResponseWriter{ResponseWriter: c.Writer}
+		c.Next()
+	}
+}
+
+func registerGETAndHEAD(routes gin.IRoutes, relativePath string, handlers ...gin.HandlerFunc) {
+	routes.GET(relativePath, handlers...)
+	routes.HEAD(relativePath, append([]gin.HandlerFunc{suppressHeadBody()}, handlers...)...)
+}
+
 // SetupRoutes 设置路由
 func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, serverCfg *config.ServerConfig, version, buildTime string) {
 	origins := serverCfg.AllowedOrigins
@@ -65,7 +95,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 				c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 		}
-		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, PUT, GET, DELETE, OPTIONS")
+		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, PUT, GET, HEAD, DELETE, OPTIONS")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(http.StatusNoContent)
@@ -76,7 +106,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 
 	// robots.txt（在认证之前，确保爬虫和工具可以访问）
 	webFS, _ := fs.Sub(web.StaticFiles, ".")
-	r.GET("/robots.txt", serveEmbeddedFile(webFS, "robots.txt"))
+	registerGETAndHEAD(r, "/robots.txt", serveEmbeddedFile(webFS, "robots.txt"))
 
 	// Basic Auth 中间件（如果启用）
 	if authCfg.Enabled() {
@@ -87,17 +117,17 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 	}
 
 	// Web UI (embedded)
-	r.GET("/", serveEmbeddedFile(webFS, "index.html"))
-	r.GET("/index.html", serveEmbeddedFile(webFS, "index.html"))
-	r.GET("/timeline", serveEmbeddedFile(webFS, "timeline.html"))
-	r.GET("/timeline.html", serveEmbeddedFile(webFS, "timeline.html"))
-	r.GET("/logs", serveEmbeddedFile(webFS, "logs.html"))
-	r.GET("/logs.html", serveEmbeddedFile(webFS, "logs.html"))
-	r.GET("/favicon.ico", serveEmbeddedFile(webFS, "favicon.ico"))
+	registerGETAndHEAD(r, "/", serveEmbeddedFile(webFS, "index.html"))
+	registerGETAndHEAD(r, "/index.html", serveEmbeddedFile(webFS, "index.html"))
+	registerGETAndHEAD(r, "/timeline", serveEmbeddedFile(webFS, "timeline.html"))
+	registerGETAndHEAD(r, "/timeline.html", serveEmbeddedFile(webFS, "timeline.html"))
+	registerGETAndHEAD(r, "/logs", serveEmbeddedFile(webFS, "logs.html"))
+	registerGETAndHEAD(r, "/logs.html", serveEmbeddedFile(webFS, "logs.html"))
+	registerGETAndHEAD(r, "/favicon.ico", serveEmbeddedFile(webFS, "favicon.ico"))
 
 	api := r.Group("/api")
 	{
-		api.GET("/version", func(c *gin.Context) {
+		registerGETAndHEAD(api, "/version", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{
 				"version":    version,
 				"build_time": buildTime,
@@ -122,23 +152,21 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 		}
 		api.POST("/archive", handler.ArchivePage)
 		api.PUT("/archive/:id", handler.UpdatePage)
-		api.GET("/pages", handler.ListPages)
-		api.GET("/pages/timeline", handler.GetPageTimeline)
-		api.GET("/pages/:id", handler.GetPage)
-		api.GET("/pages/:id/content", handler.GetPageContent)
+		registerGETAndHEAD(api, "/pages", handler.ListPages)
+		registerGETAndHEAD(api, "/pages/timeline", handler.GetPageTimeline)
+		registerGETAndHEAD(api, "/pages/:id", handler.GetPage)
+		registerGETAndHEAD(api, "/pages/:id/content", handler.GetPageContent)
 		api.DELETE("/pages/:id", handler.DeletePage)
-		api.GET("/search", handler.SearchPages)
-		api.GET("/logs", handler.ListLogs)
-		api.GET("/logs/latest", handler.GetLatestLog)
-		api.GET("/logs/:filename", handler.GetLog)
+		registerGETAndHEAD(api, "/search", handler.SearchPages)
+		registerGETAndHEAD(api, "/logs", handler.ListLogs)
+		registerGETAndHEAD(api, "/logs/latest", handler.GetLatestLog)
+		registerGETAndHEAD(api, "/logs/:filename", handler.GetLog)
 	}
 
 	// 查看归档页面
-	r.GET("/view/:id", handler.ViewPage)
-	r.GET("/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
-	r.HEAD("/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
+	registerGETAndHEAD(r, "/view/:id", handler.ViewPage)
+	registerGETAndHEAD(r, "/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
 
 	// 直接资源访问（CSS 中引用的资源路径格式: /archive/resources/xx/yy/hash.ext）
-	r.GET("/archive/resources/*filepath", handler.ServeLocalResource)
-	r.HEAD("/archive/resources/*filepath", handler.ServeLocalResource)
+	registerGETAndHEAD(r, "/archive/resources/*filepath", handler.ServeLocalResource)
 }

--- a/server/internal/api/routes_test.go
+++ b/server/internal/api/routes_test.go
@@ -110,6 +110,22 @@ func TestRoutes_CORS_IncludesAuthorizationHeader(t *testing.T) {
 	}
 }
 
+func TestRoutes_CORS_IncludesHEADMethod(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/api/archive", nil)
+	r.ServeHTTP(w, req)
+
+	allowMethods := w.Header().Get("Access-Control-Allow-Methods")
+	if allowMethods == "" {
+		t.Fatal("Access-Control-Allow-Methods not set")
+	}
+	if !containsSubstring(allowMethods, "HEAD") {
+		t.Fatalf("CORS Allow-Methods = %q, want it to include HEAD", allowMethods)
+	}
+}
+
 func TestRoutes_CORS_AllowedOriginsEnvEnablesCustomOrigin(t *testing.T) {
 	t.Setenv("ALLOWED_ORIGINS", "https://allowed.example.com")
 	r := setupRouterFromEnv(t)
@@ -214,6 +230,57 @@ func TestServeEmbeddedFile_SetsContentType(t *testing.T) {
 	}
 }
 
+func TestRoutes_HEAD_EmbeddedPageReturnsHeadersWithoutBody(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+	}
+	if bodyLen := w.Body.Len(); bodyLen != 0 {
+		t.Fatalf("HEAD / body length = %d, want 0", bodyLen)
+	}
+}
+
+func TestRoutes_HEAD_APIVersionReturnsHeadersWithoutBody(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/api/version", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got == "" {
+		t.Fatal("Content-Type not set for HEAD /api/version")
+	}
+	if bodyLen := w.Body.Len(); bodyLen != 0 {
+		t.Fatalf("HEAD /api/version body length = %d, want 0", bodyLen)
+	}
+}
+
+func TestRoutes_HEAD_ViewPageInvalidIDReturnsNoBody(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/view/not-a-number", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if bodyLen := w.Body.Len(); bodyLen != 0 {
+		t.Fatalf("HEAD /view/not-a-number body length = %d, want 0", bodyLen)
+	}
+}
+
 func containsSubstring(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
 }
@@ -225,42 +292,4 @@ func stringContains(s, substr string) bool {
 		}
 	}
 	return false
-}
-
-func TestRoutes_HEAD_ProxyResource(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	r := gin.New()
-
-	// Register a simple handler that returns 200 for HEAD requests
-	r.HEAD("/archive/:page_id/:timestamp/*resource_path", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("HEAD", "/archive/123/20240309150405mp_/https://example.com/style.css", nil)
-	r.ServeHTTP(w, req)
-
-	// Should not be 404 (route should exist)
-	if w.Code == http.StatusNotFound {
-		t.Errorf("HEAD /archive/:page_id/:timestamp/*resource_path route not registered, got 404")
-	}
-}
-
-func TestRoutes_HEAD_ServeLocalResource(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	r := gin.New()
-
-	// Register a simple handler that returns 200 for HEAD requests
-	r.HEAD("/archive/resources/*filepath", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("HEAD", "/archive/resources/ab/cd/hash.css", nil)
-	r.ServeHTTP(w, req)
-
-	// Should not be 404 (route should exist)
-	if w.Code == http.StatusNotFound {
-		t.Errorf("HEAD /archive/resources/*filepath route not registered, got 404")
-	}
 }

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -73,7 +73,6 @@ func NewPostgres(host, port, user, password, dbname string, sslmode ...string) (
 		conn.Close()
 		return nil, fmt.Errorf("failed to ensure snapshot_state column: %w", err)
 	}
-
 	return db, nil
 }
 
@@ -270,7 +269,7 @@ func (db *PostgresDB) CreatePage(url, title, htmlPath, contentHash string, captu
 	var id int64
 	err := db.conn.QueryRow(
 		"INSERT INTO pages (url, title, html_path, content_hash, snapshot_state, captured_at, first_visited, last_visited, domain) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id",
-		url, title, htmlPath, contentHash, models.SnapshotStatePending, capturedAt, capturedAt, capturedAt, extractDomain(url),
+		url, title, htmlPath, contentHash, models.SnapshotStatePending, capturedAt.UTC(), capturedAt.UTC(), capturedAt.UTC(), extractDomain(url),
 	).Scan(&id)
 	return id, err
 }
@@ -301,7 +300,7 @@ func (db *PostgresDB) GetPageByURLAndHash(url, contentHash string) (*models.Page
 
 // UpdatePageLastVisited 更新页面最后访问时间
 func (db *PostgresDB) UpdatePageLastVisited(id int64, lastVisited time.Time) error {
-	_, err := db.conn.Exec("UPDATE pages SET last_visited = $1 WHERE id = $2", lastVisited, id)
+	_, err := db.conn.Exec("UPDATE pages SET last_visited = $1 WHERE id = $2", lastVisited.UTC(), id)
 	return err
 }
 
@@ -325,17 +324,18 @@ func (db *PostgresDB) GetResourceByHash(hash string) (*models.Resource, error) {
 // CreateResource 创建资源记录
 func (db *PostgresDB) CreateResource(url, hash, resourceType, filePath string, fileSize int64) (int64, error) {
 	var id int64
+	now := time.Now().UTC()
 	err := db.conn.QueryRow(
-		"INSERT INTO resources (url, content_hash, resource_type, file_path, file_size) VALUES ($1, $2, $3, $4, $5) RETURNING id",
-		url, hash, resourceType, filePath, fileSize,
+		"INSERT INTO resources (url, content_hash, resource_type, file_path, file_size, first_seen, last_seen) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
+		url, hash, resourceType, filePath, fileSize, now, now,
 	).Scan(&id)
 	return id, err
 }
 
 // UpdateResourceLastSeen 更新资源最后见到时间
 func (db *PostgresDB) UpdateResourceLastSeen(id int64) error {
-	query := fmt.Sprintf("UPDATE resources SET last_seen = %s WHERE id = $1", db.qb.CurrentTimestamp())
-	_, err := db.conn.Exec(query, id)
+	now := time.Now().UTC()
+	_, err := db.conn.Exec("UPDATE resources SET last_seen = $1 WHERE id = $2", now, id)
 	return err
 }
 
@@ -343,8 +343,8 @@ func (db *PostgresDB) touchResourcesLastSeen(tx *sql.Tx, resourceIDs []int64) er
 	if len(resourceIDs) == 0 {
 		return nil
 	}
-	query := fmt.Sprintf("UPDATE resources SET last_seen = %s WHERE id = ANY($1)", db.qb.CurrentTimestamp())
-	_, err := tx.Exec(query, pq.Array(resourceIDs))
+	now := time.Now().UTC()
+	_, err := tx.Exec("UPDATE resources SET last_seen = $1 WHERE id = ANY($2)", now, pq.Array(resourceIDs))
 	return err
 }
 
@@ -714,8 +714,8 @@ func (db *PostgresDB) GetResourceByURLPath(urlPath string, pageID int64) (*model
 
 // UpdatePageContent 更新页面内容（HTML路径、哈希、标题、最后访问时间）
 func (db *PostgresDB) UpdatePageContent(id int64, htmlPath, contentHash, title string) error {
-	query := fmt.Sprintf("UPDATE pages SET html_path = $1, content_hash = $2, title = $3, snapshot_state = $4, last_visited = %s WHERE id = $5", db.qb.CurrentTimestamp())
-	_, err := db.conn.Exec(query, htmlPath, contentHash, title, models.SnapshotStateReady, id)
+	now := time.Now().UTC()
+	_, err := db.conn.Exec("UPDATE pages SET html_path = $1, content_hash = $2, title = $3, snapshot_state = $4, last_visited = $5 WHERE id = $6", htmlPath, contentHash, title, models.SnapshotStateReady, now, id)
 	return err
 }
 
@@ -727,15 +727,13 @@ func (db *PostgresDB) ReplacePageSnapshot(id int64, htmlPath, contentHash, title
 	}
 	defer tx.Rollback()
 
-	nowSQL := db.qb.CurrentTimestamp()
+	now := time.Now().UTC()
 	if bodyText != nil {
-		query := fmt.Sprintf("UPDATE pages SET html_path = $1, content_hash = $2, title = $3, body_text = $4, snapshot_state = $5, last_visited = %s WHERE id = $6", nowSQL)
-		if _, err := tx.Exec(query, htmlPath, contentHash, title, *bodyText, models.SnapshotStateReady, id); err != nil {
+		if _, err := tx.Exec("UPDATE pages SET html_path = $1, content_hash = $2, title = $3, body_text = $4, snapshot_state = $5, last_visited = $6 WHERE id = $7", htmlPath, contentHash, title, *bodyText, models.SnapshotStateReady, now, id); err != nil {
 			return err
 		}
 	} else {
-		query := fmt.Sprintf("UPDATE pages SET html_path = $1, content_hash = $2, title = $3, snapshot_state = $4, last_visited = %s WHERE id = $5", nowSQL)
-		if _, err := tx.Exec(query, htmlPath, contentHash, title, models.SnapshotStateReady, id); err != nil {
+		if _, err := tx.Exec("UPDATE pages SET html_path = $1, content_hash = $2, title = $3, snapshot_state = $4, last_visited = $5 WHERE id = $6", htmlPath, contentHash, title, models.SnapshotStateReady, now, id); err != nil {
 			return err
 		}
 	}
@@ -772,7 +770,7 @@ func (db *PostgresDB) ResetPageForCreateRetry(id int64, title, htmlPath string, 
 	}
 	if _, err := tx.Exec(
 		"UPDATE pages SET title = $1, html_path = $2, snapshot_state = $3, last_visited = $4 WHERE id = $5",
-		title, htmlPath, models.SnapshotStatePending, capturedAt, id,
+		title, htmlPath, models.SnapshotStatePending, capturedAt.UTC(), id,
 	); err != nil {
 		return "", err
 	}

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -22,6 +22,25 @@ type SQLiteDB struct {
 	qb   *QueryBuilder
 }
 
+const (
+	// SQLite 将时间保存为固定宽度 UTC 文本，保证字符串比较/排序与真实时间顺序一致。
+	sqliteTimestampFormat = "2006-01-02T15:04:05.000000000Z"
+
+	sqliteMigrationVersionDomain                 = 1
+	sqliteMigrationVersionSnapshotState          = 2
+	sqliteMigrationVersionTimestampNormalization = 3
+	sqliteMigrationVersionTimestampFixedWidth    = 4
+	sqliteMigrationVersionCurrent                = sqliteMigrationVersionTimestampFixedWidth
+)
+
+func formatSQLiteTimestamp(t time.Time) string {
+	return t.UTC().Format(sqliteTimestampFormat)
+}
+
+func currentSQLiteTimestamp() string {
+	return formatSQLiteTimestamp(time.Now())
+}
+
 // NewSQLite 创建 SQLite 数据库连接
 func NewSQLite(dbPath string) (Database, error) {
 	// 确保数据库目录存在
@@ -87,6 +106,11 @@ func (db *SQLiteDB) ensureSchema() error {
 		if _, err := db.conn.Exec(sqliteSchema); err != nil {
 			return fmt.Errorf("failed to initialize schema: %w", err)
 		}
+
+		// 新库直接标记为当前迁移版本，避免进入历史兼容迁移路径。
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionCurrent); err != nil {
+			return err
+		}
 	}
 
 	// 执行增量迁移
@@ -95,21 +119,151 @@ func (db *SQLiteDB) ensureSchema() error {
 
 // ensureMigrations 执行增量迁移
 func (db *SQLiteDB) ensureMigrations() error {
-	// 检查 domain 列
-	if err := db.ensureDomainColumn(); err != nil {
+	version, err := db.getSQLiteUserVersion()
+	if err != nil {
 		return err
 	}
 
-	// 检查 snapshot_state 列
-	if err := db.ensureSnapshotStateColumn(); err != nil {
-		return err
+	if version < sqliteMigrationVersionDomain {
+		if err := db.ensureDomainColumn(); err != nil {
+			return err
+		}
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionDomain); err != nil {
+			return err
+		}
+		version = sqliteMigrationVersionDomain
 	}
 
-	if err := db.ensureFTSConsistency(); err != nil {
-		return err
+	if version < sqliteMigrationVersionSnapshotState {
+		if err := db.ensureSnapshotStateColumn(); err != nil {
+			return err
+		}
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionSnapshotState); err != nil {
+			return err
+		}
+		version = sqliteMigrationVersionSnapshotState
+	}
+
+	if version < sqliteMigrationVersionTimestampNormalization {
+		if err := db.ensureNormalizedTimestamps(); err != nil {
+			return err
+		}
+
+		if err := db.ensureFTSConsistency(); err != nil {
+			return err
+		}
+
+		// ensureNormalizedTimestamps 现在直接产出最终的固定宽度 UTC 文本，
+		// 旧库首次升级时可直接推进到当前版本，避免同一轮启动里再做一次全表重写。
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionCurrent); err != nil {
+			return err
+		}
+		version = sqliteMigrationVersionCurrent
+	}
+
+	if version < sqliteMigrationVersionTimestampFixedWidth {
+		if err := db.ensureNormalizedTimestamps(); err != nil {
+			return err
+		}
+
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionTimestampFixedWidth); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func (db *SQLiteDB) getSQLiteUserVersion() (int, error) {
+	var version int
+	if err := db.conn.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		return 0, fmt.Errorf("failed to read SQLite user_version: %w", err)
+	}
+	return version, nil
+}
+
+func (db *SQLiteDB) setSQLiteUserVersion(version int) error {
+	if _, err := db.conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", version)); err != nil {
+		return fmt.Errorf("failed to set SQLite user_version to %d: %w", version, err)
+	}
+	return nil
+}
+
+func (db *SQLiteDB) ensureNormalizedTimestamps() error {
+	// 历史兼容迁移：将旧 DATETIME 文本统一改写为固定宽度 UTC，
+	// 让 SQLite 直接使用字符串比较/排序时也保持正确的时间顺序。
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	pageRows, err := tx.Query("SELECT id, captured_at, first_visited, last_visited FROM pages")
+	if err != nil {
+		return err
+	}
+	for pageRows.Next() {
+		var id int64
+		var capturedAt time.Time
+		var firstVisited sql.NullTime
+		var lastVisited sql.NullTime
+		if err := pageRows.Scan(&id, &capturedAt, &firstVisited, &lastVisited); err != nil {
+			pageRows.Close()
+			return err
+		}
+
+		var firstVisitedValue any
+		if firstVisited.Valid {
+			firstVisitedValue = formatSQLiteTimestamp(firstVisited.Time)
+		}
+		var lastVisitedValue any
+		if lastVisited.Valid {
+			lastVisitedValue = formatSQLiteTimestamp(lastVisited.Time)
+		}
+
+		if _, err := tx.Exec(
+			"UPDATE pages SET captured_at = ?, first_visited = ?, last_visited = ? WHERE id = ?",
+			formatSQLiteTimestamp(capturedAt),
+			firstVisitedValue,
+			lastVisitedValue,
+			id,
+		); err != nil {
+			pageRows.Close()
+			return err
+		}
+	}
+	if err := pageRows.Close(); err != nil {
+		return err
+	}
+
+	resourceRows, err := tx.Query("SELECT id, first_seen, last_seen FROM resources")
+	if err != nil {
+		return err
+	}
+	for resourceRows.Next() {
+		var id int64
+		var firstSeen time.Time
+		var lastSeen time.Time
+		if err := resourceRows.Scan(&id, &firstSeen, &lastSeen); err != nil {
+			resourceRows.Close()
+			return err
+		}
+
+		if _, err := tx.Exec(
+			"UPDATE resources SET first_seen = ?, last_seen = ? WHERE id = ?",
+			formatSQLiteTimestamp(firstSeen),
+			formatSQLiteTimestamp(lastSeen),
+			id,
+		); err != nil {
+			resourceRows.Close()
+			return err
+		}
+	}
+	if err := resourceRows.Close(); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 func (db *SQLiteDB) ensureFTSConsistency() error {
@@ -213,9 +367,10 @@ func (db *SQLiteDB) Close() error {
 
 // CreatePage 创建页面记录
 func (db *SQLiteDB) CreatePage(url, title, htmlPath, contentHash string, capturedAt time.Time) (int64, error) {
+	timestamp := formatSQLiteTimestamp(capturedAt)
 	result, err := db.conn.Exec(
 		"INSERT INTO pages (url, title, html_path, content_hash, snapshot_state, captured_at, first_visited, last_visited, domain) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		url, title, htmlPath, contentHash, models.SnapshotStatePending, capturedAt, capturedAt, capturedAt, extractDomain(url),
+		url, title, htmlPath, contentHash, models.SnapshotStatePending, timestamp, timestamp, timestamp, extractDomain(url),
 	)
 	if err != nil {
 		return 0, err
@@ -249,7 +404,7 @@ func (db *SQLiteDB) GetPageByURLAndHash(url, contentHash string) (*models.Page, 
 
 // UpdatePageLastVisited 更新页面最后访问时间
 func (db *SQLiteDB) UpdatePageLastVisited(id int64, lastVisited time.Time) error {
-	_, err := db.conn.Exec("UPDATE pages SET last_visited = ? WHERE id = ?", lastVisited, id)
+	_, err := db.conn.Exec("UPDATE pages SET last_visited = ? WHERE id = ?", formatSQLiteTimestamp(lastVisited), id)
 	return err
 }
 
@@ -272,9 +427,10 @@ func (db *SQLiteDB) GetResourceByHash(hash string) (*models.Resource, error) {
 
 // CreateResource 创建资源记录
 func (db *SQLiteDB) CreateResource(url, hash, resourceType, filePath string, fileSize int64) (int64, error) {
+	now := currentSQLiteTimestamp()
 	result, err := db.conn.Exec(
-		"INSERT INTO resources (url, content_hash, resource_type, file_path, file_size) VALUES (?, ?, ?, ?, ?)",
-		url, hash, resourceType, filePath, fileSize,
+		"INSERT INTO resources (url, content_hash, resource_type, file_path, file_size, first_seen, last_seen) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		url, hash, resourceType, filePath, fileSize, now, now,
 	)
 	if err != nil {
 		return 0, err
@@ -284,8 +440,8 @@ func (db *SQLiteDB) CreateResource(url, hash, resourceType, filePath string, fil
 
 // UpdateResourceLastSeen 更新资源最后见到时间
 func (db *SQLiteDB) UpdateResourceLastSeen(id int64) error {
-	query := fmt.Sprintf("UPDATE resources SET last_seen = %s WHERE id = ?", db.qb.CurrentTimestamp())
-	_, err := db.conn.Exec(query, id)
+	now := time.Now()
+	_, err := db.conn.Exec("UPDATE resources SET last_seen = ? WHERE id = ?", formatSQLiteTimestamp(now), id)
 	return err
 }
 
@@ -302,9 +458,10 @@ func (db *SQLiteDB) touchResourcesLastSeen(tx *sql.Tx, resourceIDs []int64) erro
 		args[i] = id
 	}
 
-	query := fmt.Sprintf("UPDATE resources SET last_seen = %s WHERE id IN (%s)",
-		db.qb.CurrentTimestamp(), strings.Join(placeholders, ", "))
-	_, err := tx.Exec(query, args...)
+	now := time.Now()
+	query := fmt.Sprintf("UPDATE resources SET last_seen = ? WHERE id IN (%s)", strings.Join(placeholders, ", "))
+	argsWithTime := append([]interface{}{formatSQLiteTimestamp(now)}, args...)
+	_, err := tx.Exec(query, argsWithTime...)
 	return err
 }
 
@@ -342,7 +499,7 @@ func (db *SQLiteDB) CheckRecentCapture(url string, within time.Duration) (bool, 
 	var count int
 	err := db.conn.QueryRow(
 		"SELECT COUNT(*) FROM pages WHERE url = ? AND captured_at > ?",
-		url, time.Now().Add(-within),
+		url, formatSQLiteTimestamp(time.Now().Add(-within)),
 	).Scan(&count)
 	return count > 0, err
 }
@@ -407,13 +564,13 @@ func (db *SQLiteDB) ListPages(limit, offset int, from, to *time.Time, domain str
 	var conditions []string
 	if from != nil {
 		conditions = append(conditions, "captured_at >= ?")
-		args = append(args, *from)
+		args = append(args, formatSQLiteTimestamp(*from))
 	}
 	if to != nil {
 		// to 使用 < nextDay 确保包含当天全部记录
 		nextDay := to.AddDate(0, 0, 1)
 		conditions = append(conditions, "captured_at < ?")
-		args = append(args, nextDay)
+		args = append(args, formatSQLiteTimestamp(nextDay))
 	}
 	if domain != "" {
 		conditions = append(conditions, "(domain = ? OR domain LIKE ?)")
@@ -424,7 +581,7 @@ func (db *SQLiteDB) ListPages(limit, offset int, from, to *time.Time, domain str
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
 
-	query += " ORDER BY last_visited DESC LIMIT ? OFFSET ?"
+	query += " ORDER BY COALESCE(julianday(last_visited), julianday(captured_at)) DESC, id DESC LIMIT ? OFFSET ?"
 	args = append(args, limit, offset)
 
 	rows, err := db.conn.Query(query, args...)
@@ -453,13 +610,13 @@ func (db *SQLiteDB) GetTotalPagesCount(from, to *time.Time, domain string) (int,
 	var conditions []string
 	if from != nil {
 		conditions = append(conditions, "captured_at >= ?")
-		args = append(args, *from)
+		args = append(args, formatSQLiteTimestamp(*from))
 	}
 	if to != nil {
 		// to 使用 < nextDay 确保包含当天全部记录
 		nextDay := to.AddDate(0, 0, 1)
 		conditions = append(conditions, "captured_at < ?")
-		args = append(args, nextDay)
+		args = append(args, formatSQLiteTimestamp(nextDay))
 	}
 	if domain != "" {
 		conditions = append(conditions, "(domain = ? OR domain LIKE ?)")
@@ -506,20 +663,20 @@ func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain stri
 	// 追加时间过滤条件
 	if from != nil {
 		query += " AND captured_at >= ?"
-		args = append(args, *from)
+		args = append(args, formatSQLiteTimestamp(*from))
 	}
 	if to != nil {
 		// to 使用 < nextDay 确保包含当天全部记录
 		nextDay := to.AddDate(0, 0, 1)
 		query += " AND captured_at < ?"
-		args = append(args, nextDay)
+		args = append(args, formatSQLiteTimestamp(nextDay))
 	}
 	if domain != "" {
 		query += " AND (domain = ? OR domain LIKE ?)"
 		args = append(args, domain, "%."+domain)
 	}
 
-	query += " ORDER BY last_visited DESC LIMIT 100"
+	query += " ORDER BY COALESCE(julianday(last_visited), julianday(captured_at)) DESC, id DESC LIMIT 100"
 
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
@@ -660,8 +817,8 @@ func (db *SQLiteDB) GetResourceByURLPath(urlPath string, pageID int64) (*models.
 
 // UpdatePageContent 更新页面内容（HTML路径、哈希、标题、最后访问时间）
 func (db *SQLiteDB) UpdatePageContent(id int64, htmlPath, contentHash, title string) error {
-	query := fmt.Sprintf("UPDATE pages SET html_path = ?, content_hash = ?, title = ?, snapshot_state = ?, last_visited = %s WHERE id = ?", db.qb.CurrentTimestamp())
-	_, err := db.conn.Exec(query, htmlPath, contentHash, title, models.SnapshotStateReady, id)
+	now := time.Now()
+	_, err := db.conn.Exec("UPDATE pages SET html_path = ?, content_hash = ?, title = ?, snapshot_state = ?, last_visited = ? WHERE id = ?", htmlPath, contentHash, title, models.SnapshotStateReady, formatSQLiteTimestamp(now), id)
 	return err
 }
 
@@ -673,15 +830,14 @@ func (db *SQLiteDB) ReplacePageSnapshot(id int64, htmlPath, contentHash, title s
 	}
 	defer tx.Rollback()
 
-	nowSQL := db.qb.CurrentTimestamp()
+	now := time.Now()
+	nowText := formatSQLiteTimestamp(now)
 	if bodyText != nil {
-		query := fmt.Sprintf("UPDATE pages SET html_path = ?, content_hash = ?, title = ?, body_text = ?, snapshot_state = ?, last_visited = %s WHERE id = ?", nowSQL)
-		if _, err := tx.Exec(query, htmlPath, contentHash, title, *bodyText, models.SnapshotStateReady, id); err != nil {
+		if _, err := tx.Exec("UPDATE pages SET html_path = ?, content_hash = ?, title = ?, body_text = ?, snapshot_state = ?, last_visited = ? WHERE id = ?", htmlPath, contentHash, title, *bodyText, models.SnapshotStateReady, nowText, id); err != nil {
 			return err
 		}
 	} else {
-		query := fmt.Sprintf("UPDATE pages SET html_path = ?, content_hash = ?, title = ?, snapshot_state = ?, last_visited = %s WHERE id = ?", nowSQL)
-		if _, err := tx.Exec(query, htmlPath, contentHash, title, models.SnapshotStateReady, id); err != nil {
+		if _, err := tx.Exec("UPDATE pages SET html_path = ?, content_hash = ?, title = ?, snapshot_state = ?, last_visited = ? WHERE id = ?", htmlPath, contentHash, title, models.SnapshotStateReady, nowText, id); err != nil {
 			return err
 		}
 	}
@@ -718,7 +874,7 @@ func (db *SQLiteDB) ResetPageForCreateRetry(id int64, title, htmlPath string, ca
 	}
 	if _, err := tx.Exec(
 		"UPDATE pages SET title = ?, html_path = ?, snapshot_state = ?, last_visited = ? WHERE id = ?",
-		title, htmlPath, models.SnapshotStatePending, capturedAt, id,
+		title, htmlPath, models.SnapshotStatePending, formatSQLiteTimestamp(capturedAt), id,
 	); err != nil {
 		return "", err
 	}

--- a/server/internal/database/sqlite_test.go
+++ b/server/internal/database/sqlite_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -121,4 +122,413 @@ func TestSQLiteReplacePageSnapshotWithBodyText(t *testing.T) {
 	if len(pages) != 1 || pages[0].ID != pageID {
 		t.Fatalf("SearchPages returned %+v, want page %d", pages, pageID)
 	}
+}
+
+func TestSQLiteNewDBMarksCurrentMigrationVersion(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	if got := sqliteUserVersion(t, db); got != sqliteMigrationVersionCurrent {
+		t.Fatalf("user_version = %d, want %d", got, sqliteMigrationVersionCurrent)
+	}
+}
+
+func TestSQLiteStartupHeavyMigrationRunsOnlyOnce(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "wayback.db")
+	openDB := func() *SQLiteDB {
+		t.Helper()
+
+		database, err := NewSQLite(dbPath)
+		if err != nil {
+			t.Fatalf("NewSQLite failed: %v", err)
+		}
+
+		sqliteDB, ok := database.(*SQLiteDB)
+		if !ok {
+			t.Fatalf("expected *SQLiteDB, got %T", database)
+		}
+
+		return sqliteDB
+	}
+
+	db := openDB()
+	pageID, err := db.CreatePage("https://example.com/legacy-migration", "Legacy Page", "html/test/legacy.html", "hash-legacy", time.Date(2026, 4, 24, 15, 23, 24, 230000000, time.FixedZone("CST", 8*3600)))
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	resourceID, err := db.CreateResource("https://example.com/style.css", "hash-resource", "css", "assets/test/style.css", 123)
+	if err != nil {
+		t.Fatalf("CreateResource failed: %v", err)
+	}
+
+	if _, err := db.conn.Exec("UPDATE pages SET captured_at = ?, first_visited = ?, last_visited = ? WHERE id = ?", "2026-04-24 15:23:24.230476+08:00", "2026-04-24 15:23:24.230476+08:00", "2026-04-24 07:23:51", pageID); err != nil {
+		t.Fatalf("seed mixed page timestamps failed: %v", err)
+	}
+	if _, err := db.conn.Exec("UPDATE resources SET first_seen = ?, last_seen = ? WHERE id = ?", "2026-04-24 15:23:24.230476+08:00", "2026-04-24 07:23:51", resourceID); err != nil {
+		t.Fatalf("seed mixed resource timestamps failed: %v", err)
+	}
+	if _, err := db.conn.Exec("CREATE TABLE migration_audit (target TEXT PRIMARY KEY, count INTEGER NOT NULL DEFAULT 0)"); err != nil {
+		t.Fatalf("create migration_audit failed: %v", err)
+	}
+	if _, err := db.conn.Exec("INSERT INTO migration_audit(target, count) VALUES ('pages', 0), ('resources', 0)"); err != nil {
+		t.Fatalf("seed migration_audit failed: %v", err)
+	}
+	if _, err := db.conn.Exec("CREATE TRIGGER count_pages_updates AFTER UPDATE ON pages BEGIN UPDATE migration_audit SET count = count + 1 WHERE target = 'pages'; END;"); err != nil {
+		t.Fatalf("create pages audit trigger failed: %v", err)
+	}
+	if _, err := db.conn.Exec("CREATE TRIGGER count_resources_updates AFTER UPDATE ON resources BEGIN UPDATE migration_audit SET count = count + 1 WHERE target = 'resources'; END;"); err != nil {
+		t.Fatalf("create resources audit trigger failed: %v", err)
+	}
+	if err := db.setSQLiteUserVersion(0); err != nil {
+		t.Fatalf("setSQLiteUserVersion failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	db = openDB()
+	if got := sqliteUserVersion(t, db); got != sqliteMigrationVersionCurrent {
+		t.Fatalf("user_version after legacy startup = %d, want %d", got, sqliteMigrationVersionCurrent)
+	}
+	if got := sqliteAuditCount(t, db, "pages"); got != 1 {
+		t.Fatalf("pages updated %d times during first legacy startup, want 1", got)
+	}
+	if got := sqliteAuditCount(t, db, "resources"); got != 1 {
+		t.Fatalf("resources updated %d times during first legacy startup, want 1", got)
+	}
+
+	var capturedAt, firstVisited, lastVisited string
+	if err := db.conn.QueryRow("SELECT CAST(captured_at AS TEXT), CAST(first_visited AS TEXT), CAST(last_visited AS TEXT) FROM pages WHERE id = ?", pageID).Scan(&capturedAt, &firstVisited, &lastVisited); err != nil {
+		t.Fatalf("query normalized page timestamps failed: %v", err)
+	}
+	var firstSeen, lastSeen string
+	if err := db.conn.QueryRow("SELECT CAST(first_seen AS TEXT), CAST(last_seen AS TEXT) FROM resources WHERE id = ?", resourceID).Scan(&firstSeen, &lastSeen); err != nil {
+		t.Fatalf("query normalized resource timestamps failed: %v", err)
+	}
+
+	for name, value := range map[string]string{
+		"captured_at":   capturedAt,
+		"first_visited": firstVisited,
+		"last_visited":  lastVisited,
+		"first_seen":    firstSeen,
+		"last_seen":     lastSeen,
+	} {
+		assertSQLiteTimestampText(t, name, value)
+	}
+
+	if !sqliteTriggerExists(t, db, "pages_fts_update") {
+		t.Fatal("pages_fts_update trigger should exist after legacy migration")
+	}
+	if _, err := db.conn.Exec("CREATE TRIGGER pages_block_update BEFORE UPDATE ON pages BEGIN SELECT RAISE(ABORT, 'unexpected pages update'); END;"); err != nil {
+		t.Fatalf("create pages blocker trigger failed: %v", err)
+	}
+	if _, err := db.conn.Exec("CREATE TRIGGER resources_block_update BEFORE UPDATE ON resources BEGIN SELECT RAISE(ABORT, 'unexpected resources update'); END;"); err != nil {
+		t.Fatalf("create resources blocker trigger failed: %v", err)
+	}
+	if _, err := db.conn.Exec("DROP TRIGGER pages_fts_update"); err != nil {
+		t.Fatalf("drop pages_fts_update failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	db = openDB()
+	defer db.Close()
+
+	if got := sqliteUserVersion(t, db); got != sqliteMigrationVersionCurrent {
+		t.Fatalf("user_version after second startup = %d, want %d", got, sqliteMigrationVersionCurrent)
+	}
+	if sqliteTriggerExists(t, db, "pages_fts_update") {
+		t.Fatal("pages_fts_update was recreated on second startup")
+	}
+}
+
+func TestSQLiteNormalizeTimestamps_UnifiesStoredFormat(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	pageID, err := db.CreatePage("https://example.com/timestamp", "Timestamp Page", "html/test/timestamp.html", "hash-ts", time.Date(2026, 4, 24, 15, 23, 24, 230000000, time.FixedZone("CST", 8*3600)))
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+
+	if _, err := db.conn.Exec("UPDATE pages SET captured_at = ?, first_visited = ?, last_visited = ? WHERE id = ?", "2026-04-24 15:23:24.230476+08:00", "2026-04-24 15:23:24.230476+08:00", "2026-04-24 07:23:51", pageID); err != nil {
+		t.Fatalf("seed mixed timestamp formats failed: %v", err)
+	}
+
+	if err := db.ensureNormalizedTimestamps(); err != nil {
+		t.Fatalf("ensureNormalizedTimestamps failed: %v", err)
+	}
+
+	var capturedAt, firstVisited, lastVisited string
+	if err := db.conn.QueryRow("SELECT CAST(captured_at AS TEXT), CAST(first_visited AS TEXT), CAST(last_visited AS TEXT) FROM pages WHERE id = ?", pageID).Scan(&capturedAt, &firstVisited, &lastVisited); err != nil {
+		t.Fatalf("query normalized timestamps failed: %v", err)
+	}
+
+	for name, value := range map[string]string{
+		"captured_at":   capturedAt,
+		"first_visited": firstVisited,
+		"last_visited":  lastVisited,
+	} {
+		assertSQLiteTimestampText(t, name, value)
+	}
+}
+
+func TestSQLiteUpgradeFromVariablePrecisionTimestamps(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "wayback.db")
+	openDB := func() *SQLiteDB {
+		t.Helper()
+
+		database, err := NewSQLite(dbPath)
+		if err != nil {
+			t.Fatalf("NewSQLite failed: %v", err)
+		}
+
+		sqliteDB, ok := database.(*SQLiteDB)
+		if !ok {
+			t.Fatalf("expected *SQLiteDB, got %T", database)
+		}
+
+		return sqliteDB
+	}
+
+	db := openDB()
+	pageID, err := db.CreatePage("https://example.com/version-3-upgrade", "Version 3 Upgrade", "html/test/version3.html", strings.Repeat("a", 64), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	resourceID, err := db.CreateResource("https://example.com/version-3.css", strings.Repeat("b", 64), "css", "assets/test/version-3.css", 123)
+	if err != nil {
+		t.Fatalf("CreateResource failed: %v", err)
+	}
+
+	if _, err := db.conn.Exec("UPDATE pages SET captured_at = ?, first_visited = ?, last_visited = ? WHERE id = ?", "2026-04-24T07:23:51Z", "2026-04-24T07:23:51.1Z", "2026-04-24T07:23:51.25Z", pageID); err != nil {
+		t.Fatalf("seed variable-precision page timestamps failed: %v", err)
+	}
+	if _, err := db.conn.Exec("UPDATE resources SET first_seen = ?, last_seen = ? WHERE id = ?", "2026-04-24T07:23:51Z", "2026-04-24T07:23:51.1Z", resourceID); err != nil {
+		t.Fatalf("seed variable-precision resource timestamps failed: %v", err)
+	}
+	if err := db.setSQLiteUserVersion(sqliteMigrationVersionTimestampNormalization); err != nil {
+		t.Fatalf("setSQLiteUserVersion failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	db = openDB()
+	defer db.Close()
+
+	if got := sqliteUserVersion(t, db); got != sqliteMigrationVersionCurrent {
+		t.Fatalf("user_version after version 3 upgrade = %d, want %d", got, sqliteMigrationVersionCurrent)
+	}
+
+	var capturedAt, firstVisited, lastVisited string
+	if err := db.conn.QueryRow("SELECT CAST(captured_at AS TEXT), CAST(first_visited AS TEXT), CAST(last_visited AS TEXT) FROM pages WHERE id = ?", pageID).Scan(&capturedAt, &firstVisited, &lastVisited); err != nil {
+		t.Fatalf("query upgraded page timestamps failed: %v", err)
+	}
+	var firstSeen, lastSeen string
+	if err := db.conn.QueryRow("SELECT CAST(first_seen AS TEXT), CAST(last_seen AS TEXT) FROM resources WHERE id = ?", resourceID).Scan(&firstSeen, &lastSeen); err != nil {
+		t.Fatalf("query upgraded resource timestamps failed: %v", err)
+	}
+
+	for name, value := range map[string]string{
+		"captured_at":   capturedAt,
+		"first_visited": firstVisited,
+		"last_visited":  lastVisited,
+		"first_seen":    firstSeen,
+		"last_seen":     lastSeen,
+	} {
+		assertSQLiteTimestampText(t, name, value)
+	}
+}
+
+func TestSQLiteListPages_OrdersByActualTimeAfterNormalization(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	olderID, err := db.CreatePage("https://example.com/older", "Older", "html/test/older.html", "hash-older", time.Date(2026, 4, 24, 15, 20, 21, 0, time.FixedZone("CST", 8*3600)))
+	if err != nil {
+		t.Fatalf("CreatePage older failed: %v", err)
+	}
+	newerID, err := db.CreatePage("https://example.com/newer", "Newer", "html/test/newer.html", "hash-newer", time.Date(2026, 4, 24, 15, 23, 24, 0, time.FixedZone("CST", 8*3600)))
+	if err != nil {
+		t.Fatalf("CreatePage newer failed: %v", err)
+	}
+
+	if _, err := db.conn.Exec("UPDATE pages SET last_visited = ? WHERE id = ?", "2026-04-24 15:20:21.847822+08:00", olderID); err != nil {
+		t.Fatalf("seed older last_visited failed: %v", err)
+	}
+	if _, err := db.conn.Exec("UPDATE pages SET last_visited = ? WHERE id = ?", "2026-04-24 07:23:51", newerID); err != nil {
+		t.Fatalf("seed newer last_visited failed: %v", err)
+	}
+
+	if err := db.ensureNormalizedTimestamps(); err != nil {
+		t.Fatalf("ensureNormalizedTimestamps failed: %v", err)
+	}
+
+	pages, err := db.ListPages(10, 0, nil, nil, "")
+	if err != nil {
+		t.Fatalf("ListPages failed: %v", err)
+	}
+	if len(pages) < 2 {
+		t.Fatalf("ListPages returned %d pages, want at least 2", len(pages))
+	}
+	if pages[0].ID != newerID || pages[1].ID != olderID {
+		t.Fatalf("ListPages order = [%d, %d], want [%d, %d]", pages[0].ID, pages[1].ID, newerID, olderID)
+	}
+}
+
+func TestSQLiteFixedWidthTimestampFormat_SortsLexicographically(t *testing.T) {
+	earlier := time.Date(2026, 4, 24, 7, 23, 51, 0, time.UTC)
+	later := earlier.Add(100 * time.Millisecond)
+
+	earlierText := formatSQLiteTimestamp(earlier)
+	laterText := formatSQLiteTimestamp(later)
+
+	if len(earlierText) != len(laterText) {
+		t.Fatalf("timestamp lengths differ: %q (%d) vs %q (%d)", earlierText, len(earlierText), laterText, len(laterText))
+	}
+	if earlierText >= laterText {
+		t.Fatalf("lexicographic order mismatch: %q should be less than %q", earlierText, laterText)
+	}
+	assertSQLiteTimestampText(t, "earlier", earlierText)
+	assertSQLiteTimestampText(t, "later", laterText)
+}
+
+func TestSQLiteGetResourceByURL_UsesSubsecondLastSeenOrder(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	resourceURL := "https://example.com/assets/app.css"
+	olderID, err := db.CreateResource(resourceURL, strings.Repeat("c", 64), "css", "assets/test/older.css", 10)
+	if err != nil {
+		t.Fatalf("CreateResource older failed: %v", err)
+	}
+	newerID, err := db.CreateResource(resourceURL, strings.Repeat("d", 64), "css", "assets/test/newer.css", 10)
+	if err != nil {
+		t.Fatalf("CreateResource newer failed: %v", err)
+	}
+
+	base := time.Date(2026, 4, 24, 7, 23, 51, 0, time.UTC)
+	if _, err := db.conn.Exec("UPDATE resources SET last_seen = ? WHERE id = ?", formatSQLiteTimestamp(base), olderID); err != nil {
+		t.Fatalf("seed older last_seen failed: %v", err)
+	}
+	if _, err := db.conn.Exec("UPDATE resources SET last_seen = ? WHERE id = ?", formatSQLiteTimestamp(base.Add(100*time.Millisecond)), newerID); err != nil {
+		t.Fatalf("seed newer last_seen failed: %v", err)
+	}
+
+	resource, err := db.GetResourceByURL(resourceURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL failed: %v", err)
+	}
+	if resource == nil {
+		t.Fatal("expected resource, got nil")
+	}
+	if resource.ID != newerID {
+		t.Fatalf("resource ID = %d, want %d", resource.ID, newerID)
+	}
+}
+
+func TestSQLiteGetPagesByURLAndNeighbors_UseSubsecondFirstVisitedOrder(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	testURL := "https://example.com/subsecond-history"
+	olderID, err := db.CreatePage(testURL, "Older", "html/test/subsecond-older.html", strings.Repeat("e", 64), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("CreatePage older failed: %v", err)
+	}
+	middleID, err := db.CreatePage(testURL, "Middle", "html/test/subsecond-middle.html", strings.Repeat("f", 64), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("CreatePage middle failed: %v", err)
+	}
+	newerID, err := db.CreatePage(testURL, "Newer", "html/test/subsecond-newer.html", strings.Repeat("g", 64), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("CreatePage newer failed: %v", err)
+	}
+
+	base := time.Date(2026, 4, 24, 7, 23, 51, 0, time.UTC)
+	for _, tc := range []struct {
+		id   int64
+		when time.Time
+	}{
+		{id: olderID, when: base},
+		{id: middleID, when: base.Add(100 * time.Millisecond)},
+		{id: newerID, when: base.Add(200 * time.Millisecond)},
+	} {
+		if _, err := db.conn.Exec("UPDATE pages SET first_visited = ?, last_visited = ? WHERE id = ?", formatSQLiteTimestamp(tc.when), formatSQLiteTimestamp(tc.when), tc.id); err != nil {
+			t.Fatalf("seed page %d timestamps failed: %v", tc.id, err)
+		}
+	}
+
+	pages, err := db.GetPagesByURL(testURL)
+	if err != nil {
+		t.Fatalf("GetPagesByURL failed: %v", err)
+	}
+	if len(pages) != 3 {
+		t.Fatalf("GetPagesByURL returned %d pages, want 3", len(pages))
+	}
+	if pages[0].ID != newerID || pages[1].ID != middleID || pages[2].ID != olderID {
+		t.Fatalf("GetPagesByURL order = [%d, %d, %d], want [%d, %d, %d]", pages[0].ID, pages[1].ID, pages[2].ID, newerID, middleID, olderID)
+	}
+
+	prev, next, total, err := db.GetSnapshotNeighbors(testURL, middleID)
+	if err != nil {
+		t.Fatalf("GetSnapshotNeighbors failed: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if prev == nil || prev.ID != olderID {
+		t.Fatalf("prev = %+v, want ID %d", prev, olderID)
+	}
+	if next == nil || next.ID != newerID {
+		t.Fatalf("next = %+v, want ID %d", next, newerID)
+	}
+}
+
+func mustParseUTC(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		t.Fatalf("parse %q failed: %v", raw, err)
+	}
+	return parsed
+}
+
+func assertSQLiteTimestampText(t *testing.T, name, value string) {
+	t.Helper()
+
+	parsed := mustParseUTC(t, value)
+	if parsed.Location() != time.UTC {
+		t.Fatalf("%s location = %v, want UTC", name, parsed.Location())
+	}
+	if want := formatSQLiteTimestamp(parsed); value != want {
+		t.Fatalf("%s stored as %q, want fixed-width UTC text %q", name, value, want)
+	}
+}
+
+func sqliteUserVersion(t *testing.T, db *SQLiteDB) int {
+	t.Helper()
+
+	var version int
+	if err := db.conn.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatalf("query user_version failed: %v", err)
+	}
+	return version
+}
+
+func sqliteTriggerExists(t *testing.T, db *SQLiteDB, name string) bool {
+	t.Helper()
+
+	var count int
+	if err := db.conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = ?", name).Scan(&count); err != nil {
+		t.Fatalf("query trigger %q failed: %v", name, err)
+	}
+	return count > 0
+}
+
+func sqliteAuditCount(t *testing.T, db *SQLiteDB, target string) int {
+	t.Helper()
+
+	var count int
+	if err := db.conn.QueryRow("SELECT count FROM migration_audit WHERE target = ?", target).Scan(&count); err != nil {
+		t.Fatalf("query migration audit %q failed: %v", target, err)
+	}
+	return count
 }

--- a/tests/server/test_deletion_queue.js
+++ b/tests/server/test_deletion_queue.js
@@ -14,7 +14,7 @@ const path = require('path');
 
 const SERVER_URL = 'http://localhost:8080';
 const TEST_URL = 'https://example.com/test-deletion-queue';
-const DATA_DIR = path.join(__dirname, '../../data');
+const DATA_DIR = process.env.WAYBACK_DATA_DIR || path.join(__dirname, '../../data');
 const DELETION_QUEUE_FILE = path.join(DATA_DIR, 'deletion_queue.jsonl');
 
 async function sleep(ms) {


### PR DESCRIPTION
## Summary
- move detached fixed-layout normalization and viewport metadata into capture-time HTML so archived pages replay with stable layout without extra server-side viewport overrides
- add HEAD parity for embedded pages, API routes, and archived resource endpoints with regression coverage for replay sanitization behavior
- normalize SQLite and PostgreSQL timestamp writes/migrations for stable ordering, and let the deletion-queue E2E test point at an isolated data directory

## Testing
- make test
- cd server && go test -count=1 -tags fts5 ./... -v
- cd browser && npm test --silent
- make test-e2e
- WAYBACK_DATA_DIR=/tmp/wayback-deletion-e2e.Cju242/data node tests/server/test_deletion_queue.js