### PR TITLE
Move Markdown view out of API routes

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -199,13 +199,13 @@ export https_proxy=http://127.0.0.1:7897
 | `PUT` | `/api/archive/:id` | 更新已有归档快照 |
 | `GET` | `/api/pages?limit=50&offset=0` | 分页列出归档页面 |
 | `GET` | `/api/pages/:id` | 获取页面详情 |
-| `GET` | `/api/pages/:id/content` | 获取页面正文的 Markdown 格式（方便 AI/LLM 读取） |
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | 按 URL、标题或正文分页搜索 |
 | `GET` | `/api/pages/timeline?url=URL` | 获取同一 URL 的所有快照（时间线视图） |
 | `GET` | `/api/logs` | 列出可用日志文件 |
 | `GET` | `/api/logs/latest` | 获取最新日志文件内容（支持 `?tail=N&grep=关键词`） |
 | `GET` | `/api/logs/:filename` | 获取日志文件内容（支持 `?tail=N&grep=关键词`） |
 | `GET` | `/view/:id` | 还原归档页面 |
+| `GET` | `/view/:id/md` | 获取归档页面正文的 Markdown 格式（方便 AI/LLM 读取） |
 | `GET` | `/timeline?url=URL` | URL 时间线可视化页面 |
 | `GET` | `/logs` | 服务器日志查看器 |
 

--- a/README.md
+++ b/README.md
@@ -232,13 +232,13 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 | `PUT` | `/api/archive/:id` | Update an existing archive snapshot |
 | `GET` | `/api/pages?limit=50&offset=0` | List archived pages with pagination |
 | `GET` | `/api/pages/:id` | Get page details |
-| `GET` | `/api/pages/:id/content` | Get page content as Markdown (for AI/LLM consumption) |
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | Search pages by URL, title, or body text with pagination |
 | `GET` | `/api/pages/timeline?url=URL` | Get all snapshots of a URL (timeline view) |
 | `GET` | `/api/logs` | List available log files |
 | `GET` | `/api/logs/latest` | Get latest log file content (supports `?tail=N&grep=keyword`) |
 | `GET` | `/api/logs/:filename` | Get log file content (supports `?tail=N&grep=keyword`) |
 | `GET` | `/view/:id` | Replay an archived page |
+| `GET` | `/view/:id/md` | Get archived page content as Markdown (for AI/LLM consumption) |
 | `GET` | `/timeline?url=URL` | Visual timeline page for a URL |
 | `GET` | `/logs` | Server logs viewer |
 

--- a/server/internal/api/pages_handler.go
+++ b/server/internal/api/pages_handler.go
@@ -3,13 +3,10 @@ package api
 import (
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"wayback/internal/storage"
 )
 
 func parsePageIDParam(c *gin.Context) (int64, bool) {
@@ -226,34 +223,4 @@ func (h *Handler) DeletePage(c *gin.Context) {
 
 	log.Printf("Deleted page: %s (%s)", id, page.URL)
 	c.JSON(http.StatusOK, gin.H{"status": "success"})
-}
-
-// GetPageContent 返回页面正文的 Markdown 格式（精简版，方便 AI 读取）
-func (h *Handler) GetPageContent(c *gin.Context) {
-	pageID, ok := parsePageIDParam(c)
-	if !ok {
-		return
-	}
-
-	page, err := h.db.GetPageByID(strconv.FormatInt(pageID, 10))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if page == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "page not found"})
-		return
-	}
-
-	htmlPath := filepath.Join(h.dataDir, page.HTMLPath)
-	htmlContent, err := os.ReadFile(htmlPath)
-	if err != nil {
-		c.String(http.StatusInternalServerError, "Failed to read HTML file")
-		return
-	}
-
-	markdown := storage.ExtractMarkdown(string(htmlContent))
-
-	c.Header("Content-Type", "text/markdown; charset=utf-8")
-	c.String(http.StatusOK, markdown)
 }

