### PR TITLE
fix: quarantine historically corrupted CSS resources

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -106,6 +106,18 @@ echo "DB_NAME=wayback" >> .env
 
 服务器默认在 `http://localhost:8080` 启动。
 
+如需处理生产环境里历史遗留的坏 CSS 缓存，可在停服后执行一次离线隔离：
+
+```bash
+./wayback-server --quarantine-corrupted-css
+```
+
+这个命令会扫描所有未隔离的 CSS 资源，校验磁盘文件内容是否仍然匹配数据库中的 `content_hash`。发现被污染或丢失的文件后，会：
+
+- 把旧文件复制到 `data/resources/quarantine/...`
+- 将对应 `resources` 记录标记为隔离，不再参与后续去重/复用
+- 保留隔离副本，避免旧归档页面完全失去可读性
+
 如需通过代理下载外部资源：
 
 ```bash
@@ -254,8 +266,11 @@ data/
 │   ├── wayback-2026-03-12.001.log
 │   └── wayback-2026-03-12.002.log
 └── resources/                # 去重后的静态资源
-    └── ab/cd/
-        └── <sha256>.css
+    ├── ab/cd/
+    │   └── <sha256>.css
+    └── quarantine/           # 被隔离的历史坏资源副本
+        └── ab/cd/
+            └── <sha256>-quarantined-<ts>.css
 ```
 
 ## 从源码构建
@@ -272,6 +287,7 @@ data/
 - 通过 JS 动态注入的脚本可能无法被捕获
 - 带动态参数的统计/追踪 URL 不会被保存（不影响页面渲染）
 - 大型媒体文件（视频、高清图片）会占用较多存储空间
+- 若生产环境存在历史污染的共享 CSS，请先执行离线隔离命令，再恢复线上流量
 
 ## 许可证
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ The server will create the configured PostgreSQL database and tables automatical
 
 The server starts at `http://localhost:8080` by default.
 
+If you need to quarantine historically corrupted CSS cache files in production, stop the server and run a one-off offline pass:
+
+```bash
+./wayback-server --quarantine-corrupted-css
+```
+
+This command scans every non-quarantined CSS resource and verifies that the file still matches the `content_hash` stored in the database. When a polluted or missing file is found, it will:
+
+- copy the old file into `data/resources/quarantine/...`
+- mark every matching `resources` row as quarantined so it is no longer reused for deduplication
+- keep the quarantined copy on disk so older archived pages do not lose the historical file completely
+
 If you need a proxy for downloading external resources:
 
 ```bash
@@ -287,8 +299,11 @@ data/
 │   ├── wayback-2026-03-12.001.log
 │   └── wayback-2026-03-12.002.log
 └── resources/                # Deduplicated static resources
-    └── ab/cd/
-        └── <sha256>.css
+    ├── ab/cd/
+    │   └── <sha256>.css
+    └── quarantine/           # Historical corrupted resource copies kept for isolation
+        └── ab/cd/
+            └── <sha256>-quarantined-<ts>.css
 ```
 
 ## Building from Source
