### PR TITLE
fix: skip non-downloadable CSS resource URLs

### DIFF
--- a/server/internal/storage/css_parser.go
+++ b/server/internal/storage/css_parser.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	neturl "net/url"
 	"regexp"
 	"strings"
 )
@@ -31,7 +32,7 @@ func (p *CSSParser) ExtractResources(cssContent string) []string {
 	for _, match := range importMatches {
 		if len(match) > 1 {
 			url := strings.TrimSpace(match[1])
-			if url != "" && !seen[url] && !isDataURL(url) && !isFragmentOnlyURL(url) {
+			if !isSkippableResourceURL(url) && !seen[url] {
 				seen[url] = true
 				resources = append(resources, url)
 			}
@@ -43,7 +44,7 @@ func (p *CSSParser) ExtractResources(cssContent string) []string {
 	for _, match := range urlMatches {
 		if len(match) > 1 {
 			url := strings.TrimSpace(match[1])
-			if url != "" && !seen[url] && !isDataURL(url) && !isFragmentOnlyURL(url) {
+			if !isSkippableResourceURL(url) && !seen[url] {
 				seen[url] = true
 				resources = append(resources, url)
 			}
@@ -96,11 +97,39 @@ func (p *CSSParser) RewriteCSS(cssContent string, urlMapping map[string]string) 
 	return result
 }
 
-// isDataURL checks if a URL is a data URL (data:...)
-func isDataURL(url string) bool {
-	return strings.HasPrefix(url, "data:")
+func isSkippableResourceURL(rawURL string) bool {
+	resourceURL := strings.TrimSpace(rawURL)
+	resourceURL = strings.Trim(resourceURL, `"'`)
+	if resourceURL == "" {
+		return true
+	}
+
+	return isDataURL(resourceURL) || isFragmentOnlyURL(resourceURL) || hasUnsupportedResourceScheme(resourceURL)
 }
 
-func isFragmentOnlyURL(url string) bool {
-	return strings.HasPrefix(url, "#")
+func isDataURL(rawURL string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawURL)), "data:")
+}
+
+func isFragmentOnlyURL(rawURL string) bool {
+	resourceURL := strings.TrimSpace(rawURL)
+	resourceURL = strings.Trim(resourceURL, `"'`)
+	if strings.HasPrefix(resourceURL, "#") {
+		return true
+	}
+
+	decodedURL, err := neturl.PathUnescape(resourceURL)
+	if err != nil {
+		return false
+	}
+
+	return strings.HasPrefix(strings.TrimSpace(decodedURL), "#")
+}
+
+func hasUnsupportedResourceScheme(rawURL string) bool {
+	resourceURL := strings.ToLower(strings.TrimSpace(rawURL))
+	return strings.HasPrefix(resourceURL, "blob:") ||
+		strings.HasPrefix(resourceURL, "javascript:") ||
+		strings.HasPrefix(resourceURL, "mailto:") ||
+		strings.HasPrefix(resourceURL, "about:")
 }

--- a/server/internal/storage/css_parser_test.go
+++ b/server/internal/storage/css_parser_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestCSSParserExtractResources_SkipsFragmentOnlyURLs(t *testing.T) {
 	parser := NewCSSParser()
-	resources := parser.ExtractResources(`.mask{filter:url(#goo)} .bg{background:url("icons.svg#sprite")} @import url("theme.css")`)
+	resources := parser.ExtractResources(`.mask{filter:url(#goo)} .quoted{filter:url("#paint")} .bg{background:url("icons.svg#sprite")} @import url("theme.css")`)
 
 	for _, resource := range resources {
-		if resource == "#goo" {
+		if resource == "#goo" || resource == "#paint" {
 			t.Fatal("fragment-only CSS url() should not be extracted")
 		}
 	}
@@ -22,5 +22,51 @@ func TestCSSParserExtractResources_SkipsFragmentOnlyURLs(t *testing.T) {
 
 	if resources[0] != "icons.svg#sprite" && resources[1] != "icons.svg#sprite" {
 		t.Fatalf("expected icons.svg#sprite to be preserved, got %#v", resources)
+	}
+}
+
+func TestCSSParserExtractResources_SkipsEncodedFragmentOnlyURLs(t *testing.T) {
+	parser := NewCSSParser()
+	resources := parser.ExtractResources(`.mask{filter:url(%23clip)} .quoted{filter:url(" %23paint ")} .bg{background:url("icons.svg#sprite")} .encoded{background:url("icons.svg%23sprite")}`)
+
+	if len(resources) != 2 {
+		t.Fatalf("expected only the external SVG sprites, got %#v", resources)
+	}
+
+	foundPlainFragment := false
+	foundEncodedFragment := false
+	for _, resource := range resources {
+		switch resource {
+		case "icons.svg#sprite":
+			foundPlainFragment = true
+		case "icons.svg%23sprite":
+			foundEncodedFragment = true
+		case "%23clip", "%23paint":
+			t.Fatalf("encoded fragment-only CSS url() should not be extracted: %#v", resources)
+		}
+	}
+	if !foundPlainFragment || !foundEncodedFragment {
+		t.Fatalf("expected external SVG fragments to be preserved, got %#v", resources)
+	}
+}
+
+func TestCSSParserExtractResources_SkipsDataURLNestedFragmentReferences(t *testing.T) {
+	parser := NewCSSParser()
+	resources := parser.ExtractResources(`.icon{background-image:url("data:image/svg+xml,%3Csvg%3E%3Ccircle mask='url(%23clip)'/%3E%3C/svg%3E")}`)
+
+	if len(resources) != 0 {
+		t.Fatalf("data URL internals should not be extracted as resources, got %#v", resources)
+	}
+}
+
+func TestCSSParserExtractResources_SkipsUnsupportedSchemes(t *testing.T) {
+	parser := NewCSSParser()
+	resources := parser.ExtractResources(`.blob{background:url(BLOB:https://example.com/id)} .js{background:url(" JAVASCRIPT:noop ")} .mail{background:url(mailto:a@example.com)} .about{background:url(about:blank)} .img{background:url(/img.png)}`)
+
+	if len(resources) != 1 {
+		t.Fatalf("expected only the downloadable image URL, got %#v", resources)
+	}
+	if resources[0] != "/img.png" {
+		t.Fatalf("expected /img.png to be preserved, got %#v", resources)
 	}
 }

--- a/server/internal/storage/html_extractor.go
+++ b/server/internal/storage/html_extractor.go
@@ -191,6 +191,9 @@ func (e *HTMLResourceExtractor) ExtractResources(html string, pageURL string) []
 			rawURL = htmlpkg.UnescapeString(rawURL)
 			// 移除可能残留的引号
 			rawURL = strings.Trim(rawURL, `"'`)
+			if isSkippableResourceURL(rawURL) {
+				continue
+			}
 			fullURL := e.resolveURL(rawURL, pageURL)
 			if e.isExternalURL(fullURL) {
 				// 猜测类型
@@ -206,6 +209,9 @@ func (e *HTMLResourceExtractor) ExtractResources(html string, pageURL string) []
 		if len(match) > 1 {
 			rawURL := htmlpkg.UnescapeString(match[1])
 			rawURL = strings.Trim(rawURL, `"'`)
+			if isSkippableResourceURL(rawURL) {
+				continue
+			}
 			fullURL := e.resolveURL(rawURL, pageURL)
 			if e.isExternalURL(fullURL) {
 				resourceType := guessResourceType(fullURL)

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -231,15 +231,21 @@ func TestExtractResources_IframeCGIWithoutHTMLExtension(t *testing.T) {
 func TestExtractResources_SkipsFragmentOnlyCSSURLs(t *testing.T) {
 	extractor := NewHTMLResourceExtractor()
 
-	html := `<html><body><svg><rect style="fill:url(#paint0_linear_0_3)"></rect></svg></body></html>`
+	html := `<html><body><svg><rect style="fill:url(#paint0_linear_0_3);mask:url(%23clip)"></rect></svg></body></html>`
 	resources := extractor.ExtractResources(html, "https://example.com/page")
 
 	for _, r := range resources {
 		if r.URL == "https://example.com/page#paint0_linear_0_3" {
 			t.Fatalf("should not extract same-document fragment URL, got %q", r.URL)
 		}
+		if r.URL == "https://example.com/%23clip" || r.URL == "https://example.com/page%23clip" {
+			t.Fatalf("should not extract encoded same-document fragment URL, got %q", r.URL)
+		}
 		if r.URL == "#paint0_linear_0_3" {
 			t.Fatalf("should not extract raw fragment URL, got %q", r.URL)
+		}
+		if r.URL == "%23clip" {
+			t.Fatalf("should not extract raw encoded fragment URL, got %q", r.URL)
 		}
 	}
 }
@@ -263,20 +269,52 @@ func TestExtractResources_SkipsFragmentOnlyQuotedCSSURLs(t *testing.T) {
 func TestExtractResources_PreservesAssetURLsWithFragments(t *testing.T) {
 	extractor := NewHTMLResourceExtractor()
 
-	html := `<html><body><div style="mask:url(icons.svg#sprite)"></div></body></html>`
+	html := `<html><body><div style="mask:url(icons.svg#sprite);clip-path:url(icons.svg%23encoded-sprite)"></div></body></html>`
 	resources := extractor.ExtractResources(html, "https://example.com/assets/page")
 
-	found := false
+	foundPlainFragment := false
+	foundEncodedFragment := false
 	for _, r := range resources {
-		if r.URL == "https://example.com/assets/icons.svg#sprite" {
-			found = true
+		switch r.URL {
+		case "https://example.com/assets/icons.svg#sprite":
+			foundPlainFragment = true
 			if r.Type != "image" {
 				t.Fatalf("asset URL with fragment type = %q, want image", r.Type)
+			}
+		case "https://example.com/assets/icons.svg%23encoded-sprite":
+			foundEncodedFragment = true
+			if r.Type != "image" {
+				t.Fatalf("asset URL with encoded fragment type = %q, want image", r.Type)
 			}
 		}
 	}
 
-	if !found {
-		t.Fatal("should preserve asset URL with fragment suffix")
+	if !foundPlainFragment || !foundEncodedFragment {
+		t.Fatalf("should preserve asset URL with fragment suffix, got %#v", resources)
+	}
+}
+
+func TestExtractResources_SkipsDataURLNestedFragmentReferences(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body><div style="background-image:url(&quot;data:image/svg+xml,%3Csvg%3E%3Ccircle mask='url(%23clip)'/%3E%3C/svg%3E&quot;)"></div></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	if len(resources) != 0 {
+		t.Fatalf("data URL internals should not be extracted as resources, got %#v", resources)
+	}
+}
+
+func TestExtractResources_SkipsUnsupportedCSSURLSchemes(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body><div style="background:url(BLOB:https://example.com/id);border-image:url(&quot; JAVASCRIPT:noop &quot;);mask:url(about:blank);list-style:url(mailto:a@example.com);background-image:url(/img.png)"></div></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	if len(resources) != 1 {
+		t.Fatalf("expected only the downloadable image URL, got %#v", resources)
+	}
+	if resources[0].URL != "https://example.com/img.png" {
+		t.Fatalf("expected /img.png to be preserved, got %#v", resources)
 	}
 }


### PR DESCRIPTION
## Summary
- Skip fragment-only CSS URLs even when encoded as `%23...` so SVG internals are not downloaded as external resources.
- Filter unsupported CSS resource schemes such as `blob:`, `javascript:`, `mailto:`, and `about:` before HTML/CSS resource processing.
- Add regression coverage for encoded fragments, data URL internals, unsupported schemes, and external SVG fragment resources.

## Tests
- `go test ./internal/storage -run 'TestCSSParserExtractResources|TestExtractResources_Skips|TestExtractResources_PreservesAssetURLsWithFragments'`
- `make test`
- `make test-e2e`