### PR TITLE
fix: spec-compliant srcset parsing in browser normalizer

### DIFF
--- a/browser/src/html-url-normalizer.ts
+++ b/browser/src/html-url-normalizer.ts
@@ -24,18 +24,55 @@ function toAbsoluteURL(value: string, baseURL: string): string {
   }
 }
 
-function normalizeSrcset(value: string, baseURL: string): string {
-  return value
-    .split(',')
-    .map((part) => {
-      const trimmed = part.trim();
-      if (!trimmed) {
-        return part;
-      }
+// Parse srcset per HTML spec: URLs are non-whitespace sequences, so commas
+// without surrounding whitespace are part of the URL (e.g. OSS query params).
+function parseSrcsetCandidates(srcset: string): Array<{ url: string; descriptor: string }> {
+  const candidates: Array<{ url: string; descriptor: string }> = [];
+  let i = 0;
+  const n = srcset.length;
 
-      const fields = trimmed.split(/\s+/);
-      fields[0] = toAbsoluteURL(fields[0], baseURL);
-      return fields.join(' ');
+  while (i < n) {
+    // Skip whitespace and commas (separators)
+    while (i < n && (srcset[i] === ' ' || srcset[i] === '\t' || srcset[i] === '\n' ||
+      srcset[i] === '\r' || srcset[i] === '\f' || srcset[i] === ',')) {
+      i++;
+    }
+    if (i >= n) break;
+
+    // Collect non-whitespace → URL
+    const start = i;
+    while (i < n && srcset[i] !== ' ' && srcset[i] !== '\t' && srcset[i] !== '\n' &&
+      srcset[i] !== '\r' && srcset[i] !== '\f') {
+      i++;
+    }
+    let url = srcset.slice(start, i).replace(/,+$/, '');
+    if (!url) continue;
+
+    // Skip whitespace after URL
+    while (i < n && (srcset[i] === ' ' || srcset[i] === '\t' || srcset[i] === '\n' ||
+      srcset[i] === '\r' || srcset[i] === '\f')) {
+      i++;
+    }
+
+    // Collect descriptor until comma or end
+    const descStart = i;
+    while (i < n && srcset[i] !== ',') {
+      i++;
+    }
+    const descriptor = srcset.slice(descStart, i).trim();
+
+    candidates.push({ url, descriptor });
+  }
+
+  return candidates;
+}
+
+function normalizeSrcset(value: string, baseURL: string): string {
+  const candidates = parseSrcsetCandidates(value);
+  return candidates
+    .map((c) => {
+      const absoluteURL = toAbsoluteURL(c.url, baseURL);
+      return c.descriptor ? `${absoluteURL} ${c.descriptor}` : absoluteURL;
     })
     .join(', ');
 }


### PR DESCRIPTION
## Summary
- 浏览器端 `normalizeSrcset` 按逗号分割 srcset，破坏了 URL 中包含逗号的查询参数（如阿里云 OSS `?x-oss-process=image/format,webp/resize,w_200`）
- 按 HTML 规范重写：URL 是连续的非空白字符序列，逗号只有在空白分隔后才是候选项分隔符
- 这是 #117 中 400 错误的真正根源 — 浏览器端在发送 HTML 给服务端之前就已截断 URL

## Test plan
- [x] `make build` 编译通过（TypeScript + Go）
- [x] 服务端测试全部通过

🤖 Generated with [Claude Code](https://claude.ai/code)