--- a/server/internal/api/pages_handler_test.go
+++ b/server/internal/api/pages_handler_test.go
@@ -18,7 +18,6 @@ func setupPagesRouter(handler *Handler) *gin.Engine {
 	api := r.Group("/api")
 	api.GET("/pages", handler.ListPages)
 	api.GET("/pages/:id", handler.GetPage)
-	api.GET("/pages/:id/content", handler.GetPageContent)
 	api.DELETE("/pages/:id", handler.DeletePage)
 	api.GET("/search", handler.SearchPages)
 	return r
@@ -45,20 +44,6 @@ func TestDeletePage_InvalidID(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodDelete, "/api/pages/not-a-number", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid page ID, got %d: %s", w.Code, w.Body.String())
-	}
-}
-
-func TestGetPageContent_InvalidID(t *testing.T) {
-	handler, cleanup := setupTestHandler(t)
-	defer cleanup()
-	router := setupPagesRouter(handler)
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/pages/not-a-number/content", nil)
 	router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -155,7 +155,6 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 		registerGETAndHEAD(api, "/pages", handler.ListPages)
 		registerGETAndHEAD(api, "/pages/timeline", handler.GetPageTimeline)
 		registerGETAndHEAD(api, "/pages/:id", handler.GetPage)
-		registerGETAndHEAD(api, "/pages/:id/content", handler.GetPageContent)
 		api.DELETE("/pages/:id", handler.DeletePage)
 		registerGETAndHEAD(api, "/search", handler.SearchPages)
 		registerGETAndHEAD(api, "/logs", handler.ListLogs)
@@ -165,6 +164,7 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 
 	// 查看归档页面
 	registerGETAndHEAD(r, "/view/:id", handler.ViewPage)
+	registerGETAndHEAD(r, "/view/:id/md", handler.ViewPageMarkdown)
 	registerGETAndHEAD(r, "/archive/:page_id/:timestamp/*resource_path", handler.ProxyResource)
 
 	// 直接资源访问（CSS 中引用的资源路径格式: /archive/resources/xx/yy/hash.ext）

--- a/server/internal/api/routes_test.go
+++ b/server/internal/api/routes_test.go
@@ -281,6 +281,33 @@ func TestRoutes_HEAD_ViewPageInvalidIDReturnsNoBody(t *testing.T) {
 	}
 }
 
+func TestRoutes_HEAD_ViewPageMarkdownInvalidIDReturnsNoBody(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/view/not-a-number/md", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if bodyLen := w.Body.Len(); bodyLen != 0 {
+		t.Fatalf("HEAD /view/not-a-number/md body length = %d, want 0", bodyLen)
+	}
+}
+
+func TestRoutes_APIPageContentRouteRemoved(t *testing.T) {
+	r := setupAuthRouter(&config.AuthConfig{Password: ""}, &config.ServerConfig{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/pages/123/content", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected removed route to return 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func containsSubstring(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
 }

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"wayback/internal/models"
+	"wayback/internal/storage"
 )
 
 // generateNonce 生成随机 CSP nonce（128 位，base64 编码）
@@ -117,6 +118,36 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	c.Header("Content-Security-Policy", fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';", nonce))
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(modifiedHTML))
+}
+
+// ViewPageMarkdown 返回归档页面正文的 Markdown 格式（精简版，方便 AI 读取）
+func (h *Handler) ViewPageMarkdown(c *gin.Context) {
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+
+	page, err := h.db.GetPageByID(strconv.FormatInt(pageID, 10))
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Database error")
+		return
+	}
+	if page == nil {
+		c.String(http.StatusNotFound, "Page not found")
+		return
+	}
+
+	htmlPath := filepath.Join(h.dataDir, page.HTMLPath)
+	htmlContent, err := os.ReadFile(htmlPath)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Failed to read HTML file")
+		return
+	}
+
+	markdown := storage.ExtractMarkdown(string(htmlContent))
+
+	c.Header("Content-Type", "text/markdown; charset=utf-8")
+	c.String(http.StatusOK, markdown)
 }
 
 // ProxyResource 代理资源请求

