### PR TITLE
fix: skip unrendered template literal URLs in resource extraction

### DIFF
--- a/server/internal/storage/css_parser.go
+++ b/server/internal/storage/css_parser.go
@@ -107,7 +107,18 @@ func isSkippableResourceURL(rawURL string) bool {
 	return isDataURL(resourceURL) ||
 		isFragmentOnlyURL(resourceURL) ||
 		hasUnsupportedResourceScheme(resourceURL) ||
-		hasMalformedAbsoluteHost(resourceURL)
+		hasMalformedAbsoluteHost(resourceURL) ||
+		isTemplateLiteral(resourceURL)
+}
+
+// isTemplateLiteral detects unrendered template expressions in URLs.
+// e.g. ${escapeHtml(imgBannerUrl)} or {{variable}} — either raw or percent-encoded.
+func isTemplateLiteral(rawURL string) bool {
+	decoded, err := neturl.PathUnescape(rawURL)
+	if err != nil {
+		decoded = rawURL
+	}
+	return strings.Contains(decoded, "${") || strings.Contains(decoded, "{{")
 }
 
 func isDataURL(rawURL string) bool {

--- a/server/internal/storage/html_extractor.go
+++ b/server/internal/storage/html_extractor.go
@@ -231,19 +231,24 @@ func (e *HTMLResourceExtractor) ExtractResources(html string, pageURL string) []
 }
 
 // isExternalURL 判断是否是外部 URL
-func (e *HTMLResourceExtractor) isExternalURL(url string) bool {
+func (e *HTMLResourceExtractor) isExternalURL(rawURL string) bool {
 	// 跳过 data: URLs
-	if strings.HasPrefix(url, "data:") {
+	if strings.HasPrefix(rawURL, "data:") {
 		return false
 	}
 
 	// 跳过相对路径（这些应该由浏览器端处理）
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
 		return false
 	}
 
 	// 跳过本地 URL
-	if strings.Contains(url, "localhost") || strings.Contains(url, "127.0.0.1") {
+	if strings.Contains(rawURL, "localhost") || strings.Contains(rawURL, "127.0.0.1") {
+		return false
+	}
+
+	// 跳过未渲染的模板表达式
+	if isTemplateLiteral(rawURL) {
 		return false
 	}
 

--- a/server/internal/storage/html_extractor_test.go
+++ b/server/internal/storage/html_extractor_test.go
@@ -333,6 +333,25 @@ func TestExtractResources_SkipsMalformedAbsoluteHostInCSSURL(t *testing.T) {
 	}
 }
 
+func TestExtractResources_SkipsTemplateLiterals(t *testing.T) {
+	extractor := NewHTMLResourceExtractor()
+
+	html := `<html><body>
+		<img src="https://v2ex.com/$%7BescapeHtml%28imgBannerUrl%29%7D">
+		<img src="https://example.com/${variable}">
+		<img src="https://example.com/{{placeholder}}">
+		<img src="https://example.com/real-image.png">
+	</body></html>`
+	resources := extractor.ExtractResources(html, "https://example.com/page")
+
+	if len(resources) != 1 {
+		t.Fatalf("expected only the real image, got %d: %#v", len(resources), resources)
+	}
+	if resources[0].URL != "https://example.com/real-image.png" {
+		t.Fatalf("expected real-image.png, got %q", resources[0].URL)
+	}
+}
+
 func TestParseSrcset(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- 过滤包含未渲染模板表达式（`${...}` 或 `{{...}}`）的资源 URL，避免无意义的 404 下载
- 同时处理 raw 和 percent-encoded 形式（如 `$%7B...%7D`）
- 在 `isExternalURL` 和 `isSkippableResourceURL` 两个入口都添加了检测

## 触发场景
v2ex.com 页面 HTML 中包含未执行的模板字面量：
```
https://v2ex.com/$%7BescapeHtml%28imgBannerUrl%29%7D
```
解码后为 `https://v2ex.com/${escapeHtml(imgBannerUrl)}`，显然不是真实资源。

## Test plan
- [x] 新增单元测试 `TestExtractResources_SkipsTemplateLiterals`
- [x] `make test` 全部通过