### PR TITLE
Highlight search result matches

### DIFF
--- a/server/internal/database/common.go
+++ b/server/internal/database/common.go
@@ -10,6 +10,8 @@ import (
 // pageSelectColumns 定义查询页面时的标准列列表
 const pageSelectColumns = "id, url, title, captured_at, html_path, content_hash, snapshot_state, first_visited, last_visited"
 
+const pageSearchSelectColumns = pageSelectColumns + ", COALESCE(body_text, '')"
+
 const resourceSelectColumns = "id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen, is_quarantined, quarantine_reason"
 
 // pageScanner 定义可以扫描数据库行的接口
@@ -24,6 +26,10 @@ type resourceScanner interface {
 // scanPage 从数据库行扫描页面数据到 Page 结构体
 func scanPage(scanner pageScanner, page *models.Page) error {
 	return scanner.Scan(&page.ID, &page.URL, &page.Title, &page.CapturedAt, &page.HTMLPath, &page.ContentHash, &page.SnapshotState, &page.FirstVisited, &page.LastVisited)
+}
+
+func scanSearchPage(scanner pageScanner, page *models.Page, bodyText *string) error {
+	return scanner.Scan(&page.ID, &page.URL, &page.Title, &page.CapturedAt, &page.HTMLPath, &page.ContentHash, &page.SnapshotState, &page.FirstVisited, &page.LastVisited, bodyText)
 }
 
 func scanResource(scanner resourceScanner, resource *models.Resource) error {

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -570,7 +570,7 @@ func (db *PostgresDB) GetPageByID(id string) (*models.Page, error) {
 // SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
 func (db *PostgresDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
 	likeOp := db.qb.CaseInsensitiveLike()
-	query := fmt.Sprintf("SELECT %s FROM pages WHERE (url %s $1 ESCAPE '\\' OR title %s $1 ESCAPE '\\' OR body_text %s $1 ESCAPE '\\')", pageSelectColumns, likeOp, likeOp, likeOp)
+	query := fmt.Sprintf("SELECT %s FROM pages WHERE (url %s $1 ESCAPE '\\' OR title %s $1 ESCAPE '\\' OR body_text %s $1 ESCAPE '\\')", pageSearchSelectColumns, likeOp, likeOp, likeOp)
 	args := []interface{}{"%" + escapeLikePattern(keyword) + "%"}
 	argIndex := 2
 
@@ -604,9 +604,11 @@ func (db *PostgresDB) SearchPages(keyword string, from, to *time.Time, domain st
 	pages := []models.Page{}
 	for rows.Next() {
 		var p models.Page
-		if err := scanPage(rows, &p); err != nil {
+		var bodyText string
+		if err := scanSearchPage(rows, &p, &bodyText); err != nil {
 			return nil, err
 		}
+		applySearchHighlights(&p, keyword, bodyText)
 		pages = append(pages, p)
 	}
 	return pages, nil

--- a/server/internal/database/search_highlight.go
+++ b/server/internal/database/search_highlight.go
@@ -1,0 +1,136 @@
+package database
+
+import (
+	"html"
+	"strings"
+
+	"wayback/internal/models"
+)
+
+const searchSnippetContextRunes = 80
+
+func applySearchHighlights(page *models.Page, keyword, bodyText string) {
+	page.HighlightedURL = highlightSearchTerm(page.URL, keyword)
+	page.HighlightedTitle = highlightSearchTerm(page.Title, keyword)
+	page.SearchSnippet = buildSearchSnippet(bodyText, keyword, searchSnippetContextRunes)
+}
+
+func buildSearchSnippet(text, keyword string, contextRunes int) string {
+	ranges := findFoldRanges(text, keyword)
+	if len(ranges) == 0 {
+		return ""
+	}
+
+	textRunes := []rune(text)
+	first := ranges[0]
+	start := first.start - contextRunes
+	if start < 0 {
+		start = 0
+	}
+	end := first.end + contextRunes
+	if end > len(textRunes) {
+		end = len(textRunes)
+	}
+
+	snippetRunes := textRunes[start:end]
+	snippetRanges := make([]searchRange, 0, len(ranges))
+	for _, r := range ranges {
+		if r.end <= start {
+			continue
+		}
+		if r.start >= end {
+			break
+		}
+		snippetRanges = append(snippetRanges, searchRange{
+			start: maxInt(r.start-start, 0),
+			end:   minInt(r.end-start, len(snippetRunes)),
+		})
+	}
+
+	var b strings.Builder
+	if start > 0 {
+		b.WriteString("...")
+	}
+	b.WriteString(highlightRunes(snippetRunes, snippetRanges))
+	if end < len(textRunes) {
+		b.WriteString("...")
+	}
+	return b.String()
+}
+
+func highlightSearchTerm(text, keyword string) string {
+	ranges := findFoldRanges(text, keyword)
+	if len(ranges) == 0 {
+		return ""
+	}
+	return highlightRunes([]rune(text), ranges)
+}
+
+type searchRange struct {
+	start int
+	end   int
+}
+
+func findFoldRanges(text, keyword string) []searchRange {
+	textRunes := []rune(text)
+	keywordRunes := []rune(keyword)
+	if len(keywordRunes) == 0 || len(keywordRunes) > len(textRunes) {
+		return nil
+	}
+
+	ranges := []searchRange{}
+	for i := 0; i <= len(textRunes)-len(keywordRunes); i++ {
+		if runesEqualFold(textRunes[i:i+len(keywordRunes)], keywordRunes) {
+			ranges = append(ranges, searchRange{start: i, end: i + len(keywordRunes)})
+			i += len(keywordRunes) - 1
+		}
+	}
+	return ranges
+}
+
+func runesEqualFold(a, b []rune) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !strings.EqualFold(string(a[i]), string(b[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+func highlightRunes(textRunes []rune, ranges []searchRange) string {
+	if len(ranges) == 0 {
+		return html.EscapeString(string(textRunes))
+	}
+
+	var b strings.Builder
+	cursor := 0
+	for _, r := range ranges {
+		if r.start < cursor || r.start > len(textRunes) || r.end > len(textRunes) || r.start >= r.end {
+			continue
+		}
+		b.WriteString(html.EscapeString(string(textRunes[cursor:r.start])))
+		b.WriteString("<mark>")
+		b.WriteString(html.EscapeString(string(textRunes[r.start:r.end])))
+		b.WriteString("</mark>")
+		cursor = r.end
+	}
+	b.WriteString(html.EscapeString(string(textRunes[cursor:])))
+	return b.String()
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -680,7 +680,7 @@ func (db *SQLiteDB) GetPageByID(id string) (*models.Page, error) {
 
 // SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
 func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
-	query := `SELECT ` + pageSelectColumns + ` FROM pages WHERE (` +
+	query := `SELECT ` + pageSearchSelectColumns + ` FROM pages WHERE (` +
 		`LOWER(COALESCE(url, '')) LIKE LOWER(?) ESCAPE '\' OR ` +
 		`LOWER(COALESCE(title, '')) LIKE LOWER(?) ESCAPE '\' OR ` +
 		`LOWER(COALESCE(body_text, '')) LIKE LOWER(?) ESCAPE '\'` +
@@ -715,9 +715,11 @@ func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain stri
 	pages := []models.Page{}
 	for rows.Next() {
 		var p models.Page
-		if err := scanPage(rows, &p); err != nil {
+		var bodyText string
+		if err := scanSearchPage(rows, &p, &bodyText); err != nil {
 			return nil, err
 		}
+		applySearchHighlights(&p, keyword, bodyText)
 		pages = append(pages, p)
 	}
 	return pages, nil

--- a/server/internal/database/sqlite_test.go
+++ b/server/internal/database/sqlite_test.go
@@ -84,6 +84,47 @@ func TestSQLiteSearchPages_MatchesURLTitleAndBodyText(t *testing.T) {
 	}
 }
 
+func TestSQLiteSearchPages_ReturnsEscapedHighlights(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	pageID, err := db.CreatePage("https://snippet.example.com/archive/Needle", "Needle <Title>", "html/test/highlight.html", "hash-highlight", now)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	if err := db.UpdatePageBodyText(pageID, "prefix unsafe <script>alert(1)</script> body Needle suffix"); err != nil {
+		t.Fatalf("UpdatePageBodyText failed: %v", err)
+	}
+
+	pages, err := db.SearchPages("needle", nil, nil, "")
+	if err != nil {
+		t.Fatalf("SearchPages failed: %v", err)
+	}
+	if len(pages) != 1 || pages[0].ID != pageID {
+		t.Fatalf("SearchPages returned %+v, want page %d", pages, pageID)
+	}
+
+	page := pages[0]
+	if !strings.Contains(page.HighlightedTitle, "<mark>Needle</mark>") {
+		t.Fatalf("HighlightedTitle = %q, want highlighted title", page.HighlightedTitle)
+	}
+	if strings.Contains(page.HighlightedTitle, "<Title>") || !strings.Contains(page.HighlightedTitle, "&lt;Title&gt;") {
+		t.Fatalf("HighlightedTitle = %q, want escaped title markup", page.HighlightedTitle)
+	}
+	if !strings.Contains(page.HighlightedURL, "<mark>Needle</mark>") {
+		t.Fatalf("HighlightedURL = %q, want highlighted URL", page.HighlightedURL)
+	}
+	if !strings.Contains(page.SearchSnippet, "<mark>Needle</mark>") {
+		t.Fatalf("SearchSnippet = %q, want highlighted snippet", page.SearchSnippet)
+	}
+	if strings.Contains(page.SearchSnippet, "<script>") || !strings.Contains(page.SearchSnippet, "&lt;script&gt;") {
+		t.Fatalf("SearchSnippet = %q, want escaped snippet markup", page.SearchSnippet)
+	}
+	if page.BodyText != "" {
+		t.Fatalf("BodyText should not be returned in search results, got %q", page.BodyText)
+	}
+}
+
 func TestSQLiteSearchPages_EscapesLikeWildcards(t *testing.T) {
 	db := newSQLiteTestDB(t)
 

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -3,17 +3,20 @@ package models
 import "time"
 
 type Page struct {
-	ID            int64     `json:"id"`
-	URL           string    `json:"url"`
-	Title         string    `json:"title"`
-	CapturedAt    time.Time `json:"captured_at"`
-	HTMLPath      string    `json:"html_path"`
-	ContentHash   string    `json:"content_hash"`
-	SnapshotState string    `json:"snapshot_state"`
-	FirstVisited  time.Time `json:"first_visited"`
-	LastVisited   time.Time `json:"last_visited"`
-	BodyText      string    `json:"body_text,omitempty"`
-	Domain        string    `json:"domain,omitempty"`
+	ID               int64     `json:"id"`
+	URL              string    `json:"url"`
+	Title            string    `json:"title"`
+	CapturedAt       time.Time `json:"captured_at"`
+	HTMLPath         string    `json:"html_path"`
+	ContentHash      string    `json:"content_hash"`
+	SnapshotState    string    `json:"snapshot_state"`
+	FirstVisited     time.Time `json:"first_visited"`
+	LastVisited      time.Time `json:"last_visited"`
+	BodyText         string    `json:"body_text,omitempty"`
+	Domain           string    `json:"domain,omitempty"`
+	SearchSnippet    string    `json:"search_snippet,omitempty"`
+	HighlightedURL   string    `json:"highlighted_url,omitempty"`
+	HighlightedTitle string    `json:"highlighted_title,omitempty"`
 }
 
 type Resource struct {

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -425,6 +425,23 @@
             text-decoration: underline;
         }
 
+        .search-snippet {
+            margin: 0 0 12px;
+            color: var(--color-text-secondary);
+            font-size: 0.8125rem;
+            line-height: 1.6;
+            font-family: var(--font-sans);
+            word-break: break-word;
+        }
+
+        .page-title mark,
+        .page-url mark,
+        .search-snippet mark {
+            background: rgba(0, 255, 136, 0.18);
+            color: var(--color-accent);
+            padding: 0 2px;
+        }
+
         .page-meta {
             display: flex;
             align-items: center;
@@ -712,7 +729,7 @@
 
                 const title = document.createElement('h2');
                 title.className = 'page-title';
-                title.textContent = page.title || 'Untitled';
+                appendHighlightedHTML(title, page.highlighted_title, page.title || 'Untitled');
 
                 const pageId = document.createElement('span');
                 pageId.className = 'page-id';
@@ -734,7 +751,7 @@
                 deleteBtn.textContent = 'Delete';
                 deleteBtn.addEventListener('click', (event) => deletePage(event, page.id));
 
-                const urlLink = createSafeExternalLink(page.url, 'page-url');
+                const urlLink = createSafeExternalLink(page.url, 'page-url', page.highlighted_url);
 
                 const meta = document.createElement('div');
                 meta.className = 'page-meta';
@@ -754,6 +771,12 @@
 
                 item.appendChild(header);
                 item.appendChild(urlLink);
+                if (page.search_snippet) {
+                    const snippet = document.createElement('div');
+                    snippet.className = 'search-snippet';
+                    appendHighlightedHTML(snippet, page.search_snippet, '');
+                    item.appendChild(snippet);
+                }
                 item.appendChild(meta);
 
                 item.addEventListener('click', (e) => {
@@ -874,10 +897,10 @@
             return item;
         }
 
-        function createSafeExternalLink(rawURL, className) {
+        function createSafeExternalLink(rawURL, className, highlightedHTML) {
             const link = document.createElement('a');
             link.className = className;
-            link.textContent = rawURL || '';
+            appendHighlightedHTML(link, highlightedHTML, rawURL || '');
 
             const safeURL = normalizeExternalURL(rawURL);
             if (safeURL) {
@@ -890,6 +913,40 @@
             }
 
             return link;
+        }
+
+        function appendHighlightedHTML(target, highlightedHTML, fallbackText) {
+            target.textContent = '';
+            if (!highlightedHTML) {
+                target.textContent = fallbackText || '';
+                return;
+            }
+
+            const template = document.createElement('template');
+            template.innerHTML = highlightedHTML;
+            const nodes = Array.from(template.content.childNodes);
+            if (nodes.length === 0) {
+                target.textContent = fallbackText || '';
+                return;
+            }
+
+            nodes.forEach((node) => appendAllowedHighlightNode(target, node));
+        }
+
+        function appendAllowedHighlightNode(target, node) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                target.appendChild(document.createTextNode(node.textContent || ''));
+                return;
+            }
+
+            if (node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'mark') {
+                const mark = document.createElement('mark');
+                mark.textContent = node.textContent || '';
+                target.appendChild(mark);
+                return;
+            }
+
+            target.appendChild(document.createTextNode(node.textContent || ''));
         }
 
         function normalizeExternalURL(rawURL) {


### PR DESCRIPTION
## Summary
- add search response fields for highlighted title, URL, and body snippets
- generate escaped highlight markup with only <mark> tags around matches
- render search highlights and snippets safely in the web UI

## Review
- No blocking issues found in the implementation review.
- Highlight markup is escaped server-side and sanitized client-side to allow only <mark>.

## Tests
- go test -tags sqlite_fts5 ./...