@@ -305,6 +320,7 @@ This project includes an [Agent skill](skill.md) for AI-assisted querying and ex
 - Dynamically injected scripts (loaded via JS at runtime) may not be captured
 - Tracking pixels and analytics URLs with dynamic parameters are not preserved (they don't affect page rendering)
 - Very large media files (video, large images) will consume significant storage
+- Historically polluted shared CSS files should be handled with the offline quarantine command before restarting production traffic
 
 ## License
 

--- a/docs/technical/snapshot-and-update.md
+++ b/docs/technical/snapshot-and-update.md
@@ -180,6 +180,20 @@ CSS 文件按内容哈希去重后，会被多个页面共享复用。
 3. CSS 的 `url(...)` 重写必须在查看阶段完成：`GET /archive/:page_id/:timestamp/...css` 返回 CSS 时，再根据当前 `page_id` 动态改写为 `/archive/resources/...`。
 4. 这样共享 CSS 永远保持原始内容，后续页面复用时不会把归档路径误当成原站 URL 再次下载。
 
+### 资源完整性隔离
+
+历史版本曾出现过共享 CSS 被本地流程错误改写、导致磁盘文件内容与 `resources.content_hash` 不一致的情况。
+
+当前仅保留**离线隔离**方案：
+
+1. `wayback-server --quarantine-corrupted-css` 会批量扫描所有未隔离的 CSS 资源
+2. 对每个文件重新计算 SHA-256，若与 `resources.content_hash` 不一致，说明这份共享 CSS 已经被污染或丢失
+3. 被判定为损坏的资源文件会先复制到 `data/resources/quarantine/...`
+4. 对应 `resources` 记录会被标记为 `is_quarantined=true`，并写入 `quarantine_reason`
+5. 后续捕获和去重查询会自动忽略这些已隔离资源，但旧归档页仍可通过隔离副本保留历史文件
+
+这样线上热路径不需要为每次资源复用额外做文件 hash 校验，生产环境只需在发现历史污染后停服执行一次离线扫描即可。
+
 ### 更新归档（PUT /api/archive/:id）
 
 `Deduplicator.UpdateCapture()`:

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -29,6 +29,8 @@ var (
 
 const shutdownTimeout = 30 * time.Second
 
+const quarantineCorruptedCSSFlag = "--quarantine-corrupted-css"
+
 type backgroundTaskWaiter interface {
 	WaitForBackgroundTasks()
 }
@@ -90,14 +92,61 @@ func serveWithGracefulShutdown(ctx context.Context, server *http.Server, waiter 
 	return nil
 }
 
+func runQuarantineCorruptedCSS() error {
+	_ = godotenv.Load()
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		return fmt.Errorf("load configuration failed: %w", err)
+	}
+
+	logger, err := logging.Setup(cfg.Storage.LogDir)
+	if err != nil {
+		return fmt.Errorf("setup logging failed: %w", err)
+	}
+	defer logger.Close()
+
+	db, err := database.Open(&cfg.Database)
+	if err != nil {
+		return fmt.Errorf("connect database failed: %w", err)
+	}
+	defer db.Close()
+
+	fileStorage := storage.NewFileStorage(cfg.Storage.DataDir, cfg.Resource.DownloadTimeout)
+	dedup := storage.NewDeduplicator(db, fileStorage, cfg.Resource)
+
+	log.Printf("Starting corrupted CSS quarantine scan")
+	summary, err := dedup.QuarantineCorruptedCSS(200)
+	if err != nil {
+		return fmt.Errorf("quarantine corrupted css failed: %w", err)
+	}
+	log.Printf(
+		"Corrupted CSS quarantine completed: scanned_resources=%d scanned_files=%d corrupted_files=%d missing_files=%d quarantined_files=%d",
+		summary.ScannedResources,
+		summary.ScannedFiles,
+		summary.CorruptedFiles,
+		summary.MissingFiles,
+		summary.QuarantinedFiles,
+	)
+	return nil
+}
+
 func main() {
 	// Handle --version / -v
-	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
-		fmt.Printf("wayback-server %s\n", Version)
-		if BuildTime != "" {
-			fmt.Printf("built at %s\n", BuildTime)
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "--version", "-v":
+			fmt.Printf("wayback-server %s\n", Version)
+			if BuildTime != "" {
+				fmt.Printf("built at %s\n", BuildTime)
+			}
+			return
+		case quarantineCorruptedCSSFlag:
+			if err := runQuarantineCorruptedCSS(); err != nil {
+				log.Fatalf("Resource integrity task failed: %v", err)
+			}
+			return
 		}
-		return
 	}
 	// 加载 .env 文件（如果存在）
 	// 忽略错误，因为 .env 文件是可选的（可以直接使用环境变量）

--- a/server/internal/database/common.go
+++ b/server/internal/database/common.go
@@ -10,14 +10,35 @@ import (
 // pageSelectColumns 定义查询页面时的标准列列表
 const pageSelectColumns = "id, url, title, captured_at, html_path, content_hash, snapshot_state, first_visited, last_visited"
 
+const resourceSelectColumns = "id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen, is_quarantined, quarantine_reason"
+
 // pageScanner 定义可以扫描数据库行的接口
 type pageScanner interface {
+	Scan(dest ...any) error
+}
+
+type resourceScanner interface {
 	Scan(dest ...any) error
 }
 
 // scanPage 从数据库行扫描页面数据到 Page 结构体
 func scanPage(scanner pageScanner, page *models.Page) error {
 	return scanner.Scan(&page.ID, &page.URL, &page.Title, &page.CapturedAt, &page.HTMLPath, &page.ContentHash, &page.SnapshotState, &page.FirstVisited, &page.LastVisited)
+}
+
+func scanResource(scanner resourceScanner, resource *models.Resource) error {
+	return scanner.Scan(
+		&resource.ID,
+		&resource.URL,
+		&resource.ContentHash,
+		&resource.ResourceType,
+		&resource.FilePath,
+		&resource.FileSize,
+		&resource.FirstSeen,
+		&resource.LastSeen,
+		&resource.IsQuarantined,
+		&resource.QuarantineReason,
+	)
 }
 
 // extractDomain 从 URL 字符串中提取主机名

--- a/server/internal/database/interface.go
+++ b/server/internal/database/interface.go
@@ -43,7 +43,9 @@ type Database interface {
 	GetResourceByURLPrefix(urlPrefix string, pageID int64) (*models.Resource, error)
 	GetResourceByURLPath(urlPath string, pageID int64) (*models.Resource, error)
 	GetResourcesByPageID(pageID int64) ([]models.Resource, error)
+	ListResourcesForIntegrityCheck(resourceType string, lastID int64, limit int) ([]models.Resource, error)
 	UpdateResourceLastSeen(id int64) error
+	QuarantineResourcesByFilePath(filePath, quarantinePath, reason string) (int64, error)
 
 	// 页面-资源关联
 	LinkPageResource(pageID, resourceID int64) error

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -73,6 +73,10 @@ func NewPostgres(host, port, user, password, dbname string, sslmode ...string) (
 		conn.Close()
 		return nil, fmt.Errorf("failed to ensure snapshot_state column: %w", err)
 	}
+	if err := db.ensureResourceQuarantineColumns(); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to ensure resource quarantine columns: %w", err)
+	}
 	return db, nil
 }
 
@@ -260,6 +264,19 @@ func (db *PostgresDB) ensureSnapshotStateColumn() error {
 	return nil
 }
 
+func (db *PostgresDB) ensureResourceQuarantineColumns() error {
+	if _, err := db.conn.Exec(`ALTER TABLE resources ADD COLUMN IF NOT EXISTS is_quarantined BOOLEAN NOT NULL DEFAULT FALSE`); err != nil {
+		return err
+	}
+	if _, err := db.conn.Exec(`ALTER TABLE resources ADD COLUMN IF NOT EXISTS quarantine_reason TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
+	if _, err := db.conn.Exec(`UPDATE resources SET quarantine_reason = '' WHERE quarantine_reason IS NULL`); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (db *PostgresDB) Close() error {
 	return db.conn.Close()
 }
@@ -307,10 +324,10 @@ func (db *PostgresDB) UpdatePageLastVisited(id int64, lastVisited time.Time) err
 // GetResourceByHash 根据哈希查找资源
 func (db *PostgresDB) GetResourceByHash(hash string) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE content_hash = $1",
+	err := scanResource(db.conn.QueryRow(
+		"SELECT "+resourceSelectColumns+" FROM resources WHERE content_hash = $1 AND is_quarantined = FALSE ORDER BY last_seen DESC LIMIT 1",
 		hash,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -390,10 +407,7 @@ func (db *PostgresDB) CheckRecentCapture(url string, within time.Duration) (bool
 // GetResourceByID 根据 ID 获取资源
 func (db *PostgresDB) GetResourceByID(id int64) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE id = $1",
-		id,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	err := scanResource(db.conn.QueryRow("SELECT "+resourceSelectColumns+" FROM resources WHERE id = $1", id), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -406,11 +420,17 @@ func (db *PostgresDB) GetResourceByID(id int64) (*models.Resource, error) {
 
 // GetResourceByURL 根据 URL 获取资源（返回最新的）
 func (db *PostgresDB) GetResourceByURL(url string) (*models.Resource, error) {
+	return db.getAnyResourceByURL(url, false)
+}
+
+func (db *PostgresDB) getAnyResourceByURL(url string, includeQuarantined bool) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE url = $1 ORDER BY last_seen DESC LIMIT 1",
-		url,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	query := "SELECT " + resourceSelectColumns + " FROM resources WHERE url = $1"
+	if !includeQuarantined {
+		query += " AND is_quarantined = FALSE"
+	}
+	query += " ORDER BY last_seen DESC LIMIT 1"
+	err := scanResource(db.conn.QueryRow(query, url), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -424,10 +444,10 @@ func (db *PostgresDB) GetResourceByURL(url string) (*models.Resource, error) {
 // GetResourceByURLLike 根据 URL 模糊匹配查找资源（如忽略查询参数差异）
 func (db *PostgresDB) GetResourceByURLLike(pattern string) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE url LIKE $1 ORDER BY last_seen DESC LIMIT 1",
+	err := scanResource(db.conn.QueryRow(
+		"SELECT "+resourceSelectColumns+" FROM resources WHERE url LIKE $1 AND is_quarantined = FALSE ORDER BY last_seen DESC LIMIT 1",
 		pattern,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -616,7 +636,7 @@ func (db *PostgresDB) GetPagesWithoutBodyText() ([]models.Page, error) {
 // GetResourcesByPageID 获取页面关联的所有资源
 func (db *PostgresDB) GetResourcesByPageID(pageID int64) ([]models.Resource, error) {
 	rows, err := db.conn.Query(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = $1
@@ -629,7 +649,7 @@ func (db *PostgresDB) GetResourcesByPageID(pageID int64) ([]models.Resource, err
 	var resources []models.Resource
 	for rows.Next() {
 		var r models.Resource
-		if err := rows.Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen); err != nil {
+		if err := scanResource(rows, &r); err != nil {
 			return nil, err
 		}
 		resources = append(resources, r)
@@ -645,19 +665,19 @@ func (db *PostgresDB) GetResourceByURLAndPageID(url string, pageID int64) (*mode
 	}
 
 	// 如果页面关联中没有，尝试直接按URL查找最新的
-	return db.GetResourceByURL(url)
+	return db.getAnyResourceByURL(url, true)
 }
 
 // GetLinkedResourceByURLAndPageID 根据URL和页面ID查找资源，只查询 page_resources 关联，不做全局兜底
 func (db *PostgresDB) GetLinkedResourceByURLAndPageID(url string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+	err := scanResource(db.conn.QueryRow(`
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = $1 AND r.url = $2
 		LIMIT 1
-	`, pageID, url).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, url), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -672,14 +692,14 @@ func (db *PostgresDB) GetLinkedResourceByURLAndPageID(url string, pageID int64) 
 func (db *PostgresDB) GetResourceByURLPrefix(urlPrefix string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
 	escapedPrefix := escapeLikePattern(urlPrefix)
-	err := db.conn.QueryRow(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+	err := scanResource(db.conn.QueryRow(`
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = $1 AND (r.url LIKE $2 ESCAPE '\' OR r.url LIKE $3 ESCAPE '\')
 		ORDER BY r.last_seen DESC, r.id DESC
 		LIMIT 1
-	`, pageID, escapedPrefix+"#%", escapedPrefix+"%23%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, escapedPrefix+"#%", escapedPrefix+"%23%"), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -694,14 +714,14 @@ func (db *PostgresDB) GetResourceByURLPrefix(urlPrefix string, pageID int64) (*m
 func (db *PostgresDB) GetResourceByURLPath(urlPath string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
 	escapedPath := escapeLikePattern(urlPath)
-	err := db.conn.QueryRow(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+	err := scanResource(db.conn.QueryRow(`
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = $1 AND (r.url = $2 OR r.url LIKE $3 ESCAPE '\')
 		ORDER BY CASE WHEN r.url = $2 THEN 0 ELSE 1 END, r.last_seen DESC, r.id DESC
 		LIMIT 1
-	`, pageID, urlPath, escapedPath+"?%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, urlPath, escapedPath+"?%"), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -710,6 +730,42 @@ func (db *PostgresDB) GetResourceByURLPath(urlPath string, pageID int64) (*model
 		return nil, err
 	}
 	return &r, nil
+}
+
+func (db *PostgresDB) ListResourcesForIntegrityCheck(resourceType string, lastID int64, limit int) ([]models.Resource, error) {
+	rows, err := db.conn.Query(
+		"SELECT "+resourceSelectColumns+" FROM resources WHERE resource_type = $1 AND is_quarantined = FALSE AND id > $2 ORDER BY id ASC LIMIT $3",
+		resourceType,
+		lastID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	resources := make([]models.Resource, 0, limit)
+	for rows.Next() {
+		var r models.Resource
+		if err := scanResource(rows, &r); err != nil {
+			return nil, err
+		}
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func (db *PostgresDB) QuarantineResourcesByFilePath(filePath, quarantinePath, reason string) (int64, error) {
+	result, err := db.conn.Exec(
+		"UPDATE resources SET file_path = $1, is_quarantined = TRUE, quarantine_reason = $2 WHERE file_path = $3 AND is_quarantined = FALSE",
+		quarantinePath,
+		reason,
+		filePath,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 // UpdatePageContent 更新页面内容（HTML路径、哈希、标题、最后访问时间）

--- a/server/internal/database/schema/init_postgres.sql
+++ b/server/internal/database/schema/init_postgres.sql
@@ -39,7 +39,9 @@ CREATE TABLE IF NOT EXISTS resources (
     file_path TEXT NOT NULL,
     file_size BIGINT,
     first_seen TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    last_seen TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    last_seen TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    is_quarantined BOOLEAN NOT NULL DEFAULT FALSE,
+    quarantine_reason TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_resources_hash ON resources(content_hash);

--- a/server/internal/database/schema/init_sqlite.sql
+++ b/server/internal/database/schema/init_sqlite.sql
@@ -53,7 +53,9 @@ CREATE TABLE IF NOT EXISTS resources (
     file_path TEXT NOT NULL,
     file_size BIGINT,
     first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
-    last_seen DATETIME DEFAULT CURRENT_TIMESTAMP
+    last_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_quarantined BOOLEAN NOT NULL DEFAULT 0,
+    quarantine_reason TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_resources_hash ON resources(content_hash);

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -30,7 +30,8 @@ const (
 	sqliteMigrationVersionSnapshotState          = 2
 	sqliteMigrationVersionTimestampNormalization = 3
 	sqliteMigrationVersionTimestampFixedWidth    = 4
-	sqliteMigrationVersionCurrent                = sqliteMigrationVersionTimestampFixedWidth
+	sqliteMigrationVersionResourceQuarantine     = 5
+	sqliteMigrationVersionCurrent                = sqliteMigrationVersionResourceQuarantine
 )
 
 func formatSQLiteTimestamp(t time.Time) string {
@@ -169,6 +170,17 @@ func (db *SQLiteDB) ensureMigrations() error {
 		if err := db.setSQLiteUserVersion(sqliteMigrationVersionTimestampFixedWidth); err != nil {
 			return err
 		}
+		version = sqliteMigrationVersionTimestampFixedWidth
+	}
+
+	if version < sqliteMigrationVersionResourceQuarantine {
+		if err := db.ensureResourceQuarantineColumns(); err != nil {
+			return err
+		}
+
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionResourceQuarantine); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -264,6 +276,19 @@ func (db *SQLiteDB) ensureNormalizedTimestamps() error {
 	}
 
 	return tx.Commit()
+}
+
+func (db *SQLiteDB) ensureResourceQuarantineColumns() error {
+	if _, err := db.conn.Exec("ALTER TABLE resources ADD COLUMN is_quarantined BOOLEAN NOT NULL DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return err
+	}
+	if _, err := db.conn.Exec("ALTER TABLE resources ADD COLUMN quarantine_reason TEXT NOT NULL DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return err
+	}
+	if _, err := db.conn.Exec("UPDATE resources SET quarantine_reason = '' WHERE quarantine_reason IS NULL"); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (db *SQLiteDB) ensureFTSConsistency() error {
@@ -411,10 +436,10 @@ func (db *SQLiteDB) UpdatePageLastVisited(id int64, lastVisited time.Time) error
 // GetResourceByHash 根据哈希查找资源
 func (db *SQLiteDB) GetResourceByHash(hash string) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE content_hash = ?",
+	err := scanResource(db.conn.QueryRow(
+		"SELECT "+resourceSelectColumns+" FROM resources WHERE content_hash = ? AND is_quarantined = 0 ORDER BY last_seen DESC LIMIT 1",
 		hash,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -507,10 +532,7 @@ func (db *SQLiteDB) CheckRecentCapture(url string, within time.Duration) (bool, 
 // GetResourceByID 根据 ID 获取资源
 func (db *SQLiteDB) GetResourceByID(id int64) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE id = ?",
-		id,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	err := scanResource(db.conn.QueryRow("SELECT "+resourceSelectColumns+" FROM resources WHERE id = ?", id), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -523,11 +545,17 @@ func (db *SQLiteDB) GetResourceByID(id int64) (*models.Resource, error) {
 
 // GetResourceByURL 根据 URL 获取资源（返回最新的）
 func (db *SQLiteDB) GetResourceByURL(url string) (*models.Resource, error) {
+	return db.getAnyResourceByURL(url, false)
+}
+
+func (db *SQLiteDB) getAnyResourceByURL(url string, includeQuarantined bool) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE url = ? ORDER BY last_seen DESC LIMIT 1",
-		url,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	query := "SELECT " + resourceSelectColumns + " FROM resources WHERE url = ?"
+	if !includeQuarantined {
+		query += " AND is_quarantined = 0"
+	}
+	query += " ORDER BY last_seen DESC LIMIT 1"
+	err := scanResource(db.conn.QueryRow(query, url), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -541,10 +569,10 @@ func (db *SQLiteDB) GetResourceByURL(url string) (*models.Resource, error) {
 // GetResourceByURLLike 根据 URL 模糊匹配查找资源（如忽略查询参数差异）
 func (db *SQLiteDB) GetResourceByURLLike(pattern string) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(
-		"SELECT id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen FROM resources WHERE url LIKE ? ORDER BY last_seen DESC LIMIT 1",
+	err := scanResource(db.conn.QueryRow(
+		"SELECT "+resourceSelectColumns+" FROM resources WHERE url LIKE ? AND is_quarantined = 0 ORDER BY last_seen DESC LIMIT 1",
 		pattern,
-	).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -719,7 +747,7 @@ func (db *SQLiteDB) GetPagesWithoutBodyText() ([]models.Page, error) {
 // GetResourcesByPageID 获取页面关联的所有资源
 func (db *SQLiteDB) GetResourcesByPageID(pageID int64) ([]models.Resource, error) {
 	rows, err := db.conn.Query(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = ?
@@ -732,7 +760,7 @@ func (db *SQLiteDB) GetResourcesByPageID(pageID int64) ([]models.Resource, error
 	var resources []models.Resource
 	for rows.Next() {
 		var r models.Resource
-		if err := rows.Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen); err != nil {
+		if err := scanResource(rows, &r); err != nil {
 			return nil, err
 		}
 		resources = append(resources, r)
@@ -748,19 +776,19 @@ func (db *SQLiteDB) GetResourceByURLAndPageID(url string, pageID int64) (*models
 	}
 
 	// 如果页面关联中没有，尝试直接按URL查找最新的
-	return db.GetResourceByURL(url)
+	return db.getAnyResourceByURL(url, true)
 }
 
 // GetLinkedResourceByURLAndPageID 根据URL和页面ID查找资源，只查询 page_resources 关联，不做全局兜底
 func (db *SQLiteDB) GetLinkedResourceByURLAndPageID(url string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
-	err := db.conn.QueryRow(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+	err := scanResource(db.conn.QueryRow(`
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = ? AND r.url = ?
 		LIMIT 1
-	`, pageID, url).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, url), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -775,14 +803,14 @@ func (db *SQLiteDB) GetLinkedResourceByURLAndPageID(url string, pageID int64) (*
 func (db *SQLiteDB) GetResourceByURLPrefix(urlPrefix string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
 	escapedPrefix := escapeLikePattern(urlPrefix)
-	err := db.conn.QueryRow(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+	err := scanResource(db.conn.QueryRow(`
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = ? AND (r.url LIKE ? ESCAPE '\' OR r.url LIKE ? ESCAPE '\')
 		ORDER BY r.last_seen DESC, r.id DESC
 		LIMIT 1
-	`, pageID, escapedPrefix+"#%", escapedPrefix+"%23%").Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, escapedPrefix+"#%", escapedPrefix+"%23%"), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -797,14 +825,14 @@ func (db *SQLiteDB) GetResourceByURLPrefix(urlPrefix string, pageID int64) (*mod
 func (db *SQLiteDB) GetResourceByURLPath(urlPath string, pageID int64) (*models.Resource, error) {
 	var r models.Resource
 	escapedPath := escapeLikePattern(urlPath)
-	err := db.conn.QueryRow(`
-		SELECT r.id, r.url, r.content_hash, r.resource_type, r.file_path, r.file_size, r.first_seen, r.last_seen
+	err := scanResource(db.conn.QueryRow(`
+		SELECT `+resourceSelectColumns+`
 		FROM resources r
 		INNER JOIN page_resources pr ON r.id = pr.resource_id
 		WHERE pr.page_id = ? AND (r.url = ? OR r.url LIKE ? ESCAPE '\')
 		ORDER BY CASE WHEN r.url = ? THEN 0 ELSE 1 END, r.last_seen DESC, r.id DESC
 		LIMIT 1
-	`, pageID, urlPath, escapedPath+"?%", urlPath).Scan(&r.ID, &r.URL, &r.ContentHash, &r.ResourceType, &r.FilePath, &r.FileSize, &r.FirstSeen, &r.LastSeen)
+	`, pageID, urlPath, escapedPath+"?%", urlPath), &r)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -813,6 +841,42 @@ func (db *SQLiteDB) GetResourceByURLPath(urlPath string, pageID int64) (*models.
 		return nil, err
 	}
 	return &r, nil
+}
+
+func (db *SQLiteDB) ListResourcesForIntegrityCheck(resourceType string, lastID int64, limit int) ([]models.Resource, error) {
+	rows, err := db.conn.Query(
+		"SELECT "+resourceSelectColumns+" FROM resources WHERE resource_type = ? AND is_quarantined = 0 AND id > ? ORDER BY id ASC LIMIT ?",
+		resourceType,
+		lastID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	resources := make([]models.Resource, 0, limit)
+	for rows.Next() {
+		var r models.Resource
+		if err := scanResource(rows, &r); err != nil {
+			return nil, err
+		}
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func (db *SQLiteDB) QuarantineResourcesByFilePath(filePath, quarantinePath, reason string) (int64, error) {
+	result, err := db.conn.Exec(
+		"UPDATE resources SET file_path = ?, is_quarantined = 1, quarantine_reason = ? WHERE file_path = ? AND is_quarantined = 0",
+		quarantinePath,
+		reason,
+		filePath,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 // UpdatePageContent 更新页面内容（HTML路径、哈希、标题、最后访问时间）

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -17,14 +17,16 @@ type Page struct {
 }
 
 type Resource struct {
-	ID           int64     `json:"id"`
-	URL          string    `json:"url"`
-	ContentHash  string    `json:"content_hash"`
-	ResourceType string    `json:"resource_type"`
-	FilePath     string    `json:"file_path"`
-	FileSize     int64     `json:"file_size"`
-	FirstSeen    time.Time `json:"first_seen"`
-	LastSeen     time.Time `json:"last_seen"`
+	ID               int64     `json:"id"`
+	URL              string    `json:"url"`
+	ContentHash      string    `json:"content_hash"`
+	ResourceType     string    `json:"resource_type"`
+	FilePath         string    `json:"file_path"`
+	FileSize         int64     `json:"file_size"`
+	FirstSeen        time.Time `json:"first_seen"`
+	LastSeen         time.Time `json:"last_seen"`
+	IsQuarantined    bool      `json:"is_quarantined"`
+	QuarantineReason string    `json:"quarantine_reason,omitempty"`
 }
 
 type CaptureRequest struct {

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -405,6 +405,55 @@ func (d *Deduplicator) loadCachedResource(url string) *resourceCacheEntry {
 	return cached
 }
 
+func shortHashForLog(hash string) string {
+	if len(hash) <= 16 {
+		return hash
+	}
+	return hash[:16]
+}
+
+func (d *Deduplicator) quarantineResourceFile(filePath, reason string) error {
+	quarantinePath := filePath
+	fullPath := filepath.Join(d.storage.baseDir, filePath)
+	if _, err := os.Stat(fullPath); err == nil {
+		copiedPath, copyErr := d.storage.CreateResourceQuarantineCopy(filePath)
+		if copyErr != nil {
+			return fmt.Errorf("create quarantine copy failed: %w", copyErr)
+		}
+		quarantinePath = copiedPath
+	}
+
+	affected, err := d.db.QuarantineResourcesByFilePath(filePath, quarantinePath, reason)
+	if err != nil {
+		if quarantinePath != filePath {
+			_ = os.Remove(filepath.Join(d.storage.baseDir, quarantinePath))
+		}
+		return fmt.Errorf("update quarantine metadata failed: %w", err)
+	}
+	if quarantinePath != filePath {
+		if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove corrupted file failed: %w", err)
+		}
+	}
+	log.Printf("[resource] quarantined corrupted file=%s moved_to=%s affected=%d reason=%s", filePath, quarantinePath, affected, reason)
+	return nil
+}
+
+func (d *Deduplicator) ensureReusableResource(resource *models.Resource, reuseURL string) bool {
+	if resource == nil {
+		return false
+	}
+	if resource.IsQuarantined {
+		log.Printf("[resource] skip quarantined reuse id=%d url=%s reason=%s", resource.ID, shortURLForLog(reuseURL), resource.QuarantineReason)
+		return false
+	}
+	if resource.FilePath == "" {
+		log.Printf("[resource] skip reuse for empty file path id=%d url=%s", resource.ID, shortURLForLog(reuseURL))
+		return false
+	}
+	return true
+}
+
 func (d *Deduplicator) tryReuseFreshCache(url string, cached *resourceCacheEntry) (int64, string, bool) {
 	if cached == nil || cached.freshUntil.IsZero() || !time.Now().Before(cached.freshUntil) {
 		return 0, "", false
@@ -413,14 +462,24 @@ func (d *Deduplicator) tryReuseFreshCache(url string, cached *resourceCacheEntry
 		d.cacheDelete(url)
 		return 0, "", false
 	}
+	resource, err := d.db.GetResourceByID(cached.resourceID)
+	if err != nil {
+		log.Printf("[cache] failed to load cached resource %d for %s: %v", cached.resourceID, shortURLForLog(url), err)
+		d.cacheDelete(url)
+		return 0, "", false
+	}
+	if !d.ensureReusableResource(resource, url) {
+		d.cacheDelete(url)
+		return 0, "", false
+	}
 
-	d.cacheStoreWithMetadata(url, cached.resourceID, cached.filePath, downloadMetadata{
+	d.cacheStoreWithMetadata(url, resource.ID, resource.FilePath, downloadMetadata{
 		etag:       cached.etag,
 		lastMod:    cached.lastMod,
 		freshUntil: cached.freshUntil,
 	}, nil)
 	log.Printf("[cache] fresh reuse: %s", shortURLForLog(url))
-	return cached.resourceID, cached.filePath, true
+	return resource.ID, resource.FilePath, true
 }
 
 func shortURLForLog(raw string) string {
@@ -596,18 +655,31 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 				return d.processResourceFallback(url, err)
 			}
 		} else {
-			if !metadata.hasFreshness {
-				metadata.freshUntil = cached.freshUntil
+			cachedResource, err := d.db.GetResourceByID(cached.resourceID)
+			if err != nil {
+				return 0, "", nil, fmt.Errorf("db query cached resource failed: %w", err)
 			}
-			if metadata.etag == "" {
-				metadata.etag = cached.etag
+			if !d.ensureReusableResource(cachedResource, url) {
+				d.cacheDelete(url)
+				data, hash, tmpPath, metadata, trace, err = d.storage.DownloadResourceWithMetadata(url, pageURL, headers, cookies, streamThreshold, "", "")
+				if err != nil {
+					log.Printf("Download failed for %s after corrupted cache revalidation miss: %v", url, err)
+					return d.processResourceFallback(url, err)
+				}
+			} else {
+				if !metadata.hasFreshness {
+					metadata.freshUntil = cached.freshUntil
+				}
+				if metadata.etag == "" {
+					metadata.etag = cached.etag
+				}
+				if metadata.lastMod == "" {
+					metadata.lastMod = cached.lastMod
+				}
+				d.cacheStoreWithMetadata(url, cachedResource.ID, cachedResource.FilePath, metadata, nil)
+				log.Printf("[cache] revalidated 304: %s (%v)", shortURLForLog(url), time.Since(startTime))
+				return cachedResource.ID, cachedResource.FilePath, nil, nil
 			}
-			if metadata.lastMod == "" {
-				metadata.lastMod = cached.lastMod
-			}
-			d.cacheStoreWithMetadata(url, cached.resourceID, cached.filePath, metadata, nil)
-			log.Printf("[cache] revalidated 304: %s (%v)", shortURLForLog(url), time.Since(startTime))
-			return cached.resourceID, cached.filePath, nil, nil
 		}
 	}
 	if data != nil {
@@ -634,16 +706,16 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 		if err != nil {
 			return 0, "", nil, fmt.Errorf("db query cached resource failed: %w", err)
 		}
-		if cachedResource != nil && cachedResource.ContentHash == hash {
+		if cachedResource != nil && cachedResource.ContentHash == hash && d.ensureReusableResource(cachedResource, url) {
 			dbStart = time.Now()
-			if err := d.db.UpdateResourceLastSeen(cached.resourceID); err != nil {
+			if err := d.db.UpdateResourceLastSeen(cachedResource.ID); err != nil {
 				dbDuration += time.Since(dbStart)
 				return 0, "", nil, err
 			}
 			dbDuration += time.Since(dbStart)
-			d.cacheStoreWithMetadata(url, cached.resourceID, cached.filePath, metadata, data)
+			d.cacheStoreWithMetadata(url, cachedResource.ID, cachedResource.FilePath, metadata, data)
 			logSlowResource(url, resourceType, fileSize, trace, dbDuration, saveDuration, time.Since(startTime))
-			return cached.resourceID, cached.filePath, data, nil
+			return cachedResource.ID, cachedResource.FilePath, data, nil
 		}
 	}
 
@@ -653,6 +725,9 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 	dbDuration += time.Since(dbStart)
 	if err != nil {
 		return 0, "", nil, fmt.Errorf("db query by url failed: %w", err)
+	}
+	if existingByURL != nil && !d.ensureReusableResource(existingByURL, url) {
+		existingByURL = nil
 	}
 	if existingByURL != nil {
 		if existingByURL.ContentHash == hash {
@@ -676,6 +751,9 @@ func (d *Deduplicator) ProcessResource(url, resourceType string, pageURL string,
 	dbDuration += time.Since(dbStart)
 	if err != nil {
 		return 0, "", nil, fmt.Errorf("db query by hash failed: %w", err)
+	}
+	if existingByHash != nil && !d.ensureReusableResource(existingByHash, url) {
+		existingByHash = nil
 	}
 
 	var filePath string
@@ -734,6 +812,9 @@ func (d *Deduplicator) processResourceFallback(url string, downloadErr error) (i
 		return 0, "", nil, fmt.Errorf("download failed: %w (fallback lookup failed: %v)", downloadErr, err)
 	}
 	if resource == nil || resource.FilePath == "" {
+		return 0, "", nil, fmt.Errorf("download failed: %w", downloadErr)
+	}
+	if !d.ensureReusableResource(resource, url) {
 		return 0, "", nil, fmt.Errorf("download failed: %w", downloadErr)
 	}
 
@@ -887,8 +968,13 @@ func (d *Deduplicator) processInlineResource(url, resourceType string, data []by
 
 	var filePath string
 	if existingByHash != nil {
-		filePath = existingByHash.FilePath
-	} else {
+		if d.ensureReusableResource(existingByHash, url) {
+			filePath = existingByHash.FilePath
+		} else {
+			existingByHash = nil
+		}
+	}
+	if existingByHash == nil {
 		filePath, err = d.storage.SaveResource(data, hash, resourceType)
 		if err != nil {
 			return 0, "", nil, fmt.Errorf("save failed: %w", err)

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -16,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"wayback/internal/config"
+	"wayback/internal/database"
 	"wayback/internal/models"
 )
 
@@ -41,6 +45,43 @@ func routeStorageHTTPClientToServer(t *testing.T, fs *FileStorage, server *httpt
 	fs.httpClient.Transport = cloned
 
 	return "http://archive-test.example"
+}
+
+func newSQLiteIntegrityTestDeduplicator(t *testing.T) (*Deduplicator, database.Database, *FileStorage) {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "wayback.db")
+	db, err := database.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLite failed: %v", err)
+	}
+
+	fs := NewFileStorage(dataDir)
+	dedup := NewDeduplicator(db, fs, config.ResourceConfig{
+		Workers:           2,
+		MetadataCacheMB:   10,
+		DownloadTimeout:   1,
+		StreamThresholdKB: 2048,
+	})
+
+	return dedup, db, fs
+}
+
+func createStoredTestResource(t *testing.T, db database.Database, fs *FileStorage, resourceURL, resourceType string, content []byte) (int64, string, string) {
+	t.Helper()
+
+	hashBytes := sha256.Sum256(content)
+	hash := hex.EncodeToString(hashBytes[:])
+	relPath, err := fs.SaveResource(content, hash, resourceType)
+	if err != nil {
+		t.Fatalf("SaveResource failed: %v", err)
+	}
+	resourceID, err := db.CreateResource(resourceURL, hash, resourceType, relPath, int64(len(content)))
+	if err != nil {
+		t.Fatalf("CreateResource failed: %v", err)
+	}
+	return resourceID, relPath, hash
 }
 
 func TestProcessResource_SameURLChangedContentCreatesNewVersion(t *testing.T) {
@@ -576,6 +617,261 @@ func TestUpdateCapture_FreshCacheReuseUpdatesLastSeenOnCommit(t *testing.T) {
 	}
 	if linked[0].ID != resource.ID {
 		t.Fatalf("updated page linked resource ID = %d, want %d", linked[0].ID, resource.ID)
+	}
+}
+
+func TestQuarantineCorruptedCSS_QuarantinesExistingBadCSS(t *testing.T) {
+	dedup, db, fs := newSQLiteIntegrityTestDeduplicator(t)
+	defer db.Close()
+
+	resourceURL := fmt.Sprintf("https://integrity-test.example.com/style.css?nonce=%d", time.Now().UnixNano())
+	originalCSS := []byte("body { color: red; }")
+	resourceID, filePath, _ := createStoredTestResource(t, db, fs, resourceURL, "css", originalCSS)
+
+	corruptedCSS := "body { background: url(/archive/resources/bad/file.bin); }"
+	if err := fs.UpdateResource(filePath, []byte(corruptedCSS)); err != nil {
+		t.Fatalf("UpdateResource(corrupt css) failed: %v", err)
+	}
+
+	summary, err := dedup.QuarantineCorruptedCSS(10)
+	if err != nil {
+		t.Fatalf("QuarantineCorruptedCSS failed: %v", err)
+	}
+	if summary.ScannedResources != 1 || summary.ScannedFiles != 1 {
+		t.Fatalf("unexpected scan summary: %#v", summary)
+	}
+	if summary.CorruptedFiles != 1 || summary.QuarantinedFiles != 1 {
+		t.Fatalf("unexpected quarantine summary: %#v", summary)
+	}
+
+	resource, err := db.GetResourceByID(resourceID)
+	if err != nil {
+		t.Fatalf("GetResourceByID failed: %v", err)
+	}
+	if resource == nil || !resource.IsQuarantined {
+		t.Fatalf("expected corrupted CSS resource to be quarantined")
+	}
+	if !strings.Contains(resource.FilePath, "resources/quarantine/") {
+		t.Fatalf("quarantined css path = %q, want resources/quarantine/...", resource.FilePath)
+	}
+
+	reusable, err := db.GetResourceByURL(resourceURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(active) failed: %v", err)
+	}
+	if reusable != nil {
+		t.Fatalf("quarantined CSS should be hidden from reusable lookups")
+	}
+
+	quarantinedCSS, err := fs.ReadResource(resource.FilePath)
+	if err != nil {
+		t.Fatalf("ReadResource(quarantined css) failed: %v", err)
+	}
+	if string(quarantinedCSS) != corruptedCSS {
+		t.Fatalf("quarantined css = %q, want %q", string(quarantinedCSS), corruptedCSS)
+	}
+}
+
+func TestQuarantineCorruptedCSS_MixedHealthyCorruptedAndMissingFiles(t *testing.T) {
+	dedup, db, fs := newSQLiteIntegrityTestDeduplicator(t)
+	defer db.Close()
+
+	healthyURL := fmt.Sprintf("https://integrity-test.example.com/healthy.css?nonce=%d", time.Now().UnixNano())
+	corruptedURL := fmt.Sprintf("https://integrity-test.example.com/corrupted.css?nonce=%d", time.Now().UnixNano())
+	missingURL := fmt.Sprintf("https://integrity-test.example.com/missing.css?nonce=%d", time.Now().UnixNano())
+	imageURL := fmt.Sprintf("https://integrity-test.example.com/logo.png?nonce=%d", time.Now().UnixNano())
+
+	healthyID, _, _ := createStoredTestResource(t, db, fs, healthyURL, "css", []byte("body { color: green; }"))
+	corruptedID, corruptedPath, _ := createStoredTestResource(t, db, fs, corruptedURL, "css", []byte("body { color: red; }"))
+	missingID, missingPath, _ := createStoredTestResource(t, db, fs, missingURL, "css", []byte("body { color: blue; }"))
+	imageID, imagePath, _ := createStoredTestResource(t, db, fs, imageURL, "image", []byte("image-bytes"))
+
+	corruptedCSS := "body { background: url(/archive/resources/bad/file.bin); }"
+	if err := fs.UpdateResource(corruptedPath, []byte(corruptedCSS)); err != nil {
+		t.Fatalf("UpdateResource(corrupted css) failed: %v", err)
+	}
+	if err := os.Remove(filepath.Join(fs.baseDir, missingPath)); err != nil {
+		t.Fatalf("Remove(missing css) failed: %v", err)
+	}
+	if err := fs.UpdateResource(imagePath, []byte("corrupted-image")); err != nil {
+		t.Fatalf("UpdateResource(image) failed: %v", err)
+	}
+
+	summary, err := dedup.QuarantineCorruptedCSS(1)
+	if err != nil {
+		t.Fatalf("QuarantineCorruptedCSS failed: %v", err)
+	}
+	if summary.ResourceType != "css" {
+		t.Fatalf("summary.ResourceType = %q, want css", summary.ResourceType)
+	}
+	if summary.ScannedResources != 3 {
+		t.Fatalf("ScannedResources = %d, want 3", summary.ScannedResources)
+	}
+	if summary.ScannedFiles != 3 {
+		t.Fatalf("ScannedFiles = %d, want 3", summary.ScannedFiles)
+	}
+	if summary.CorruptedFiles != 1 || summary.MissingFiles != 1 || summary.QuarantinedFiles != 2 {
+		t.Fatalf("unexpected scan summary: %#v", summary)
+	}
+
+	healthyResource, err := db.GetResourceByID(healthyID)
+	if err != nil {
+		t.Fatalf("GetResourceByID(healthy) failed: %v", err)
+	}
+	if healthyResource == nil || healthyResource.IsQuarantined {
+		t.Fatalf("healthy CSS should remain reusable")
+	}
+
+	corruptedResource, err := db.GetResourceByID(corruptedID)
+	if err != nil {
+		t.Fatalf("GetResourceByID(corrupted) failed: %v", err)
+	}
+	if corruptedResource == nil || !corruptedResource.IsQuarantined {
+		t.Fatalf("corrupted CSS should be quarantined")
+	}
+	if !strings.Contains(corruptedResource.FilePath, "resources/quarantine/") {
+		t.Fatalf("corrupted CSS path = %q, want resources/quarantine/...", corruptedResource.FilePath)
+	}
+	if !strings.Contains(corruptedResource.QuarantineReason, "hash mismatch") {
+		t.Fatalf("corrupted CSS reason = %q, want hash mismatch", corruptedResource.QuarantineReason)
+	}
+
+	missingResource, err := db.GetResourceByID(missingID)
+	if err != nil {
+		t.Fatalf("GetResourceByID(missing) failed: %v", err)
+	}
+	if missingResource == nil || !missingResource.IsQuarantined {
+		t.Fatalf("missing CSS should be quarantined")
+	}
+	if missingResource.FilePath != missingPath {
+		t.Fatalf("missing CSS path = %q, want original path %q", missingResource.FilePath, missingPath)
+	}
+	if missingResource.QuarantineReason != "resource file missing" {
+		t.Fatalf("missing CSS reason = %q, want resource file missing", missingResource.QuarantineReason)
+	}
+
+	imageResource, err := db.GetResourceByID(imageID)
+	if err != nil {
+		t.Fatalf("GetResourceByID(image) failed: %v", err)
+	}
+	if imageResource == nil || imageResource.IsQuarantined {
+		t.Fatalf("non-CSS resources should not be scanned by QuarantineCorruptedCSS")
+	}
+
+	activeCorrupted, err := db.GetResourceByURL(corruptedURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(corrupted) failed: %v", err)
+	}
+	if activeCorrupted != nil {
+		t.Fatalf("corrupted CSS should be hidden from active lookups")
+	}
+	activeMissing, err := db.GetResourceByURL(missingURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(missing) failed: %v", err)
+	}
+	if activeMissing != nil {
+		t.Fatalf("missing CSS should be hidden from active lookups")
+	}
+	activeHealthy, err := db.GetResourceByURL(healthyURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(healthy) failed: %v", err)
+	}
+	if activeHealthy == nil || activeHealthy.ID != healthyID {
+		t.Fatalf("healthy CSS should remain available via active lookup")
+	}
+	activeImage, err := db.GetResourceByURL(imageURL)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(image) failed: %v", err)
+	}
+	if activeImage == nil || activeImage.ID != imageID {
+		t.Fatalf("non-CSS resource should remain available via active lookup")
+	}
+
+	quarantinedCSS, err := fs.ReadResource(corruptedResource.FilePath)
+	if err != nil {
+		t.Fatalf("ReadResource(quarantined corrupted css) failed: %v", err)
+	}
+	if string(quarantinedCSS) != corruptedCSS {
+		t.Fatalf("quarantined corrupted css = %q, want %q", string(quarantinedCSS), corruptedCSS)
+	}
+}
+
+func TestQuarantineCorruptedCSS_QuarantinesAllRowsSharingSameFilePath(t *testing.T) {
+	dedup, db, fs := newSQLiteIntegrityTestDeduplicator(t)
+	defer db.Close()
+
+	sharedContent := []byte("body { color: red; }")
+	urlA := fmt.Sprintf("https://integrity-test.example.com/shared-a.css?nonce=%d", time.Now().UnixNano())
+	urlB := fmt.Sprintf("https://integrity-test.example.com/shared-b.css?nonce=%d", time.Now().UnixNano())
+
+	resourceIDA, sharedPath, sharedHash := createStoredTestResource(t, db, fs, urlA, "css", sharedContent)
+	resourceIDB, err := db.CreateResource(urlB, sharedHash, "css", sharedPath, int64(len(sharedContent)))
+	if err != nil {
+		t.Fatalf("CreateResource(shared duplicate) failed: %v", err)
+	}
+
+	corruptedCSS := "body { background: url(/archive/resources/shared/file.bin); }"
+	if err := fs.UpdateResource(sharedPath, []byte(corruptedCSS)); err != nil {
+		t.Fatalf("UpdateResource(shared css) failed: %v", err)
+	}
+
+	summary, err := dedup.QuarantineCorruptedCSS(10)
+	if err != nil {
+		t.Fatalf("QuarantineCorruptedCSS failed: %v", err)
+	}
+	if summary.ScannedResources != 2 {
+		t.Fatalf("ScannedResources = %d, want 2", summary.ScannedResources)
+	}
+	if summary.ScannedFiles != 1 {
+		t.Fatalf("ScannedFiles = %d, want 1", summary.ScannedFiles)
+	}
+	if summary.CorruptedFiles != 1 || summary.QuarantinedFiles != 1 {
+		t.Fatalf("unexpected scan summary: %#v", summary)
+	}
+
+	resourceA, err := db.GetResourceByID(resourceIDA)
+	if err != nil {
+		t.Fatalf("GetResourceByID(A) failed: %v", err)
+	}
+	resourceB, err := db.GetResourceByID(resourceIDB)
+	if err != nil {
+		t.Fatalf("GetResourceByID(B) failed: %v", err)
+	}
+	if resourceA == nil || resourceB == nil || !resourceA.IsQuarantined || !resourceB.IsQuarantined {
+		t.Fatalf("all rows sharing the same file path should be quarantined")
+	}
+	if resourceA.FilePath != resourceB.FilePath {
+		t.Fatalf("shared quarantined path mismatch: %q vs %q", resourceA.FilePath, resourceB.FilePath)
+	}
+	if !strings.Contains(resourceA.FilePath, "resources/quarantine/") {
+		t.Fatalf("quarantined shared path = %q, want resources/quarantine/...", resourceA.FilePath)
+	}
+}
+
+func TestQuarantineCorruptedCSS_IsIdempotentOnRepeatedRuns(t *testing.T) {
+	dedup, db, fs := newSQLiteIntegrityTestDeduplicator(t)
+	defer db.Close()
+
+	resourceURL := fmt.Sprintf("https://integrity-test.example.com/repeat.css?nonce=%d", time.Now().UnixNano())
+	_, filePath, _ := createStoredTestResource(t, db, fs, resourceURL, "css", []byte("body { color: red; }"))
+	if err := fs.UpdateResource(filePath, []byte("body { background: url(/archive/resources/repeat.bin); }")); err != nil {
+		t.Fatalf("UpdateResource(repeat css) failed: %v", err)
+	}
+
+	first, err := dedup.QuarantineCorruptedCSS(10)
+	if err != nil {
+		t.Fatalf("first QuarantineCorruptedCSS failed: %v", err)
+	}
+	if first.QuarantinedFiles != 1 {
+		t.Fatalf("first run QuarantinedFiles = %d, want 1", first.QuarantinedFiles)
+	}
+
+	second, err := dedup.QuarantineCorruptedCSS(10)
+	if err != nil {
+		t.Fatalf("second QuarantineCorruptedCSS failed: %v", err)
+	}
+	if second.ScannedResources != 0 || second.ScannedFiles != 0 || second.CorruptedFiles != 0 || second.MissingFiles != 0 || second.QuarantinedFiles != 0 {
+		t.Fatalf("second run should be idempotent, got %#v", second)
 	}
 }
 

--- a/server/internal/storage/filesystem.go
+++ b/server/internal/storage/filesystem.go
@@ -622,6 +622,46 @@ func (fs *FileStorage) ReadResource(relPath string) ([]byte, error) {
 	return os.ReadFile(filePath)
 }
 
+func (fs *FileStorage) ResourceHash(relPath string) (string, error) {
+	filePath := filepath.Join(fs.baseDir, relPath)
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func (fs *FileStorage) CreateResourceQuarantineCopy(relPath string) (string, error) {
+	fullPath := filepath.Join(fs.baseDir, relPath)
+	if _, err := os.Stat(fullPath); err != nil {
+		return "", err
+	}
+
+	ext := filepath.Ext(relPath)
+	baseName := strings.TrimSuffix(filepath.Base(relPath), ext)
+	resourceSubdir := strings.TrimPrefix(filepath.Dir(relPath), "resources"+string(filepath.Separator))
+	quarantineRelPath := filepath.Join(
+		"resources",
+		"quarantine",
+		resourceSubdir,
+		fmt.Sprintf("%s-quarantined-%d%s", baseName, time.Now().UTC().UnixNano(), ext),
+	)
+	quarantineFullPath := filepath.Join(fs.baseDir, quarantineRelPath)
+	if err := os.MkdirAll(filepath.Dir(quarantineFullPath), 0755); err != nil {
+		return "", err
+	}
+	if err := copyFile(fullPath, quarantineFullPath); err != nil {
+		return "", err
+	}
+	return quarantineRelPath, nil
+}
+
 // DeleteHTML deletes an HTML file from disk.
 func (fs *FileStorage) DeleteHTML(relPath string) error {
 	filePath := filepath.Join(fs.baseDir, relPath)

--- a/server/internal/storage/resource_integrity.go
+++ b/server/internal/storage/resource_integrity.go
@@ -1,0 +1,73 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+)
+
+type IntegrityScanSummary struct {
+	ResourceType     string
+	ScannedResources int
+	ScannedFiles     int
+	CorruptedFiles   int
+	MissingFiles     int
+	QuarantinedFiles int
+}
+
+func (d *Deduplicator) QuarantineCorruptedResources(resourceType string, batchSize int) (*IntegrityScanSummary, error) {
+	if batchSize <= 0 {
+		batchSize = 200
+	}
+
+	summary := &IntegrityScanSummary{ResourceType: resourceType}
+	handled := make(map[string]struct{})
+	var lastID int64
+
+	for {
+		resources, err := d.db.ListResourcesForIntegrityCheck(resourceType, lastID, batchSize)
+		if err != nil {
+			return nil, err
+		}
+		if len(resources) == 0 {
+			return summary, nil
+		}
+
+		for _, resource := range resources {
+			lastID = resource.ID
+			summary.ScannedResources++
+			if resource.FilePath == "" {
+				continue
+			}
+			if _, seen := handled[resource.FilePath]; seen {
+				continue
+			}
+			handled[resource.FilePath] = struct{}{}
+			summary.ScannedFiles++
+
+			actualHash, err := d.storage.ResourceHash(resource.FilePath)
+			if err == nil && actualHash == resource.ContentHash {
+				continue
+			}
+
+			reason := "resource file missing"
+			if err == nil {
+				reason = fmt.Sprintf("hash mismatch expected=%s actual=%s", shortHashForLog(resource.ContentHash), shortHashForLog(actualHash))
+				summary.CorruptedFiles++
+			} else if os.IsNotExist(err) {
+				summary.MissingFiles++
+			} else {
+				reason = fmt.Sprintf("integrity check failed: %v", err)
+				summary.CorruptedFiles++
+			}
+
+			if quarantineErr := d.quarantineResourceFile(resource.FilePath, reason); quarantineErr != nil {
+				return nil, quarantineErr
+			}
+			summary.QuarantinedFiles++
+		}
+	}
+}
+
+func (d *Deduplicator) QuarantineCorruptedCSS(batchSize int) (*IntegrityScanSummary, error) {
+	return d.QuarantineCorruptedResources("css", batchSize)
+}


### PR DESCRIPTION
## Summary
- add an offline `--quarantine-corrupted-css` command that scans stored CSS files, quarantines corrupted or missing copies, and records the reason in resource metadata
- prevent quarantined resources from being reused by deduplication, cache revalidation, and fallback lookups while preserving old archive pages through quarantine copies
- cover mixed, shared-file, and idempotent quarantine scenarios in SQLite-backed regression tests and document the operator workflow

## Testing
- `go test -tags fts5 ./internal/storage`
- `make test`