--- a/server/internal/api/view_page_handler_test.go
+++ b/server/internal/api/view_page_handler_test.go
@@ -3,7 +3,12 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -12,6 +17,7 @@ func setupViewRouter(handler *Handler) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.GET("/view/:id", handler.ViewPage)
+	r.GET("/view/:id/md", handler.ViewPageMarkdown)
 	return r
 }
 
@@ -42,5 +48,60 @@ func TestViewPage_DatabaseErrorReturnsInternalServerError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500 for database error, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestViewPageMarkdown_InvalidID(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+
+	router := setupViewRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/view/not-a-number/md", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid page id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestViewPageMarkdown_ReturnsMarkdown(t *testing.T) {
+	handler, cleanup := setupTestHandler(t)
+	defer cleanup()
+
+	htmlPath := "html/test/view-markdown.html"
+	fullPath := filepath.Join(handler.dataDir, htmlPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte("<html><body><h1>Saved Title</h1><p>Hello <strong>Markdown</strong>.</p></body></html>"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	pageID, err := handler.db.CreatePage(
+		"https://view-markdown-test.example.com/page",
+		"View Markdown",
+		htmlPath,
+		strings.Repeat("c", 64),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	defer handler.db.DeletePage(pageID)
+
+	router := setupViewRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/view/"+strconv.FormatInt(pageID, 10)+"/md", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/markdown; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/markdown; charset=utf-8", got)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "# Saved Title") || !strings.Contains(body, "**Markdown**") {
+		t.Fatalf("unexpected markdown body:\n%s", body)
 	}
 }

--- a/server/internal/storage/markdown_extractor.go
+++ b/server/internal/storage/markdown_extractor.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"regexp"
 	"strings"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/commonmark"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/strikethrough"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/table"
+	"golang.org/x/net/html"
 )
 
 var (
@@ -25,8 +27,7 @@ var (
 
 // ExtractMarkdown 从 HTML 中提取正文内容并转换为 Markdown 格式
 func ExtractMarkdown(htmlContent string) string {
-	// 先移除非正文标签内容，减少噪音
-	htmlContent = removeNonContentTags(htmlContent)
+	htmlContent = selectMarkdownHTML(htmlContent)
 
 	markdown, err := mdConverter.ConvertString(htmlContent)
 	if err != nil {
@@ -38,13 +39,167 @@ func ExtractMarkdown(htmlContent string) string {
 	return strings.TrimSpace(markdown) + "\n"
 }
 
-// removeNonContentTags 移除非正文 HTML 标签及其内容
-func removeNonContentTags(html string) string {
-	for _, tag := range []string{"script", "style", "noscript", "svg", "nav", "footer", "iframe", "object", "embed"} {
-		re := regexp.MustCompile(`(?is)<` + tag + `\b[^>]*>.*?</` + tag + `>`)
-		html = re.ReplaceAllString(html, "")
-		re2 := regexp.MustCompile(`(?i)<` + tag + `\b[^>]*/?>`)
-		html = re2.ReplaceAllString(html, "")
+func selectMarkdownHTML(htmlContent string) string {
+	doc, err := html.Parse(strings.NewReader(htmlContent))
+	if err != nil {
+		return removeNonContentTags(htmlContent)
 	}
-	return html
+
+	removeNonContentNodes(doc)
+
+	if selected := largestNodeByTag(doc, "article"); selected != nil {
+		return renderHTMLNode(selected)
+	}
+	if selected := largestNodeByTag(doc, "main"); selected != nil {
+		return renderHTMLNode(selected)
+	}
+	if selected := largestNodeByRole(doc, "main"); selected != nil {
+		return renderHTMLNode(selected)
+	}
+	if selected := firstNodeByTag(doc, "body"); selected != nil {
+		return renderHTMLNode(selected)
+	}
+
+	return renderHTMLNode(doc)
+}
+
+func removeNonContentTags(htmlContent string) string {
+	for tag := range nonContentTags {
+		re := regexp.MustCompile(`(?is)<` + tag + `\b[^>]*>.*?</` + tag + `>`)
+		htmlContent = re.ReplaceAllString(htmlContent, "")
+		re2 := regexp.MustCompile(`(?i)<` + tag + `\b[^>]*/?>`)
+		htmlContent = re2.ReplaceAllString(htmlContent, "")
+	}
+	return htmlContent
+}
+
+var nonContentTags = map[string]struct{}{
+	"script":   {},
+	"style":    {},
+	"noscript": {},
+	"svg":      {},
+	"nav":      {},
+	"footer":   {},
+	"iframe":   {},
+	"object":   {},
+	"embed":    {},
+	"template": {},
+	"form":     {},
+	"button":   {},
+	"input":    {},
+	"select":   {},
+	"textarea": {},
+}
+
+func removeNonContentNodes(n *html.Node) {
+	for child := n.FirstChild; child != nil; {
+		next := child.NextSibling
+		if shouldRemoveMarkdownNode(child) {
+			n.RemoveChild(child)
+		} else {
+			removeNonContentNodes(child)
+		}
+		child = next
+	}
+}
+
+func shouldRemoveMarkdownNode(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+	if _, ok := nonContentTags[strings.ToLower(n.Data)]; ok {
+		return true
+	}
+	for _, attr := range n.Attr {
+		key := strings.ToLower(attr.Key)
+		value := strings.ToLower(strings.TrimSpace(attr.Val))
+		if key == "hidden" {
+			return true
+		}
+		if key == "aria-hidden" && value == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func largestNodeByTag(root *html.Node, tag string) *html.Node {
+	return largestMatchingNode(root, func(n *html.Node) bool {
+		return n.Type == html.ElementNode && strings.EqualFold(n.Data, tag)
+	})
+}
+
+func largestNodeByRole(root *html.Node, role string) *html.Node {
+	return largestMatchingNode(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+		for _, attr := range n.Attr {
+			if strings.EqualFold(attr.Key, "role") && strings.EqualFold(strings.TrimSpace(attr.Val), role) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func largestMatchingNode(root *html.Node, match func(*html.Node) bool) *html.Node {
+	var selected *html.Node
+	var selectedLen int
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if match(n) {
+			if textLen := markdownTextLen(n); textLen > selectedLen {
+				selected = n
+				selectedLen = textLen
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(root)
+	return selected
+}
+
+func firstNodeByTag(root *html.Node, tag string) *html.Node {
+	var found *html.Node
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != nil {
+			return
+		}
+		if n.Type == html.ElementNode && strings.EqualFold(n.Data, tag) {
+			found = n
+			return
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(root)
+	return found
+}
+
+func markdownTextLen(n *html.Node) int {
+	var length int
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.TextNode {
+			length += len(strings.TrimSpace(node.Data))
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(n)
+	return length
+}
+
+func renderHTMLNode(n *html.Node) string {
+	var buf bytes.Buffer
+	if err := html.Render(&buf, n); err != nil {
+		return ""
+	}
+	return buf.String()
 }

--- a/server/internal/storage/markdown_extractor.go
+++ b/server/internal/storage/markdown_extractor.go
@@ -46,14 +46,9 @@ func selectMarkdownHTML(htmlContent string) string {
 	}
 
 	removeNonContentNodes(doc)
+	demoteLayoutTables(doc)
 
-	if selected := largestNodeByTag(doc, "article"); selected != nil {
-		return renderHTMLNode(selected)
-	}
-	if selected := largestNodeByTag(doc, "main"); selected != nil {
-		return renderHTMLNode(selected)
-	}
-	if selected := largestNodeByRole(doc, "main"); selected != nil {
+	if selected := bestMarkdownNode(doc); selected != nil {
 		return renderHTMLNode(selected)
 	}
 	if selected := firstNodeByTag(doc, "body"); selected != nil {
@@ -79,10 +74,12 @@ var nonContentTags = map[string]struct{}{
 	"noscript": {},
 	"svg":      {},
 	"nav":      {},
+	"aside":    {},
 	"footer":   {},
 	"iframe":   {},
 	"object":   {},
 	"embed":    {},
+	"canvas":   {},
 	"template": {},
 	"form":     {},
 	"button":   {},
@@ -119,39 +116,43 @@ func shouldRemoveMarkdownNode(n *html.Node) bool {
 		if key == "aria-hidden" && value == "true" {
 			return true
 		}
+		if key == "style" && isHiddenStyle(value) {
+			return true
+		}
+		if key == "type" && value == "hidden" {
+			return true
+		}
+		if key == "role" && isNonContentRole(value) {
+			return true
+		}
 	}
 	return false
 }
 
-func largestNodeByTag(root *html.Node, tag string) *html.Node {
-	return largestMatchingNode(root, func(n *html.Node) bool {
-		return n.Type == html.ElementNode && strings.EqualFold(n.Data, tag)
-	})
+func isHiddenStyle(style string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(style), " ", "")
+	return strings.Contains(normalized, "display:none") ||
+		strings.Contains(normalized, "visibility:hidden")
 }
 
-func largestNodeByRole(root *html.Node, role string) *html.Node {
-	return largestMatchingNode(root, func(n *html.Node) bool {
-		if n.Type != html.ElementNode {
-			return false
-		}
-		for _, attr := range n.Attr {
-			if strings.EqualFold(attr.Key, "role") && strings.EqualFold(strings.TrimSpace(attr.Val), role) {
-				return true
-			}
-		}
+func isNonContentRole(role string) bool {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "navigation", "banner", "complementary", "contentinfo", "search", "form", "dialog", "alert", "tooltip":
+		return true
+	default:
 		return false
-	})
+	}
 }
 
-func largestMatchingNode(root *html.Node, match func(*html.Node) bool) *html.Node {
+func bestMarkdownNode(root *html.Node) *html.Node {
 	var selected *html.Node
-	var selectedLen int
+	var selectedScore float64
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
-		if match(n) {
-			if textLen := markdownTextLen(n); textLen > selectedLen {
+		if isMarkdownCandidate(n) {
+			if score := markdownCandidateScore(n); score > selectedScore {
 				selected = n
-				selectedLen = textLen
+				selectedScore = score
 			}
 		}
 		for child := n.FirstChild; child != nil; child = child.NextSibling {
@@ -160,6 +161,204 @@ func largestMatchingNode(root *html.Node, match func(*html.Node) bool) *html.Nod
 	}
 	walk(root)
 	return selected
+}
+
+func isMarkdownCandidate(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+
+	tag := strings.ToLower(n.Data)
+	switch tag {
+	case "article", "main", "section", "div", "td", "body":
+		return true
+	}
+
+	return nodeRole(n) == "main" || containsAny(nodeClassID(n), positiveContentHints)
+}
+
+type markdownMetrics struct {
+	textLen          int
+	linkTextLen      int
+	blockTextLen     int
+	blockCount       int
+	headingCount     int
+	formControlCount int
+}
+
+func markdownCandidateScore(n *html.Node) float64 {
+	metrics := collectMarkdownMetrics(n)
+	if metrics.textLen < 80 && !isStrongMarkdownCandidate(n) && !strings.EqualFold(n.Data, "body") {
+		return 0
+	}
+
+	score := float64(metrics.textLen) +
+		float64(metrics.blockTextLen)*0.8 +
+		float64(metrics.blockCount)*80 +
+		float64(metrics.headingCount)*160
+
+	switch strings.ToLower(n.Data) {
+	case "article":
+		score += 900
+		score *= 1.8
+	case "main":
+		score += 700
+	case "section":
+		score += 180
+	case "body":
+		score *= 0.35
+	}
+
+	if nodeRole(n) == "main" {
+		score += 650
+	}
+	if nodeID(n) == "main" {
+		score += 2000
+	}
+
+	classID := nodeClassID(n)
+	if containsAny(classID, positiveContentHints) {
+		score += 450
+	}
+	if containsAny(classID, negativeContentHints) {
+		score *= 0.35
+	}
+
+	if metrics.textLen > 0 && metrics.linkTextLen > 0 {
+		linkDensity := float64(metrics.linkTextLen) / float64(metrics.textLen)
+		if linkDensity > 0.2 {
+			score *= 1 - minFloat(linkDensity, 0.85)
+		}
+	}
+
+	if metrics.formControlCount > 0 {
+		score -= float64(metrics.formControlCount) * 300
+	}
+
+	return score
+}
+
+func isStrongMarkdownCandidate(n *html.Node) bool {
+	tag := strings.ToLower(n.Data)
+	return tag == "article" || tag == "main" || nodeRole(n) == "main"
+}
+
+func collectMarkdownMetrics(n *html.Node) markdownMetrics {
+	var metrics markdownMetrics
+	var walk func(*html.Node, bool, bool)
+	walk = func(node *html.Node, inLink, inBlock bool) {
+		if node.Type == html.ElementNode {
+			tag := strings.ToLower(node.Data)
+			if tag == "a" {
+				inLink = true
+			}
+			if isTextBlockTag(tag) {
+				inBlock = true
+				metrics.blockCount++
+			}
+			if isHeadingTag(tag) {
+				metrics.headingCount++
+			}
+			if isFormControlTag(tag) {
+				metrics.formControlCount++
+			}
+		}
+
+		if node.Type == html.TextNode {
+			textLen := len(strings.TrimSpace(node.Data))
+			metrics.textLen += textLen
+			if inLink {
+				metrics.linkTextLen += textLen
+			}
+			if inBlock {
+				metrics.blockTextLen += textLen
+			}
+		}
+
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child, inLink, inBlock)
+		}
+	}
+	walk(n, false, false)
+	return metrics
+}
+
+func isTextBlockTag(tag string) bool {
+	switch tag {
+	case "p", "li", "pre", "blockquote":
+		return true
+	default:
+		return false
+	}
+}
+
+func isHeadingTag(tag string) bool {
+	switch tag {
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		return true
+	default:
+		return false
+	}
+}
+
+func isFormControlTag(tag string) bool {
+	switch tag {
+	case "form", "button", "input", "select", "textarea":
+		return true
+	default:
+		return false
+	}
+}
+
+func demoteLayoutTables(n *html.Node) {
+	if n.Type == html.ElementNode && strings.EqualFold(n.Data, "table") && !isSemanticTable(n) {
+		n.Data = "div"
+		n.Attr = filterTableLayoutAttrs(n.Attr)
+	}
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		demoteLayoutTables(child)
+	}
+}
+
+func isSemanticTable(n *html.Node) bool {
+	role := nodeRole(n)
+	if role == "table" || role == "grid" {
+		return true
+	}
+	if containsAny(nodeClassID(n), []string{"data-table", "markdown-table", "table-data"}) {
+		return true
+	}
+
+	var found bool
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if found || node.Type != html.ElementNode {
+			return
+		}
+		switch strings.ToLower(node.Data) {
+		case "th", "thead", "caption":
+			found = true
+			return
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(n)
+	return found
+}
+
+func filterTableLayoutAttrs(attrs []html.Attribute) []html.Attribute {
+	filtered := attrs[:0]
+	for _, attr := range attrs {
+		switch strings.ToLower(attr.Key) {
+		case "cellpadding", "cellspacing", "border", "width", "height", "align", "valign":
+			continue
+		default:
+			filtered = append(filtered, attr)
+		}
+	}
+	return filtered
 }
 
 func firstNodeByTag(root *html.Node, tag string) *html.Node {
@@ -196,10 +395,110 @@ func markdownTextLen(n *html.Node) int {
 	return length
 }
 
+func nodeRole(n *html.Node) string {
+	for _, attr := range n.Attr {
+		if strings.EqualFold(attr.Key, "role") {
+			return strings.ToLower(strings.TrimSpace(attr.Val))
+		}
+	}
+	return ""
+}
+
+func nodeID(n *html.Node) string {
+	for _, attr := range n.Attr {
+		if strings.EqualFold(attr.Key, "id") {
+			return strings.ToLower(strings.TrimSpace(attr.Val))
+		}
+	}
+	return ""
+}
+
+func nodeClassID(n *html.Node) string {
+	var parts []string
+	for _, attr := range n.Attr {
+		if strings.EqualFold(attr.Key, "class") || strings.EqualFold(attr.Key, "id") {
+			parts = append(parts, strings.ToLower(attr.Val))
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func containsAny(value string, hints []string) bool {
+	if value == "" {
+		return false
+	}
+	for _, hint := range hints {
+		if strings.Contains(value, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func minFloat(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func renderHTMLNode(n *html.Node) string {
 	var buf bytes.Buffer
 	if err := html.Render(&buf, n); err != nil {
 		return ""
 	}
 	return buf.String()
+}
+
+var positiveContentHints = []string{
+	"article",
+	"content",
+	"main",
+	"post",
+	"entry",
+	"story",
+	"body",
+	"markdown",
+	"readme",
+	"document",
+	"docs",
+	"discussion",
+	"topic",
+}
+
+var negativeContentHints = []string{
+	"nav",
+	"navbar",
+	"menu",
+	"sidebar",
+	"aside",
+	"footer",
+	"header",
+	"toolbar",
+	"breadcrumb",
+	"pagination",
+	"pager",
+	"advert",
+	"ads",
+	"promo",
+	"sponsor",
+	"campaign",
+	"social",
+	"share",
+	"modal",
+	"popup",
+	"cookie",
+	"login",
+	"signin",
+	"signup",
+	"subscribe",
+	"comment-form",
+	"reply-box",
+	"search",
+	"topbar",
+	"rightbar",
+	"leftbar",
+	"bottom",
+	"related",
+	"recommend",
 }

--- a/server/internal/storage/markdown_extractor_test.go
+++ b/server/internal/storage/markdown_extractor_test.go
@@ -169,6 +169,41 @@ func TestExtractMarkdown_SkipFooter(t *testing.T) {
 	}
 }
 
+func TestExtractMarkdown_PrefersSemanticArticle(t *testing.T) {
+	html := `<html><body>
+		<header>Top navigation</header>
+		<main>
+			<aside>Related links</aside>
+			<article>
+				<h1>Article Title</h1>
+				<p>This is the saved article body.</p>
+			</article>
+		</main>
+	</body></html>`
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "# Article Title") || !strings.Contains(md, "saved article body") {
+		t.Errorf("Should keep article content, got:\n%s", md)
+	}
+	if strings.Contains(md, "Top navigation") || strings.Contains(md, "Related links") {
+		t.Errorf("Should skip page chrome around article, got:\n%s", md)
+	}
+}
+
+func TestExtractMarkdown_RemovesInteractiveChrome(t *testing.T) {
+	html := `<html><body>
+		<form><input value="search"><button>Search</button></form>
+		<template><p>Hidden template text</p></template>
+		<p>Readable fallback body.</p>
+	</body></html>`
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "Readable fallback body") {
+		t.Errorf("Should keep readable body, got:\n%s", md)
+	}
+	if strings.Contains(md, "Search") || strings.Contains(md, "Hidden template text") {
+		t.Errorf("Should skip interactive chrome, got:\n%s", md)
+	}
+}
+
 func TestExtractMarkdown_EmptyHTML(t *testing.T) {
 	md := ExtractMarkdown("")
 	if md != "\n" {

--- a/server/internal/storage/markdown_extractor_test.go
+++ b/server/internal/storage/markdown_extractor_test.go
@@ -189,6 +189,105 @@ func TestExtractMarkdown_PrefersSemanticArticle(t *testing.T) {
 	}
 }
 
+func TestExtractMarkdown_SelectsNonSemanticMainContent(t *testing.T) {
+	html := `<html><body>
+		<div id="Top"><a href="/">Home</a><a href="/settings">Settings</a></div>
+		<div id="Rightbar">
+			<p>Promoted product should not be selected as the page body.</p>
+			<p>Related link one. Related link two. Related link three.</p>
+		</div>
+		<div id="Main">
+			<h1>Thread Title</h1>
+			<div class="topic_content">
+				<p>This is the original post with enough text to be selected as readable content.</p>
+				<p>It should keep the main discussion and ignore sidebars around it.</p>
+			</div>
+			<div class="reply_content">A useful reply that is part of the captured discussion.</div>
+		</div>
+	</body></html>`
+
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "# Thread Title") || !strings.Contains(md, "useful reply") {
+		t.Errorf("Should keep non-semantic main content, got:\n%s", md)
+	}
+	if strings.Contains(md, "Promoted product") || strings.Contains(md, "Settings") {
+		t.Errorf("Should skip page chrome around non-semantic main content, got:\n%s", md)
+	}
+}
+
+func TestExtractMarkdown_RemovesHiddenStyleContent(t *testing.T) {
+	html := `<html><body>
+		<main>
+			<p>Visible article text.</p>
+			<div style="display: none"><p>Hidden promo text.</p></div>
+			<div style="visibility:hidden"><p>Invisible tracking text.</p></div>
+		</main>
+	</body></html>`
+
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "Visible article text") {
+		t.Errorf("Should keep visible text, got:\n%s", md)
+	}
+	if strings.Contains(md, "Hidden promo") || strings.Contains(md, "Invisible tracking") {
+		t.Errorf("Should skip hidden style content, got:\n%s", md)
+	}
+}
+
+func TestExtractMarkdown_KeepsOpacityZeroAnimatedContent(t *testing.T) {
+	html := `<html><body>
+		<main>
+			<h1>Animated Page</h1>
+			<div style="opacity: 0; transform: translateY(50px)">
+				<p>Content waiting for a scroll animation should still be readable.</p>
+			</div>
+		</main>
+	</body></html>`
+
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "scroll animation should still be readable") {
+		t.Errorf("Should keep opacity-zero animated content, got:\n%s", md)
+	}
+}
+
+func TestExtractMarkdown_DemotesLayoutTables(t *testing.T) {
+	html := `<html><body>
+		<main>
+			<h1>Discussion</h1>
+			<table cellpadding="0" cellspacing="0" border="0">
+				<tr>
+					<td><img src="/avatar.png" alt="Alice"></td>
+					<td><a href="/member/alice">Alice</a></td>
+					<td><div class="reply_content">This table is only used for layout.</div></td>
+				</tr>
+			</table>
+		</main>
+	</body></html>`
+
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "This table is only used for layout") {
+		t.Errorf("Should keep layout table text, got:\n%s", md)
+	}
+	if strings.Contains(md, "|") {
+		t.Errorf("Should not render layout table as Markdown table, got:\n%s", md)
+	}
+}
+
+func TestExtractMarkdown_KeepsSemanticTables(t *testing.T) {
+	html := `<html><body>
+		<main>
+			<table>
+				<thead><tr><th>Name</th><th>Score</th></tr></thead>
+				<tbody><tr><td>Alice</td><td>10</td></tr></tbody>
+			</table>
+		</main>
+	</body></html>`
+
+	md := ExtractMarkdown(html)
+	if !strings.Contains(md, "|") || !strings.Contains(md, "Alice") {
+		t.Errorf("Should keep semantic table markdown, got:\n%s", md)
+	}
+}
+
 func TestExtractMarkdown_RemovesInteractiveChrome(t *testing.T) {
 	html := `<html><body>
 		<form><input value="search"><button>Search</button></form>

--- a/skill.md
+++ b/skill.md
@@ -131,7 +131,7 @@ curl "http://localhost:8080/api/pages/$PAGE_ID"
 Returns the page body as clean Markdown (strips scripts, nav, footer, etc.). Ideal for AI/LLM consumption.
 
 ```bash
-curl "http://localhost:8080/api/pages/$PAGE_ID/content"
+curl "http://localhost:8080/view/$PAGE_ID/md"
 ```
 
 #### Get Timeline for URL


### PR DESCRIPTION
## Summary
- expose archived page Markdown at /view/:id/md
- remove the old /api/pages/:id/content route without compatibility fallback
- update route tests and docs/skill references

## Tests
- make test