### PR TITLE
fix: skip CSS resource URLs with malformed hostnames

### DIFF
--- a/server/internal/storage/css_parser.go
+++ b/server/internal/storage/css_parser.go
@@ -104,7 +104,10 @@ func isSkippableResourceURL(rawURL string) bool {
 		return true
 	}
 
-	return isDataURL(resourceURL) || isFragmentOnlyURL(resourceURL) || hasUnsupportedResourceScheme(resourceURL)
+	return isDataURL(resourceURL) ||
+		isFragmentOnlyURL(resourceURL) ||
+		hasUnsupportedResourceScheme(resourceURL) ||
+		hasMalformedAbsoluteHost(resourceURL)
 }
 
 func isDataURL(rawURL string) bool {
@@ -132,4 +135,41 @@ func hasUnsupportedResourceScheme(rawURL string) bool {
 		strings.HasPrefix(resourceURL, "javascript:") ||
 		strings.HasPrefix(resourceURL, "mailto:") ||
 		strings.HasPrefix(resourceURL, "about:")
+}
+
+// hasMalformedAbsoluteHost rejects absolute http(s) URLs whose hostname
+// contains characters that can never appear in a valid DNS name. Some
+// upstream CSS files ship typos like https://www&google.com/... which would
+// otherwise fail DNS lookup and spam the log on every page that uses them.
+func hasMalformedAbsoluteHost(rawURL string) bool {
+	resourceURL := strings.TrimSpace(rawURL)
+	resourceURL = strings.Trim(resourceURL, `"'`)
+	lower := strings.ToLower(resourceURL)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return false
+	}
+
+	parsed, err := neturl.Parse(resourceURL)
+	if err != nil {
+		return true
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return true
+	}
+	for _, r := range host {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '.', r == '_', r == ':':
+			continue
+		default:
+			if r > 0x7f {
+				continue
+			}
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/storage/css_parser_test.go
+++ b/server/internal/storage/css_parser_test.go
@@ -1,6 +1,9 @@
 package storage
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestCSSParserExtractResources_SkipsFragmentOnlyURLs(t *testing.T) {
 	parser := NewCSSParser()
@@ -68,5 +71,20 @@ func TestCSSParserExtractResources_SkipsUnsupportedSchemes(t *testing.T) {
 	}
 	if resources[0] != "/img.png" {
 		t.Fatalf("expected /img.png to be preserved, got %#v", resources)
+	}
+}
+
+func TestCSSParserExtractResources_SkipsMalformedAbsoluteHosts(t *testing.T) {
+	parser := NewCSSParser()
+	// Mirrors a real typo in Google translate CSS: https://www&google.com/...
+	resources := parser.ExtractResources(`.bad{background-image:url(https://www&google.com/images/zippy_minus_sm.gif)} .ok{background-image:url(https://www.google.com/images/zippy_plus_sm.gif)} .rel{background-image:url(/img.png)}`)
+
+	for _, r := range resources {
+		if strings.Contains(r, "www&google.com") {
+			t.Fatalf("malformed absolute host should be skipped, got %q", r)
+		}
+	}
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 valid resources, got %#v", resources)
 	}
 }

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -318,3 +318,17 @@ func TestExtractResources_SkipsUnsupportedCSSURLSchemes(t *testing.T) {
 		t.Fatalf("expected /img.png to be preserved, got %#v", resources)
 	}
 }
+
+func TestExtractResources_SkipsMalformedAbsoluteHostInCSSURL(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	// Mirrors a real typo Google ships in their translate CSS.
+	html := `<html><body><div style="background-image:url(https://www&google.com/images/zippy_minus_sm.gif)"></div></body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	for _, r := range resources {
+		if r.URL == "https://www&google.com/images/zippy_minus_sm.gif" {
+			t.Fatalf("malformed absolute host should be skipped, got %q", r.URL)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Google Translate CSS ships a typo (`url(https://www&google.com/images/zippy_minus_sm.gif)`) that causes repeated DNS lookup failures and log spam on every page using Google Translate
- Add `hasMalformedAbsoluteHost` check to `isSkippableResourceURL`: rejects absolute http(s) URLs whose hostname contains characters invalid for DNS (e.g. `&`, `!`, `=`)
- Allows non-ASCII (IDN) and relative URLs through unaffected

## Test plan
- [x] `make test` — all pass
- [x] `make build` — clean
- [x] New unit tests in `css_parser_test.go` and `html_extractor_test.go` cover the `www&google.com` pattern

🤖 Generated with [Claude Code](https://claude.ai/code)