### PR TITLE
Fix search LIKE wildcard escaping

### DIFF
--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -570,8 +570,8 @@ func (db *PostgresDB) GetPageByID(id string) (*models.Page, error) {
 // SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
 func (db *PostgresDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
 	likeOp := db.qb.CaseInsensitiveLike()
-	query := fmt.Sprintf("SELECT %s FROM pages WHERE (url %s $1 OR title %s $1 OR body_text %s $1)", pageSelectColumns, likeOp, likeOp, likeOp)
-	args := []interface{}{"%" + keyword + "%"}
+	query := fmt.Sprintf("SELECT %s FROM pages WHERE (url %s $1 ESCAPE '\\' OR title %s $1 ESCAPE '\\' OR body_text %s $1 ESCAPE '\\')", pageSelectColumns, likeOp, likeOp, likeOp)
+	args := []interface{}{"%" + escapeLikePattern(keyword) + "%"}
 	argIndex := 2
 
 	// 追加时间过滤条件

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -278,6 +278,62 @@ func TestGetPagesByURL_NoResults(t *testing.T) {
 	}
 }
 
+func TestPostgresSearchPages_EscapesLikeWildcards(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	domain := "search-escape-" + suffix + ".example.com"
+	now := time.Now()
+
+	exactID, err := db.CreatePage("https://"+domain+"/exact", "Literal Token", "html/test/exact.html", strings.Repeat("a", 64), now)
+	if err != nil {
+		t.Fatalf("CreatePage(exact) failed: %v", err)
+	}
+	defer db.DeletePage(exactID)
+	if err := db.UpdatePageBodyText(exactID, "literal on_fail marker and progress 100% done"); err != nil {
+		t.Fatalf("UpdatePageBodyText(exact) failed: %v", err)
+	}
+
+	hyphenID, err := db.CreatePage("https://"+domain+"/hyphen", "Hyphen Token", "html/test/hyphen.html", strings.Repeat("b", 64), now)
+	if err != nil {
+		t.Fatalf("CreatePage(hyphen) failed: %v", err)
+	}
+	defer db.DeletePage(hyphenID)
+	if err := db.UpdatePageBodyText(hyphenID, "ctest --output-on-failure"); err != nil {
+		t.Fatalf("UpdatePageBodyText(hyphen) failed: %v", err)
+	}
+
+	percentID, err := db.CreatePage("https://"+domain+"/percent", "Percent Token", "html/test/percent.html", strings.Repeat("c", 64), now)
+	if err != nil {
+		t.Fatalf("CreatePage(percent) failed: %v", err)
+	}
+	defer db.DeletePage(percentID)
+	if err := db.UpdatePageBodyText(percentID, "progress 100x done"); err != nil {
+		t.Fatalf("UpdatePageBodyText(percent) failed: %v", err)
+	}
+
+	tests := []struct {
+		keyword string
+		wantID  int64
+	}{
+		{keyword: "on_fail", wantID: exactID},
+		{keyword: "100%", wantID: exactID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.keyword, func(t *testing.T) {
+			pages, err := db.SearchPages(tt.keyword, nil, nil, domain)
+			if err != nil {
+				t.Fatalf("SearchPages(%q) failed: %v", tt.keyword, err)
+			}
+			if len(pages) != 1 || pages[0].ID != tt.wantID {
+				t.Fatalf("SearchPages(%q) returned %+v, want only page %d", tt.keyword, pages, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestGetResourceByURLPath_EscapesPercentWildcards(t *testing.T) {
 	db := skipIfNoDB(t)
 	defer db.Close()

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -681,11 +681,11 @@ func (db *SQLiteDB) GetPageByID(id string) (*models.Page, error) {
 // SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
 func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
 	query := `SELECT ` + pageSelectColumns + ` FROM pages WHERE (` +
-		`LOWER(COALESCE(url, '')) LIKE LOWER(?) OR ` +
-		`LOWER(COALESCE(title, '')) LIKE LOWER(?) OR ` +
-		`LOWER(COALESCE(body_text, '')) LIKE LOWER(?)` +
+		`LOWER(COALESCE(url, '')) LIKE LOWER(?) ESCAPE '\' OR ` +
+		`LOWER(COALESCE(title, '')) LIKE LOWER(?) ESCAPE '\' OR ` +
+		`LOWER(COALESCE(body_text, '')) LIKE LOWER(?) ESCAPE '\'` +
 		`)`
-	pattern := "%" + keyword + "%"
+	pattern := "%" + escapeLikePattern(keyword) + "%"
 	args := []interface{}{pattern, pattern, pattern}
 
 	// 追加时间过滤条件

--- a/server/internal/database/sqlite_test.go
+++ b/server/internal/database/sqlite_test.go
@@ -84,6 +84,56 @@ func TestSQLiteSearchPages_MatchesURLTitleAndBodyText(t *testing.T) {
 	}
 }
 
+func TestSQLiteSearchPages_EscapesLikeWildcards(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	domain := "search-escape.example.com"
+	exactID, err := db.CreatePage("https://"+domain+"/exact", "Literal Token", "html/test/exact.html", "hash-exact", now)
+	if err != nil {
+		t.Fatalf("CreatePage(exact) failed: %v", err)
+	}
+	if err := db.UpdatePageBodyText(exactID, "literal on_fail marker and progress 100% done"); err != nil {
+		t.Fatalf("UpdatePageBodyText(exact) failed: %v", err)
+	}
+
+	hyphenID, err := db.CreatePage("https://"+domain+"/hyphen", "Hyphen Token", "html/test/hyphen.html", "hash-hyphen", now)
+	if err != nil {
+		t.Fatalf("CreatePage(hyphen) failed: %v", err)
+	}
+	if err := db.UpdatePageBodyText(hyphenID, "ctest --output-on-failure"); err != nil {
+		t.Fatalf("UpdatePageBodyText(hyphen) failed: %v", err)
+	}
+
+	percentID, err := db.CreatePage("https://"+domain+"/percent", "Percent Token", "html/test/percent.html", "hash-percent", now)
+	if err != nil {
+		t.Fatalf("CreatePage(percent) failed: %v", err)
+	}
+	if err := db.UpdatePageBodyText(percentID, "progress 100x done"); err != nil {
+		t.Fatalf("UpdatePageBodyText(percent) failed: %v", err)
+	}
+
+	tests := []struct {
+		keyword string
+		wantID  int64
+	}{
+		{keyword: "on_fail", wantID: exactID},
+		{keyword: "100%", wantID: exactID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.keyword, func(t *testing.T) {
+			pages, err := db.SearchPages(tt.keyword, nil, nil, domain)
+			if err != nil {
+				t.Fatalf("SearchPages(%q) failed: %v", tt.keyword, err)
+			}
+			if len(pages) != 1 || pages[0].ID != tt.wantID {
+				t.Fatalf("SearchPages(%q) returned %+v, want only page %d", tt.keyword, pages, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestSQLiteReplacePageSnapshotWithBodyText(t *testing.T) {
 	db := newSQLiteTestDB(t)
 


### PR DESCRIPTION
## Summary
- Escape SQL LIKE wildcards in SQLite and PostgreSQL page search queries
- Preserve literal `_` and `%` matching semantics for URL/title/body_text search
- Add regression coverage for `on_fail` vs `on-failure` and `100%` vs `100x`

## Tests
- `go test -tags fts5 ./...`