### PR TITLE
fix: parse srcset per HTML spec to preserve commas in URLs

### DIFF
--- a/server/internal/storage/html_extractor.go
+++ b/server/internal/storage/html_extractor.go
@@ -316,15 +316,84 @@ func guessResourceType(fullURL string) string {
 	return "other"
 }
 
-// parseSrcset 解析 srcset 属性值，返回 URL 列表
+// parseSrcset parses a srcset attribute value per the HTML spec algorithm.
+// URLs are sequences of non-whitespace characters; commas inside a URL
+// (e.g. OSS query params like ?x-oss-process=image/format,webp) are kept
+// intact because the spec only treats commas as separators when preceded by
+// whitespace or a descriptor.
 func parseSrcset(srcset string) []string {
-	var urls []string
-	parts := strings.Split(srcset, ",")
-	for _, part := range parts {
-		fields := strings.Fields(strings.TrimSpace(part))
-		if len(fields) > 0 && fields[0] != "" {
-			urls = append(urls, fields[0])
-		}
+	candidates := parseSrcsetCandidates(srcset)
+	urls := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		urls = append(urls, c.url)
 	}
 	return urls
+}
+
+type srcsetCandidate struct {
+	url        string
+	descriptor string
+}
+
+func parseSrcsetCandidates(srcset string) []srcsetCandidate {
+	var candidates []srcsetCandidate
+	input := srcset
+	i := 0
+	n := len(input)
+
+	for i < n {
+		// Step 1: skip ASCII whitespace and commas (separators between candidates)
+		for i < n && (input[i] == ' ' || input[i] == '\t' || input[i] == '\n' ||
+			input[i] == '\r' || input[i] == '\f' || input[i] == ',') {
+			i++
+		}
+		if i >= n {
+			break
+		}
+
+		// Step 2: collect non-whitespace characters → URL
+		start := i
+		for i < n && input[i] != ' ' && input[i] != '\t' && input[i] != '\n' &&
+			input[i] != '\r' && input[i] != '\f' {
+			i++
+		}
+		rawURL := input[start:i]
+		if rawURL == "" {
+			continue
+		}
+		// Strip trailing commas that act as candidate separators
+		rawURL = strings.TrimRight(rawURL, ",")
+		if rawURL == "" {
+			continue
+		}
+
+		// Step 3: skip whitespace after URL
+		for i < n && (input[i] == ' ' || input[i] == '\t' || input[i] == '\n' ||
+			input[i] == '\r' || input[i] == '\f') {
+			i++
+		}
+
+		// Step 4: collect descriptor (e.g. "200w", "2x") until comma or end
+		descStart := i
+		for i < n && input[i] != ',' {
+			i++
+		}
+		desc := strings.TrimSpace(input[descStart:i])
+
+		candidates = append(candidates, srcsetCandidate{url: rawURL, descriptor: desc})
+	}
+
+	return candidates
+}
+
+func joinSrcsetCandidates(candidates []srcsetCandidate) string {
+	var parts []string
+	for _, c := range candidates {
+		if c.descriptor != "" {
+			parts = append(parts, c.url+" "+c.descriptor)
+		} else {
+			parts = append(parts, c.url)
+		}
+	}
+	return strings.Join(parts, ", ")
 }

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -280,3 +280,61 @@ func TestExtractResources_PreservesAssetURLsWithFragments(t *testing.T) {
 		t.Fatal("should preserve asset URL with fragment suffix")
 	}
 }
+
+func TestParseSrcset(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "standard srcset with width descriptors",
+			input:    "image-300.png 300w, image-600.png 600w, image-1200.png 1200w",
+			expected: []string{"image-300.png", "image-600.png", "image-1200.png"},
+		},
+		{
+			name:     "standard srcset with density descriptors",
+			input:    "image.png 1x, image@2x.png 2x",
+			expected: []string{"image.png", "image@2x.png"},
+		},
+		{
+			name:     "URL with commas in query params (OSS image processing)",
+			input:    "https://www.okx.com/cdn/icon/btc.png?x-oss-process=image/format,webp/resize,w_200,h_200,type_6/ignore-error,1",
+			expected: []string{"https://www.okx.com/cdn/icon/btc.png?x-oss-process=image/format,webp/resize,w_200,h_200,type_6/ignore-error,1"},
+		},
+		{
+			name:     "single URL without descriptor",
+			input:    "https://example.com/image.png",
+			expected: []string{"https://example.com/image.png"},
+		},
+		{
+			name:     "empty srcset",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			expected: nil,
+		},
+		{
+			name:     "URLs with descriptors and query params containing commas",
+			input:    "https://cdn.example.com/img.png?process=format,webp 300w, https://cdn.example.com/img2.png?process=format,webp 600w",
+			expected: []string{"https://cdn.example.com/img.png?process=format,webp", "https://cdn.example.com/img2.png?process=format,webp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSrcset(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected %d URLs, got %d: %v", len(tt.expected), len(result), result)
+			}
+			for i, url := range result {
+				if url != tt.expected[i] {
+					t.Errorf("URL[%d]: expected %q, got %q", i, tt.expected[i], url)
+				}
+			}
+		})
+	}
+}

--- a/server/internal/storage/rewriter_fast.go
+++ b/server/internal/storage/rewriter_fast.go
@@ -103,7 +103,7 @@ func ResolveRelativeURLs(html, baseURL string) string {
 		return `url("` + resolved + `")`
 	})
 
-	// 4. srcset 中的相对路径（多值，逗号分隔）
+	// 4. srcset 中的相对路径（使用规范解析，正确处理 URL 中的逗号）
 	html = resolveSrcsetRe.ReplaceAllStringFunc(html, func(match string) string {
 		sub := resolveSrcsetRe.FindStringSubmatch(match)
 		if len(sub) < 3 {
@@ -111,22 +111,17 @@ func ResolveRelativeURLs(html, baseURL string) string {
 		}
 		attr, value := sub[1], sub[2]
 		changed := false
-		parts := strings.Split(value, ",")
-		for i, part := range parts {
-			fields := strings.Fields(strings.TrimSpace(part))
-			if len(fields) == 0 {
-				continue
-			}
-			if resolved := resolve(fields[0]); resolved != "" {
-				fields[0] = resolved
-				parts[i] = " " + strings.Join(fields, " ")
+		candidates := parseSrcsetCandidates(value)
+		for i, c := range candidates {
+			if resolved := resolve(c.url); resolved != "" {
+				candidates[i].url = resolved
 				changed = true
 			}
 		}
 		if !changed {
 			return match
 		}
-		return attr + `="` + strings.TrimLeft(strings.Join(parts, ","), " ") + `"`
+		return attr + `="` + joinSrcsetCandidates(candidates) + `"`
 	})
 
 	return html


### PR DESCRIPTION
## Summary
- 按 HTML 规范重写 `parseSrcset`，URL 以非空白字符序列为边界，逗号只有在空白分隔后才是候选项分隔符
- 修复 `ResolveRelativeURLs` 中相同的逗号分割问题，避免 URL 片段被错误 resolve 为相对路径
- 解决阿里云 OSS 图片处理 URL（如 `?x-oss-process=image/format,webp/resize,w_200`）被截断导致下载 400 的问题

## Test plan
- [x] `TestParseSrcset` 覆盖标准 srcset、含逗号的 OSS URL、空值等场景
- [x] 现有 rewriter 测试全部通过
- [x] `make build` 编译通过

🤖 Generated with [Claude Code](https://claude.ai/code)