### PR TITLE
Support paginated search results

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -197,10 +197,10 @@ export https_proxy=http://127.0.0.1:7897
 | `GET` | `/api/version` | 服务器版本和构建信息 |
 | `POST` | `/api/archive` | 创建页面归档 |
 | `PUT` | `/api/archive/:id` | 更新已有归档快照 |
-| `GET` | `/api/pages` | 列出所有归档页面 |
+| `GET` | `/api/pages?limit=50&offset=0` | 分页列出归档页面 |
 | `GET` | `/api/pages/:id` | 获取页面详情 |
 | `GET` | `/api/pages/:id/content` | 获取页面正文的 Markdown 格式（方便 AI/LLM 读取） |
-| `GET` | `/api/search?q=keyword` | 按 URL 或标题搜索 |
+| `GET` | `/api/search?q=keyword&limit=50&offset=0` | 按 URL、标题或正文分页搜索 |
 | `GET` | `/api/pages/timeline?url=URL` | 获取同一 URL 的所有快照（时间线视图） |
 | `GET` | `/api/logs` | 列出可用日志文件 |
 | `GET` | `/api/logs/latest` | 获取最新日志文件内容（支持 `?tail=N&grep=关键词`） |

--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 | `GET` | `/api/version` | Server version and build info |
 | `POST` | `/api/archive` | Create a page archive |
 | `PUT` | `/api/archive/:id` | Update an existing archive snapshot |
-| `GET` | `/api/pages` | List all archived pages |
+| `GET` | `/api/pages?limit=50&offset=0` | List archived pages with pagination |
 | `GET` | `/api/pages/:id` | Get page details |
 | `GET` | `/api/pages/:id/content` | Get page content as Markdown (for AI/LLM consumption) |
-| `GET` | `/api/search?q=keyword` | Search pages by URL or title |
+| `GET` | `/api/search?q=keyword&limit=50&offset=0` | Search pages by URL, title, or body text with pagination |
 | `GET` | `/api/pages/timeline?url=URL` | Get all snapshots of a URL (timeline view) |
 | `GET` | `/api/logs` | List available log files |
 | `GET` | `/api/logs/latest` | Get latest log file content (supports `?tail=N&grep=keyword`) |

--- a/server/internal/api/pages_handler.go
+++ b/server/internal/api/pages_handler.go
@@ -130,11 +130,16 @@ func (h *Handler) GetPage(c *gin.Context) {
 	c.JSON(http.StatusOK, page)
 }
 
-// SearchPages 搜索页面（支持时间过滤）
+// SearchPages 搜索页面（支持分页、时间和域名过滤）
 func (h *Handler) SearchPages(c *gin.Context) {
 	keyword := c.Query("q")
 	if keyword == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing query parameter"})
+		return
+	}
+
+	limit, offset, ok := parsePaginationParams(c)
+	if !ok {
 		return
 	}
 
@@ -145,12 +150,24 @@ func (h *Handler) SearchPages(c *gin.Context) {
 
 	domain := c.Query("domain")
 
-	pages, err := h.db.SearchPages(keyword, from, to, domain)
+	pages, err := h.db.SearchPages(keyword, limit, offset, from, to, domain)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, pages)
+
+	total, err := h.db.GetSearchPagesCount(keyword, from, to, domain)
+	if err != nil {
+		log.Printf("Failed to get search count: %v", err)
+		total = len(pages)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"pages":  pages,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+	})
 }
 
 // GetPageTimeline 获取同一 URL 的所有快照

--- a/server/internal/api/pages_handler_test.go
+++ b/server/internal/api/pages_handler_test.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -87,5 +91,83 @@ func TestSearchPages_InvalidFromDate(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid from date, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSearchPages_InvalidLimit(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/search?q=test&limit=0", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid limit, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSearchPages_PaginatedResponse(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+	router := setupPagesRouter(handler)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	domain := "api-search-pagination-" + suffix + ".example.com"
+	token := "api-search-pagination-token-" + suffix
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		pageID, err := handler.db.CreatePage(
+			fmt.Sprintf("https://%s/page-%d", domain, i),
+			fmt.Sprintf("API Search Pagination %d", i),
+			fmt.Sprintf("html/test/api-search-pagination-%s-%d.html", suffix, i),
+			fmt.Sprintf("%064d", i+2000),
+			now.Add(time.Duration(i)*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("CreatePage(%d) failed: %v", i, err)
+		}
+		defer handler.db.DeletePage(pageID)
+
+		if err := handler.db.UpdatePageBodyText(pageID, token); err != nil {
+			t.Fatalf("UpdatePageBodyText(%d) failed: %v", i, err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	reqURL := fmt.Sprintf(
+		"/api/search?q=%s&domain=%s&limit=2&offset=2",
+		url.QueryEscape(token),
+		url.QueryEscape(domain),
+	)
+	req, _ := http.NewRequest(http.MethodGet, reqURL, nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Pages []struct {
+			ID int64 `json:"id"`
+		} `json:"pages"`
+		Total  int `json:"total"`
+		Limit  int `json:"limit"`
+		Offset int `json:"offset"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Total != 3 {
+		t.Fatalf("total = %d, want 3", response.Total)
+	}
+	if response.Limit != 2 || response.Offset != 2 {
+		t.Fatalf("limit/offset = %d/%d, want 2/2", response.Limit, response.Offset)
+	}
+	if len(response.Pages) != 1 {
+		t.Fatalf("pages length = %d, want 1", len(response.Pages))
 	}
 }

--- a/server/internal/database/interface.go
+++ b/server/internal/database/interface.go
@@ -18,7 +18,8 @@ type Database interface {
 	GetPagesByURL(pageURL string) ([]models.Page, error)
 	ListPages(limit, offset int, from, to *time.Time, domain string) ([]models.Page, error)
 	GetTotalPagesCount(from, to *time.Time, domain string) (int, error)
-	SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error)
+	SearchPages(keyword string, limit, offset int, from, to *time.Time, domain string) ([]models.Page, error)
+	GetSearchPagesCount(keyword string, from, to *time.Time, domain string) (int, error)
 	GetPagesWithoutBodyText() ([]models.Page, error)
 	GetSnapshotNeighbors(pageURL string, currentID int64) (prev *models.Page, next *models.Page, total int, err error)
 

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -567,33 +567,45 @@ func (db *PostgresDB) GetPageByID(id string) (*models.Page, error) {
 	return &p, nil
 }
 
-// SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
-func (db *PostgresDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
+func (db *PostgresDB) buildSearchWhere(keyword string, from, to *time.Time, domain string) (string, []interface{}, int) {
 	likeOp := db.qb.CaseInsensitiveLike()
-	query := fmt.Sprintf("SELECT %s FROM pages WHERE (url %s $1 ESCAPE '\\' OR title %s $1 ESCAPE '\\' OR body_text %s $1 ESCAPE '\\')", pageSearchSelectColumns, likeOp, likeOp, likeOp)
+	where := fmt.Sprintf(" WHERE (COALESCE(url, '') %s $1 ESCAPE '\\' OR COALESCE(title, '') %s $1 ESCAPE '\\' OR COALESCE(body_text, '') %s $1 ESCAPE '\\')", likeOp, likeOp, likeOp)
 	args := []interface{}{"%" + escapeLikePattern(keyword) + "%"}
 	argIndex := 2
 
 	// 追加时间过滤条件
 	if from != nil {
-		query += fmt.Sprintf(" AND captured_at >= $%d", argIndex)
+		where += fmt.Sprintf(" AND captured_at >= $%d", argIndex)
 		args = append(args, *from)
 		argIndex++
 	}
 	if to != nil {
 		// to 使用 < nextDay 确保包含当天全部记录
 		nextDay := to.AddDate(0, 0, 1)
-		query += fmt.Sprintf(" AND captured_at < $%d", argIndex)
+		where += fmt.Sprintf(" AND captured_at < $%d", argIndex)
 		args = append(args, nextDay)
 		argIndex++
 	}
 	if domain != "" {
-		query += fmt.Sprintf(" AND (domain = $%d OR domain LIKE $%d)", argIndex, argIndex+1)
+		where += fmt.Sprintf(" AND (domain = $%d OR domain LIKE $%d)", argIndex, argIndex+1)
 		args = append(args, domain, "%."+domain)
 		argIndex += 2
 	}
 
-	query += " ORDER BY last_visited DESC LIMIT 100"
+	return where, args, argIndex
+}
+
+// SearchPages 搜索页面（按 URL、标题或正文内容，支持分页、时间和域名过滤）
+func (db *PostgresDB) SearchPages(keyword string, limit, offset int, from, to *time.Time, domain string) ([]models.Page, error) {
+	where, args, argIndex := db.buildSearchWhere(keyword, from, to, domain)
+	query := fmt.Sprintf(
+		"SELECT %s FROM pages%s ORDER BY COALESCE(last_visited, captured_at) DESC, id DESC LIMIT $%d OFFSET $%d",
+		pageSearchSelectColumns,
+		where,
+		argIndex,
+		argIndex+1,
+	)
+	args = append(args, limit, offset)
 
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
@@ -612,6 +624,16 @@ func (db *PostgresDB) SearchPages(keyword string, from, to *time.Time, domain st
 		pages = append(pages, p)
 	}
 	return pages, nil
+}
+
+// GetSearchPagesCount 获取搜索结果总数（支持时间和域名过滤）
+func (db *PostgresDB) GetSearchPagesCount(keyword string, from, to *time.Time, domain string) (int, error) {
+	where, args, _ := db.buildSearchWhere(keyword, from, to, domain)
+	query := "SELECT COUNT(*) FROM pages" + where
+
+	var count int
+	err := db.conn.QueryRow(query, args...).Scan(&count)
+	return count, err
 }
 
 // GetPagesWithoutBodyText 获取所有没有 body_text 的页面（用于回填）

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -3,10 +3,12 @@ package database
 import (
 	"errors"
 	"fmt"
-	"github.com/lib/pq"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lib/pq"
+	"wayback/internal/models"
 )
 
 func TestBuildConnectionString_DefaultSSLMode(t *testing.T) {
@@ -92,6 +94,15 @@ func skipIfNoDB(t *testing.T) *DB {
 
 func idStr(id int64) string {
 	return fmt.Sprintf("%d", id)
+}
+
+func containsResourceID(resources []models.Resource, id int64) bool {
+	for _, resource := range resources {
+		if resource.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func TestUpdatePageContent(t *testing.T) {
@@ -323,7 +334,7 @@ func TestPostgresSearchPages_EscapesLikeWildcards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.keyword, func(t *testing.T) {
-			pages, err := db.SearchPages(tt.keyword, nil, nil, domain)
+			pages, err := db.SearchPages(tt.keyword, 100, 0, nil, nil, domain)
 			if err != nil {
 				t.Fatalf("SearchPages(%q) failed: %v", tt.keyword, err)
 			}
@@ -331,6 +342,212 @@ func TestPostgresSearchPages_EscapesLikeWildcards(t *testing.T) {
 				t.Fatalf("SearchPages(%q) returned %+v, want only page %d", tt.keyword, pages, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestPostgresSearchPages_MatchesURLTitleAndBodyText(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	domain := "postgres-search-match-" + suffix + ".example.com"
+	pageID, err := db.CreatePage(
+		"https://"+domain+"/url-token",
+		"Postgres Title Token",
+		"html/test/postgres-search-match.html",
+		strings.Repeat("a", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	if err := db.UpdatePageBodyText(pageID, "This archived body includes postgres body token."); err != nil {
+		t.Fatalf("UpdatePageBodyText failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		keyword string
+	}{
+		{name: "URL substring", keyword: "url-token"},
+		{name: "title substring", keyword: "Postgres Title Token"},
+		{name: "body text substring", keyword: "postgres body token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pages, err := db.SearchPages(tt.keyword, 100, 0, nil, nil, domain)
+			if err != nil {
+				t.Fatalf("SearchPages(%q) failed: %v", tt.keyword, err)
+			}
+			if len(pages) != 1 || pages[0].ID != pageID {
+				t.Fatalf("SearchPages(%q) returned %+v, want page %d", tt.keyword, pages, pageID)
+			}
+		})
+	}
+}
+
+func TestPostgresSearchPages_ReturnsEscapedHighlights(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	domain := "postgres-highlight-" + suffix + ".example.com"
+	pageID, err := db.CreatePage(
+		"https://"+domain+"/archive/Needle",
+		"Needle <Title>",
+		"html/test/postgres-highlight.html",
+		strings.Repeat("b", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	if err := db.UpdatePageBodyText(pageID, "prefix unsafe <script>alert(1)</script> body Needle suffix"); err != nil {
+		t.Fatalf("UpdatePageBodyText failed: %v", err)
+	}
+
+	pages, err := db.SearchPages("needle", 100, 0, nil, nil, domain)
+	if err != nil {
+		t.Fatalf("SearchPages failed: %v", err)
+	}
+	if len(pages) != 1 || pages[0].ID != pageID {
+		t.Fatalf("SearchPages returned %+v, want page %d", pages, pageID)
+	}
+
+	page := pages[0]
+	if !strings.Contains(page.HighlightedTitle, "<mark>Needle</mark>") {
+		t.Fatalf("HighlightedTitle = %q, want highlighted title", page.HighlightedTitle)
+	}
+	if strings.Contains(page.HighlightedTitle, "<Title>") || !strings.Contains(page.HighlightedTitle, "&lt;Title&gt;") {
+		t.Fatalf("HighlightedTitle = %q, want escaped title markup", page.HighlightedTitle)
+	}
+	if !strings.Contains(page.HighlightedURL, "<mark>Needle</mark>") {
+		t.Fatalf("HighlightedURL = %q, want highlighted URL", page.HighlightedURL)
+	}
+	if !strings.Contains(page.SearchSnippet, "<mark>Needle</mark>") {
+		t.Fatalf("SearchSnippet = %q, want highlighted snippet", page.SearchSnippet)
+	}
+	if strings.Contains(page.SearchSnippet, "<script>") || !strings.Contains(page.SearchSnippet, "&lt;script&gt;") {
+		t.Fatalf("SearchSnippet = %q, want escaped snippet markup", page.SearchSnippet)
+	}
+	if page.BodyText != "" {
+		t.Fatalf("BodyText should not be returned in search results, got %q", page.BodyText)
+	}
+}
+
+func TestPostgresSearchPages_PaginatesAndCounts(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	domain := "search-pagination-" + suffix + ".example.com"
+	token := "search-pagination-token-" + suffix
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		pageID, err := db.CreatePage(
+			fmt.Sprintf("https://%s/page-%d", domain, i),
+			fmt.Sprintf("Search Pagination Token %d", i),
+			fmt.Sprintf("html/test/search-pagination-%s-%d.html", suffix, i),
+			fmt.Sprintf("%064d", i+1000),
+			now.Add(time.Duration(i)*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("CreatePage(%d) failed: %v", i, err)
+		}
+		defer db.DeletePage(pageID)
+
+		if err := db.UpdatePageBodyText(pageID, token); err != nil {
+			t.Fatalf("UpdatePageBodyText(%d) failed: %v", i, err)
+		}
+	}
+
+	total, err := db.GetSearchPagesCount(token, nil, nil, domain)
+	if err != nil {
+		t.Fatalf("GetSearchPagesCount failed: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("GetSearchPagesCount = %d, want 3", total)
+	}
+
+	firstPage, err := db.SearchPages(token, 2, 0, nil, nil, domain)
+	if err != nil {
+		t.Fatalf("SearchPages(first page) failed: %v", err)
+	}
+	if len(firstPage) != 2 {
+		t.Fatalf("first page length = %d, want 2", len(firstPage))
+	}
+
+	secondPage, err := db.SearchPages(token, 2, 2, nil, nil, domain)
+	if err != nil {
+		t.Fatalf("SearchPages(second page) failed: %v", err)
+	}
+	if len(secondPage) != 1 {
+		t.Fatalf("second page length = %d, want 1", len(secondPage))
+	}
+	if secondPage[0].ID == firstPage[0].ID || secondPage[0].ID == firstPage[1].ID {
+		t.Fatalf("second page returned a duplicate result: first=%+v second=%+v", firstPage, secondPage)
+	}
+}
+
+func TestPostgresReplacePageSnapshotWithBodyText(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	domain := "postgres-replace-body-" + suffix + ".example.com"
+	pageID, err := db.CreatePage(
+		"https://"+domain+"/replace",
+		"Original Title",
+		"html/test/postgres-replace-original.html",
+		strings.Repeat("c", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer db.DeletePage(pageID)
+
+	bodyText := "postgres replace snapshot body token"
+	if err := db.ReplacePageSnapshot(
+		pageID,
+		"html/test/postgres-replace-updated.html",
+		strings.Repeat("d", 64),
+		"Updated Title",
+		&bodyText,
+		nil,
+	); err != nil {
+		t.Fatalf("ReplacePageSnapshot failed: %v", err)
+	}
+
+	page, err := db.GetPageByID(idStr(pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	if page == nil {
+		t.Fatal("page should exist after ReplacePageSnapshot")
+	}
+	if page.HTMLPath != "html/test/postgres-replace-updated.html" {
+		t.Fatalf("HTMLPath = %q, want updated path", page.HTMLPath)
+	}
+	if page.ContentHash != strings.Repeat("d", 64) {
+		t.Fatalf("ContentHash = %q, want updated hash", page.ContentHash)
+	}
+	if page.Title != "Updated Title" {
+		t.Fatalf("Title = %q, want Updated Title", page.Title)
+	}
+
+	pages, err := db.SearchPages("replace snapshot body", 100, 0, nil, nil, domain)
+	if err != nil {
+		t.Fatalf("SearchPages failed: %v", err)
+	}
+	if len(pages) != 1 || pages[0].ID != pageID {
+		t.Fatalf("SearchPages returned %+v, want page %d", pages, pageID)
 	}
 }
 
@@ -425,6 +642,94 @@ func TestGetResourceByURLPrefix_EscapesUnderscoreWildcards(t *testing.T) {
 	}
 	if resource.ID != correctID {
 		t.Fatalf("resource ID = %d, want %d (wrong wildcard match to %q)", resource.ID, correctID, wrongURL)
+	}
+}
+
+func TestPostgresQuarantineResourcesByFilePath_HidesActiveResources(t *testing.T) {
+	db := skipIfNoDB(t)
+	defer db.Close()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	sharedPath := "resources/test/quarantine-shared-" + suffix + ".css"
+	quarantinePath := "resources/quarantine/quarantine-shared-" + suffix + ".css"
+	reason := "test quarantine"
+	urlA := "https://postgres-quarantine.example.com/a.css?nonce=" + suffix
+	urlB := "https://postgres-quarantine.example.com/b.css?nonce=" + suffix
+	urlImage := "https://postgres-quarantine.example.com/logo.png?nonce=" + suffix
+
+	resourceIDA, err := db.CreateResource(urlA, strings.Repeat("a", 64), "css", sharedPath, 10)
+	if err != nil {
+		t.Fatalf("CreateResource(A) failed: %v", err)
+	}
+	defer db.conn.Exec("DELETE FROM resources WHERE id = $1", resourceIDA)
+
+	resourceIDB, err := db.CreateResource(urlB, strings.Repeat("b", 64), "css", sharedPath, 10)
+	if err != nil {
+		t.Fatalf("CreateResource(B) failed: %v", err)
+	}
+	defer db.conn.Exec("DELETE FROM resources WHERE id = $1", resourceIDB)
+
+	imageID, err := db.CreateResource(urlImage, strings.Repeat("c", 64), "image", "resources/test/quarantine-image-"+suffix+".img", 10)
+	if err != nil {
+		t.Fatalf("CreateResource(image) failed: %v", err)
+	}
+	defer db.conn.Exec("DELETE FROM resources WHERE id = $1", imageID)
+
+	scanAfterID := resourceIDA - 1
+	resources, err := db.ListResourcesForIntegrityCheck("css", scanAfterID, 10)
+	if err != nil {
+		t.Fatalf("ListResourcesForIntegrityCheck(before) failed: %v", err)
+	}
+	if !containsResourceID(resources, resourceIDA) || !containsResourceID(resources, resourceIDB) {
+		t.Fatalf("expected both CSS resources in integrity scan before quarantine")
+	}
+
+	affected, err := db.QuarantineResourcesByFilePath(sharedPath, quarantinePath, reason)
+	if err != nil {
+		t.Fatalf("QuarantineResourcesByFilePath failed: %v", err)
+	}
+	if affected != 2 {
+		t.Fatalf("affected rows = %d, want 2", affected)
+	}
+
+	for _, resourceID := range []int64{resourceIDA, resourceIDB} {
+		resource, err := db.GetResourceByID(resourceID)
+		if err != nil {
+			t.Fatalf("GetResourceByID(%d) failed: %v", resourceID, err)
+		}
+		if resource == nil || !resource.IsQuarantined {
+			t.Fatalf("resource %d should be quarantined", resourceID)
+		}
+		if resource.FilePath != quarantinePath {
+			t.Fatalf("resource %d path = %q, want %q", resourceID, resource.FilePath, quarantinePath)
+		}
+		if resource.QuarantineReason != reason {
+			t.Fatalf("resource %d reason = %q, want %q", resourceID, resource.QuarantineReason, reason)
+		}
+	}
+
+	active, err := db.GetResourceByURL(urlA)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(A) failed: %v", err)
+	}
+	if active != nil {
+		t.Fatalf("quarantined resource should be hidden from active URL lookup")
+	}
+
+	resources, err = db.ListResourcesForIntegrityCheck("css", scanAfterID, 10)
+	if err != nil {
+		t.Fatalf("ListResourcesForIntegrityCheck(after) failed: %v", err)
+	}
+	if containsResourceID(resources, resourceIDA) || containsResourceID(resources, resourceIDB) {
+		t.Fatalf("quarantined resources should be hidden from integrity scans")
+	}
+
+	image, err := db.GetResourceByURL(urlImage)
+	if err != nil {
+		t.Fatalf("GetResourceByURL(image) failed: %v", err)
+	}
+	if image == nil || image.ID != imageID {
+		t.Fatalf("unrelated image resource should remain active")
 	}
 }
 

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -678,9 +678,8 @@ func (db *SQLiteDB) GetPageByID(id string) (*models.Page, error) {
 	return &p, nil
 }
 
-// SearchPages 搜索页面（按 URL、标题或正文内容，支持时间和域名过滤）
-func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain string) ([]models.Page, error) {
-	query := `SELECT ` + pageSearchSelectColumns + ` FROM pages WHERE (` +
+func buildSQLiteSearchWhere(keyword string, from, to *time.Time, domain string) (string, []interface{}) {
+	where := ` WHERE (` +
 		`LOWER(COALESCE(url, '')) LIKE LOWER(?) ESCAPE '\' OR ` +
 		`LOWER(COALESCE(title, '')) LIKE LOWER(?) ESCAPE '\' OR ` +
 		`LOWER(COALESCE(body_text, '')) LIKE LOWER(?) ESCAPE '\'` +
@@ -690,21 +689,29 @@ func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain stri
 
 	// 追加时间过滤条件
 	if from != nil {
-		query += " AND captured_at >= ?"
+		where += " AND captured_at >= ?"
 		args = append(args, formatSQLiteTimestamp(*from))
 	}
 	if to != nil {
 		// to 使用 < nextDay 确保包含当天全部记录
 		nextDay := to.AddDate(0, 0, 1)
-		query += " AND captured_at < ?"
+		where += " AND captured_at < ?"
 		args = append(args, formatSQLiteTimestamp(nextDay))
 	}
 	if domain != "" {
-		query += " AND (domain = ? OR domain LIKE ?)"
+		where += " AND (domain = ? OR domain LIKE ?)"
 		args = append(args, domain, "%."+domain)
 	}
 
-	query += " ORDER BY COALESCE(julianday(last_visited), julianday(captured_at)) DESC, id DESC LIMIT 100"
+	return where, args
+}
+
+// SearchPages 搜索页面（按 URL、标题或正文内容，支持分页、时间和域名过滤）
+func (db *SQLiteDB) SearchPages(keyword string, limit, offset int, from, to *time.Time, domain string) ([]models.Page, error) {
+	where, args := buildSQLiteSearchWhere(keyword, from, to, domain)
+	query := `SELECT ` + pageSearchSelectColumns + ` FROM pages` + where +
+		` ORDER BY COALESCE(julianday(last_visited), julianday(captured_at)) DESC, id DESC LIMIT ? OFFSET ?`
+	args = append(args, limit, offset)
 
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
@@ -723,6 +730,16 @@ func (db *SQLiteDB) SearchPages(keyword string, from, to *time.Time, domain stri
 		pages = append(pages, p)
 	}
 	return pages, nil
+}
+
+// GetSearchPagesCount 获取搜索结果总数（支持时间和域名过滤）
+func (db *SQLiteDB) GetSearchPagesCount(keyword string, from, to *time.Time, domain string) (int, error) {
+	where, args := buildSQLiteSearchWhere(keyword, from, to, domain)
+	query := "SELECT COUNT(*) FROM pages" + where
+
+	var count int
+	err := db.conn.QueryRow(query, args...).Scan(&count)
+	return count, err
 }
 
 // GetPagesWithoutBodyText 获取所有没有 body_text 的页面（用于回填）

--- a/server/internal/database/sqlite_test.go
+++ b/server/internal/database/sqlite_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -41,7 +42,7 @@ func TestSQLiteFTSUpdatePageBodyText(t *testing.T) {
 		t.Fatalf("UpdatePageBodyText failed: %v", err)
 	}
 
-	pages, err := db.SearchPages("archived", nil, nil, "")
+	pages, err := db.SearchPages("archived", 100, 0, nil, nil, "")
 	if err != nil {
 		t.Fatalf("SearchPages failed: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestSQLiteSearchPages_MatchesURLTitleAndBodyText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pages, err := db.SearchPages(tt.keyword, nil, nil, "")
+			pages, err := db.SearchPages(tt.keyword, 100, 0, nil, nil, "")
 			if err != nil {
 				t.Fatalf("SearchPages failed: %v", err)
 			}
@@ -96,7 +97,7 @@ func TestSQLiteSearchPages_ReturnsEscapedHighlights(t *testing.T) {
 		t.Fatalf("UpdatePageBodyText failed: %v", err)
 	}
 
-	pages, err := db.SearchPages("needle", nil, nil, "")
+	pages, err := db.SearchPages("needle", 100, 0, nil, nil, "")
 	if err != nil {
 		t.Fatalf("SearchPages failed: %v", err)
 	}
@@ -164,7 +165,7 @@ func TestSQLiteSearchPages_EscapesLikeWildcards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.keyword, func(t *testing.T) {
-			pages, err := db.SearchPages(tt.keyword, nil, nil, domain)
+			pages, err := db.SearchPages(tt.keyword, 100, 0, nil, nil, domain)
 			if err != nil {
 				t.Fatalf("SearchPages(%q) failed: %v", tt.keyword, err)
 			}
@@ -172,6 +173,54 @@ func TestSQLiteSearchPages_EscapesLikeWildcards(t *testing.T) {
 				t.Fatalf("SearchPages(%q) returned %+v, want only page %d", tt.keyword, pages, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestSQLiteSearchPages_PaginatesAndCounts(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		pageID, err := db.CreatePage(
+			fmt.Sprintf("https://search-pagination.example.com/page-%d", i),
+			fmt.Sprintf("Search Pagination Token %d", i),
+			fmt.Sprintf("html/test/search-pagination-%d.html", i),
+			fmt.Sprintf("hash-search-pagination-%d", i),
+			now.Add(time.Duration(i)*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("CreatePage(%d) failed: %v", i, err)
+		}
+		if err := db.UpdatePageBodyText(pageID, "search pagination token body"); err != nil {
+			t.Fatalf("UpdatePageBodyText(%d) failed: %v", i, err)
+		}
+	}
+
+	total, err := db.GetSearchPagesCount("search pagination token", nil, nil, "search-pagination.example.com")
+	if err != nil {
+		t.Fatalf("GetSearchPagesCount failed: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("GetSearchPagesCount = %d, want 3", total)
+	}
+
+	firstPage, err := db.SearchPages("search pagination token", 2, 0, nil, nil, "search-pagination.example.com")
+	if err != nil {
+		t.Fatalf("SearchPages(first page) failed: %v", err)
+	}
+	if len(firstPage) != 2 {
+		t.Fatalf("first page length = %d, want 2", len(firstPage))
+	}
+
+	secondPage, err := db.SearchPages("search pagination token", 2, 2, nil, nil, "search-pagination.example.com")
+	if err != nil {
+		t.Fatalf("SearchPages(second page) failed: %v", err)
+	}
+	if len(secondPage) != 1 {
+		t.Fatalf("second page length = %d, want 1", len(secondPage))
+	}
+	if secondPage[0].ID == firstPage[0].ID || secondPage[0].ID == firstPage[1].ID {
+		t.Fatalf("second page returned a duplicate result: first=%+v second=%+v", firstPage, secondPage)
 	}
 }
 
@@ -206,7 +255,7 @@ func TestSQLiteReplacePageSnapshotWithBodyText(t *testing.T) {
 		t.Fatalf("Title = %q, want %q", page.Title, "Updated Title")
 	}
 
-	pages, err := db.SearchPages("snapshot", nil, nil, "")
+	pages, err := db.SearchPages("snapshot", 100, 0, nil, nil, "")
 	if err != nil {
 		t.Fatalf("SearchPages failed: %v", err)
 	}

--- a/server/internal/storage/deduplicator_regression_test.go
+++ b/server/internal/storage/deduplicator_regression_test.go
@@ -1138,7 +1138,7 @@ func TestUpdateCapture_ClearsBodyTextWhenSnapshotBecomesEmpty(t *testing.T) {
 	}
 	defer db.DeletePage(pageID)
 
-	matches, err := db.SearchPages("disappear", nil, nil, "")
+	matches, err := db.SearchPages("disappear", 100, 0, nil, nil, "")
 	if err != nil {
 		t.Fatalf("SearchPages(before update) failed: %v", err)
 	}
@@ -1160,7 +1160,7 @@ func TestUpdateCapture_ClearsBodyTextWhenSnapshotBecomesEmpty(t *testing.T) {
 		t.Fatalf("action = %q, want %q", action, models.ArchiveActionUpdated)
 	}
 
-	matches, err = db.SearchPages("disappear", nil, nil, "")
+	matches, err = db.SearchPages("disappear", 100, 0, nil, nil, "")
 	if err != nil {
 		t.Fatalf("SearchPages(after update) failed: %v", err)
 	}

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -616,49 +616,202 @@
         let currentPage = 1;
         let pageSize = 50;
         let totalCount = 0;
+        let searchTimer = null;
+        let domainTimer = null;
+        let activeRequestController = null;
+        let latestRequestSeq = 0;
+
+        function normalizePageNumber(page) {
+            const parsed = Number.parseInt(page, 10);
+            if (!Number.isFinite(parsed) || parsed < 1) {
+                return 1;
+            }
+            return parsed;
+        }
+
+        function getFilters() {
+            return {
+                keyword: document.getElementById('searchInput').value.trim(),
+                dateFrom: document.getElementById('dateFrom').value,
+                dateTo: document.getElementById('dateTo').value,
+                domain: document.getElementById('domainInput').value.trim()
+            };
+        }
+
+        function buildArchiveParams(page, keyword = '') {
+            const filters = getFilters();
+            const params = new URLSearchParams();
+            params.set('limit', String(pageSize));
+            params.set('offset', String((page - 1) * pageSize));
+            if (keyword) params.set('q', keyword);
+            if (filters.dateFrom) params.set('from', filters.dateFrom);
+            if (filters.dateTo) params.set('to', filters.dateTo);
+            if (filters.domain) params.set('domain', filters.domain);
+            return params;
+        }
+
+        function syncBrowserURL(page) {
+            const filters = getFilters();
+            const params = new URLSearchParams();
+            if (filters.keyword) params.set('q', filters.keyword);
+            if (filters.dateFrom) params.set('from', filters.dateFrom);
+            if (filters.dateTo) params.set('to', filters.dateTo);
+            if (filters.domain) params.set('domain', filters.domain);
+            if (page > 1) params.set('page', String(page));
+
+            const query = params.toString();
+            const nextURL = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+            window.history.replaceState(null, '', nextURL);
+        }
+
+        function applyURLFilters() {
+            const params = new URLSearchParams(window.location.search);
+            document.getElementById('searchInput').value = params.get('q') || '';
+            document.getElementById('dateFrom').value = params.get('from') || '';
+            document.getElementById('dateTo').value = params.get('to') || '';
+            document.getElementById('domainInput').value = params.get('domain') || '';
+            return normalizePageNumber(params.get('page'));
+        }
+
+        function invalidateActiveRequest() {
+            latestRequestSeq += 1;
+            if (activeRequestController) {
+                activeRequestController.abort();
+                activeRequestController = null;
+            }
+        }
+
+        function beginArchiveRequest() {
+            if (activeRequestController) {
+                activeRequestController.abort();
+            }
+            const controller = new AbortController();
+            activeRequestController = controller;
+            const seq = latestRequestSeq + 1;
+            latestRequestSeq = seq;
+            return { controller, signal: controller.signal, seq };
+        }
+
+        function isCurrentRequest(seq) {
+            return seq === latestRequestSeq;
+        }
+
+        function finishArchiveRequest(seq, controller) {
+            if (isCurrentRequest(seq) && activeRequestController === controller) {
+                activeRequestController = null;
+            }
+        }
+
+        function isAbortError(error) {
+            return error && error.name === 'AbortError';
+        }
+
+        function parsePaginatedResponse(data) {
+            if (data && Array.isArray(data.pages)) {
+                return {
+                    pages: data.pages,
+                    total: Number.isFinite(Number(data.total)) ? Number(data.total) : data.pages.length
+                };
+            }
+
+            const pages = Array.isArray(data) ? data : [];
+            return {
+                pages,
+                total: pages.length
+            };
+        }
+
+        function applyPageResults(pages, total) {
+            const computedTotalPages = Math.ceil(total / pageSize);
+            if (total > 0 && currentPage > computedTotalPages) {
+                loadCurrentMode(computedTotalPages);
+                return;
+            }
+
+            allPages = pages || [];
+            totalCount = total;
+            totalPages = computedTotalPages;
+            document.getElementById('totalPages').textContent = totalCount;
+            renderPages(allPages);
+            updatePagination();
+        }
+
+        function showLoadError(error) {
+            console.error('Failed to load pages:', error);
+            const message = error && error.message ? error.message : String(error);
+            const isNetworkError = message.includes('fetch') || message.includes('NetworkError');
+            const errorMsg = isNetworkError
+                ? 'Unable to connect to server. Please check if the server is running.'
+                : 'Failed to load pages. Please try again.';
+            document.getElementById('pageList').innerHTML = `<li class="empty"><div class="empty-icon">[ ! ]</div>${errorMsg}</li>`;
+        }
 
         async function loadPages(page = 1) {
+            const request = beginArchiveRequest();
+            const normalizedPage = normalizePageNumber(page);
+            currentPage = normalizedPage;
+            syncBrowserURL(normalizedPage);
+
             try {
-                currentPage = page;
-                const offset = (page - 1) * pageSize;
-
-                // 构建 URL，包含日期过滤参数
-                let url = `/api/pages?limit=${pageSize}&offset=${offset}`;
-                const dateFrom = document.getElementById('dateFrom').value;
-                const dateTo = document.getElementById('dateTo').value;
-                const domain = document.getElementById('domainInput').value.trim();
-                if (dateFrom) url += `&from=${dateFrom}`;
-                if (dateTo) url += `&to=${dateTo}`;
-                if (domain) url += `&domain=${encodeURIComponent(domain)}`;
-
-                const response = await fetch(url);
+                const params = buildArchiveParams(normalizedPage);
+                const response = await fetch(`/api/pages?${params.toString()}`, {
+                    signal: request.signal
+                });
                 if (!response.ok) {
                     const errorData = await response.json().catch(() => ({}));
                     throw new Error(errorData.error || `HTTP ${response.status}`);
                 }
                 const data = await response.json();
-
-                // Handle new paginated response format
-                if (data.pages !== undefined && data.total !== undefined) {
-                    allPages = data.pages || [];
-                    totalCount = data.total;
-                } else {
-                    // Fallback for old format (array)
-                    allPages = Array.isArray(data) ? data : [];
-                    totalCount = allPages.length;
+                if (!isCurrentRequest(request.seq)) {
+                    return;
                 }
 
-                totalPages = Math.ceil(totalCount / pageSize);
-                document.getElementById('totalPages').textContent = totalCount;
-                renderPages(allPages);
-                updatePagination();
+                const result = parsePaginatedResponse(data);
+                applyPageResults(result.pages, result.total);
             } catch (error) {
-                console.error('Failed to load pages:', error);
-                const isNetworkError = error.message.includes('fetch') || error.message.includes('NetworkError');
-                const errorMsg = isNetworkError
-                    ? 'Unable to connect to server. Please check if the server is running.'
-                    : 'Failed to load pages. Please try again.';
-                document.getElementById('pageList').innerHTML = `<li class="empty"><div class="empty-icon">[ ! ]</div>${errorMsg}</li>`;
+                if (!isAbortError(error) && isCurrentRequest(request.seq)) {
+                    showLoadError(error);
+                }
+            } finally {
+                finishArchiveRequest(request.seq, request.controller);
+            }
+        }
+
+        async function searchPages(keyword, page = 1) {
+            const searchKeyword = keyword.trim();
+            if (!searchKeyword) {
+                loadPages(page);
+                return;
+            }
+
+            const request = beginArchiveRequest();
+            const normalizedPage = normalizePageNumber(page);
+            currentPage = normalizedPage;
+            syncBrowserURL(normalizedPage);
+
+            try {
+                const params = buildArchiveParams(normalizedPage, searchKeyword);
+                const response = await fetch(`/api/search?${params.toString()}`, {
+                    signal: request.signal
+                });
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || `HTTP ${response.status}`);
+                }
+                const data = await response.json();
+                if (!isCurrentRequest(request.seq)) {
+                    return;
+                }
+
+                const result = parsePaginatedResponse(data);
+                applyPageResults(result.pages, result.total);
+            } catch (error) {
+                if (!isAbortError(error) && isCurrentRequest(request.seq)) {
+                    console.error('Search error:', error);
+                    showLoadError(error);
+                }
+            } finally {
+                finishArchiveRequest(request.seq, request.controller);
             }
         }
 
@@ -670,23 +823,32 @@
 
             if (totalPages > 1) {
                 pagination.style.display = 'flex';
-                prevBtn.disabled = currentPage === 1;
-                nextBtn.disabled = currentPage === totalPages;
+                prevBtn.disabled = currentPage <= 1;
+                nextBtn.disabled = currentPage >= totalPages;
                 pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
             } else {
                 pagination.style.display = 'none';
             }
         }
 
+        function loadCurrentMode(page = currentPage) {
+            const keyword = getFilters().keyword;
+            if (keyword) {
+                searchPages(keyword, page);
+            } else {
+                loadPages(page);
+            }
+        }
+
         function loadPreviousPage() {
             if (currentPage > 1) {
-                loadPages(currentPage - 1);
+                loadCurrentMode(currentPage - 1);
             }
         }
 
         function loadNextPage() {
             if (currentPage < totalPages) {
-                loadPages(currentPage + 1);
+                loadCurrentMode(currentPage + 1);
             }
         }
 
@@ -810,8 +972,8 @@
                 });
 
                 if (response.ok) {
-                    // Reload current page to refresh the list
-                    loadPages(currentPage);
+                    // Reload current mode to refresh the list
+                    loadCurrentMode(currentPage);
                 } else {
                     const error = await response.json();
                     alert('删除失败: ' + (error.error || '未知错误'));
@@ -821,15 +983,12 @@
             }
         }
 
-        let searchTimer = null;
-        let isSearchMode = false;
-
         document.getElementById('searchInput').addEventListener('input', (e) => {
             const keyword = e.target.value.trim();
             clearTimeout(searchTimer);
+            invalidateActiveRequest();
 
             if (!keyword) {
-                isSearchMode = false;
                 loadPages(1);
                 return;
             }
@@ -840,49 +999,17 @@
 
         // 过滤器变化时重新加载
         function onFilterChange() {
-            if (isSearchMode) {
-                const keyword = document.getElementById('searchInput').value.trim();
-                if (keyword) {
-                    searchPages(keyword);
-                } else {
-                    isSearchMode = false;
-                    loadPages(1);
-                }
-            } else {
-                loadPages(1);
-            }
+            loadCurrentMode(1);
         }
 
         document.getElementById('dateFrom').addEventListener('change', onFilterChange);
         document.getElementById('dateTo').addEventListener('change', onFilterChange);
 
-        let domainTimer = null;
         document.getElementById('domainInput').addEventListener('input', () => {
             clearTimeout(domainTimer);
+            invalidateActiveRequest();
             domainTimer = setTimeout(onFilterChange, 300);
         });
-
-        async function searchPages(keyword) {
-            try {
-                // 构建 URL，包含日期过滤参数
-                let url = `/api/search?q=${encodeURIComponent(keyword)}`;
-                const dateFrom = document.getElementById('dateFrom').value;
-                const dateTo = document.getElementById('dateTo').value;
-                const domain = document.getElementById('domainInput').value.trim();
-                if (dateFrom) url += `&from=${dateFrom}`;
-                if (dateTo) url += `&to=${dateTo}`;
-                if (domain) url += `&domain=${encodeURIComponent(domain)}`;
-
-                const response = await fetch(url);
-                if (!response.ok) throw new Error('搜索失败');
-                const pages = await response.json();
-                isSearchMode = true;
-                renderPages(pages || []);
-                document.getElementById('pagination').style.display = 'none';
-            } catch (error) {
-                console.error('Search error:', error);
-            }
-        }
 
         function createMetaItem(icon, text) {
             const item = document.createElement('span');
@@ -961,7 +1088,8 @@
             }
         }
 
-        loadPages(1);
+        const initialPage = applyURLFilters();
+        loadCurrentMode(initialPage);
 
         fetch('/api/version').then(r => r.json()).then(d => {
             const el = document.getElementById('versionLink');


### PR DESCRIPTION
## Summary
- add true limit/offset pagination and total counts to /api/search
- share frontend pagination between list and search modes, with q/from/to/domain/page reflected in URL params
- guard frontend request races with AbortController and request sequence checks
- add SQLite and PostgreSQL coverage for search pagination and related database behavior

## Tests
- make test
- node inline script syntax check for server/web/index.html
- local /api/search pagination smoke test
- Puppeteer race guard simulation