### PR TITLE
Add public snapshot sharing

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -199,6 +199,9 @@ export https_proxy=http://127.0.0.1:7897
 | `PUT` | `/api/archive/:id` | 更新已有归档快照 |
 | `GET` | `/api/pages?limit=50&offset=0` | 分页列出归档页面 |
 | `GET` | `/api/pages/:id` | 获取页面详情 |
+| `POST` | `/api/pages/:id/shares` | 创建公开分享链接（需要鉴权） |
+| `GET` | `/api/pages/:id/shares` | 列出页面的分享记录（不返回 token 明文） |
+| `DELETE` | `/api/shares/:id` | 撤销公开分享 |
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | 按 URL、标题或正文分页搜索 |
 | `GET` | `/api/pages/timeline?url=URL` | 获取同一 URL 的所有快照（时间线视图） |
 | `GET` | `/api/logs` | 列出可用日志文件 |
@@ -206,6 +209,8 @@ export https_proxy=http://127.0.0.1:7897
 | `GET` | `/api/logs/:filename` | 获取日志文件内容（支持 `?tail=N&grep=关键词`） |
 | `GET` | `/view/:id` | 还原归档页面 |
 | `GET` | `/view/:id/md` | 获取归档页面正文的 Markdown 格式（方便 AI/LLM 读取） |
+| `GET` | `/share/:token` | 无鉴权访问特定公开快照 |
+| `GET` | `/share/:token/md` | 无鉴权访问公开快照 Markdown |
 | `GET` | `/timeline?url=URL` | URL 时间线可视化页面 |
 | `GET` | `/logs` | 服务器日志查看器 |
 
@@ -219,6 +224,10 @@ export https_proxy=http://127.0.0.1:7897
 
 请求体与 POST 相同。接口会在接受更新请求后立即返回；若内容有变化，资源重新处理和最终快照替换会在后台继续执行。替换成功后，旧 HTML 进入延迟删除队列。返回 `{ status, page_id, action }`，`action` 为 `updated` 或 `unchanged`。
 请求体中的 `url` 必须与 `:id` 对应的现有页面 URL 完全一致；否则服务端会返回 HTTP `400`，避免把一个页面的快照写进另一个页面记录中。
+
+### 公开分享
+
+`POST /api/pages/:id/shares` 会为当前快照创建不可枚举公开 token，返回 `{ token, snapshot_url, markdown_url }`。公开入口不需要 Basic Auth，但只暴露该分享创建时固定的 HTML 文件和资源集合；后续页面更新不会改变已创建分享指向的特定快照。撤销分享后 `/share/:token` 和 `/share/:token/md` 返回 `404`。
 
 ## 项目结构
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 | `PUT` | `/api/archive/:id` | Update an existing archive snapshot |
 | `GET` | `/api/pages?limit=50&offset=0` | List archived pages with pagination |
 | `GET` | `/api/pages/:id` | Get page details |
+| `POST` | `/api/pages/:id/shares` | Create a public share link (authenticated) |
+| `GET` | `/api/pages/:id/shares` | List share records for a page (token plaintext is not returned) |
+| `DELETE` | `/api/shares/:id` | Revoke a public share |
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | Search pages by URL, title, or body text with pagination |
 | `GET` | `/api/pages/timeline?url=URL` | Get all snapshots of a URL (timeline view) |
 | `GET` | `/api/logs` | List available log files |
@@ -239,6 +242,8 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 | `GET` | `/api/logs/:filename` | Get log file content (supports `?tail=N&grep=keyword`) |
 | `GET` | `/view/:id` | Replay an archived page |
 | `GET` | `/view/:id/md` | Get archived page content as Markdown (for AI/LLM consumption) |
+| `GET` | `/share/:token` | Public unauthenticated access to a specific shared snapshot |
+| `GET` | `/share/:token/md` | Public unauthenticated access to shared snapshot Markdown |
 | `GET` | `/timeline?url=URL` | Visual timeline page for a URL |
 | `GET` | `/logs` | Server logs viewer |
 
@@ -252,6 +257,10 @@ The server tracks background create progress with `snapshot_state` (`pending`, `
 
 Accepts the same body as POST. Returns immediately once the server has accepted the update request. If the content changed, resource re-processing and the final snapshot swap continue in the background; old HTML is queued for delayed deletion after a successful swap. Returns `{ status, page_id, action }` where `action` is `updated` or `unchanged`.
 The request body `url` must exactly match the existing page URL for `:id`; otherwise the server rejects the update with HTTP `400` to prevent cross-page snapshot corruption.
+
+### Public Sharing
+
+`POST /api/pages/:id/shares` creates an unguessable public token for the current snapshot and returns `{ token, snapshot_url, markdown_url }`. Public share routes do not require Basic Auth, but they only expose the HTML file and resource set fixed at share creation time. Later page updates do not change the shared snapshot. Revoked shares return `404` from `/share/:token` and `/share/:token/md`.
 
 ## Project Structure
 

--- a/server/internal/api/patterns.go
+++ b/server/internal/api/patterns.go
@@ -26,7 +26,8 @@ var (
 	cssFontFaceRe = regexp.MustCompile(`@font-face\s*\{[^}]*\}`)
 
 	// Path patterns
-	archivePathRe = regexp.MustCompile(`/archive/resources/`)
+	archivePathRe      = regexp.MustCompile(`/archive/resources/`)
+	shareArchivePathRe = regexp.MustCompile(`/archive/[0-9]+/([^/]+)/`)
 
 	// Meta patterns
 	metaRefreshRe = regexp.MustCompile(`(?i)<meta[^>]*http-equiv=["']?refresh["']?[^>]*>`)

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -108,6 +108,12 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 	webFS, _ := fs.Sub(web.StaticFiles, ".")
 	registerGETAndHEAD(r, "/robots.txt", serveEmbeddedFile(webFS, "robots.txt"))
 
+	// 公开分享入口（必须在 Basic Auth 之前；分享 token 负责访问控制）
+	registerGETAndHEAD(r, "/share/:token", handler.ViewSharedPage)
+	registerGETAndHEAD(r, "/share/:token/md", handler.ViewSharedPageMarkdown)
+	registerGETAndHEAD(r, "/share/:token/archive/:timestamp/*resource_path", handler.ProxySharedResource)
+	registerGETAndHEAD(r, "/share/:token/resources/*filepath", handler.ServeSharedLocalResource)
+
 	// Basic Auth 中间件（如果启用）
 	if authCfg.Enabled() {
 		accounts := gin.Accounts{
@@ -155,7 +161,10 @@ func SetupRoutes(r *gin.Engine, handler *Handler, authCfg *config.AuthConfig, se
 		registerGETAndHEAD(api, "/pages", handler.ListPages)
 		registerGETAndHEAD(api, "/pages/timeline", handler.GetPageTimeline)
 		registerGETAndHEAD(api, "/pages/:id", handler.GetPage)
+		api.POST("/pages/:id/shares", handler.CreatePageShare)
+		registerGETAndHEAD(api, "/pages/:id/shares", handler.ListPageShares)
 		api.DELETE("/pages/:id", handler.DeletePage)
+		api.DELETE("/shares/:id", handler.RevokePageShare)
 		registerGETAndHEAD(api, "/search", handler.SearchPages)
 		registerGETAndHEAD(api, "/logs", handler.ListLogs)
 		registerGETAndHEAD(api, "/logs/latest", handler.GetLatestLog)

--- a/server/internal/api/share_handler.go
+++ b/server/internal/api/share_handler.go
@@ -166,6 +166,9 @@ func (h *Handler) RevokePageShare(c *gin.Context) {
 }
 
 func (h *Handler) getActiveShare(c *gin.Context) (*models.PageShare, string, bool) {
+	c.Header("Cache-Control", "no-store")
+	c.Header("X-Robots-Tag", "noindex, nofollow")
+
 	token := c.Param("token")
 	if token == "" {
 		c.String(http.StatusNotFound, "Share not found")
@@ -182,7 +185,6 @@ func (h *Handler) getActiveShare(c *gin.Context) (*models.PageShare, string, boo
 		return nil, "", false
 	}
 
-	c.Header("X-Robots-Tag", "noindex, nofollow")
 	return share, token, true
 }
 
@@ -270,7 +272,7 @@ func (h *Handler) ProxySharedResource(c *gin.Context) {
 	}
 
 	if resource.ResourceType == "css" {
-		h.serveRewrittenCSSWithResolver(c, resource, "/share/"+url.PathEscape(c.Param("token"))+"/", func(resourceURL string) (string, bool) {
+		h.serveRewrittenCSSWithResolverAndCache(c, resource, "/share/"+url.PathEscape(c.Param("token"))+"/", "no-store", func(resourceURL string) (string, bool) {
 			cssResource, findErr := h.findResourceForShare(resourceURL, share.TokenHash)
 			if findErr != nil {
 				log.Printf("[Share] Failed to resolve CSS sub-resource %s: %v", resourceURL, findErr)
@@ -320,13 +322,13 @@ func (h *Handler) serveSharedLocalResource(c *gin.Context, share *models.PageSha
 		c.String(http.StatusForbidden, "Invalid resource path")
 		return
 	}
-	serveFileStreaming(c, safePath)
+	serveFileStreamingWithCacheControl(c, safePath, "no-store")
 }
 
 func (h *Handler) serveResourceFile(c *gin.Context, resource *models.Resource) {
 	filePath := filepath.Join(h.dataDir, resource.FilePath)
 	c.Header("Content-Type", detectContentType(resource))
-	c.Header("Cache-Control", "public, max-age=31536000")
+	c.Header("Cache-Control", "no-store")
 
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -351,7 +353,7 @@ func (h *Handler) serveSharedArchivedHTMLResource(c *gin.Context, resource *mode
 	sanitized := sanitizeArchivedHTML(string(htmlContent))
 	sanitized = rewriteHTMLForShare(sanitized, token)
 	c.Header("Content-Type", "text/html; charset=utf-8")
-	c.Header("Cache-Control", "public, max-age=31536000")
+	c.Header("Cache-Control", "no-store")
 	c.Header("Content-Security-Policy", "default-src 'self'; script-src 'none'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';")
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(sanitized))
 }

--- a/server/internal/api/share_handler.go
+++ b/server/internal/api/share_handler.go
@@ -1,0 +1,485 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"wayback/internal/models"
+	"wayback/internal/storage"
+)
+
+const shareTokenBytes = 32
+
+func generateShareToken() (string, error) {
+	b := make([]byte, shareTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "wbs_" + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func hashShareToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func sharePath(token string) string {
+	return "/share/" + url.PathEscape(token)
+}
+
+func shareMarkdownPath(token string) string {
+	return sharePath(token) + "/md"
+}
+
+func shareResponseFromModel(share *models.PageShare, token string) models.ShareResponse {
+	resp := models.ShareResponse{
+		Status:     "success",
+		ID:         share.ID,
+		Token:      token,
+		PageID:     share.PageID,
+		URL:        share.URL,
+		Title:      share.Title,
+		CapturedAt: share.CapturedAt,
+		CreatedAt:  share.CreatedAt,
+		ExpiresAt:  share.ExpiresAt,
+	}
+	if token != "" {
+		resp.SnapshotURL = sharePath(token)
+		if share.AllowMarkdown {
+			resp.MarkdownURL = shareMarkdownPath(token)
+		}
+	}
+	return resp
+}
+
+func (h *Handler) CreatePageShare(c *gin.Context) {
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+
+	var req models.CreateShareRequest
+	if c.Request.Body != nil && c.Request.ContentLength != 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+	}
+	if req.ExpiresAt != nil && !req.ExpiresAt.After(time.Now()) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "expires_at must be in the future"})
+		return
+	}
+	allowMarkdown := true
+	if req.AllowMarkdown != nil {
+		allowMarkdown = *req.AllowMarkdown
+	}
+
+	page, err := h.db.GetPageByID(strconv.FormatInt(pageID, 10))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if page == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "page not found"})
+		return
+	}
+	if page.SnapshotState != "" && page.SnapshotState != models.SnapshotStateReady {
+		c.JSON(http.StatusConflict, gin.H{"error": "snapshot is not ready"})
+		return
+	}
+
+	resources, err := h.db.GetResourcesByPageID(pageID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resourceIDs := make([]int64, 0, len(resources))
+	for _, resource := range resources {
+		resourceIDs = append(resourceIDs, resource.ID)
+	}
+
+	var token string
+	var share *models.PageShare
+	for attempt := 0; attempt < 3; attempt++ {
+		token, err = generateShareToken()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate share token"})
+			return
+		}
+		share, err = h.db.CreatePageShare(hashShareToken(token), page, resourceIDs, req.ExpiresAt, allowMarkdown)
+		if err == nil {
+			c.JSON(http.StatusCreated, shareResponseFromModel(share, token))
+			return
+		}
+		if !strings.Contains(strings.ToLower(err.Error()), "unique") {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create unique share token"})
+}
+
+func (h *Handler) ListPageShares(c *gin.Context) {
+	pageID, ok := parsePageIDParam(c)
+	if !ok {
+		return
+	}
+
+	shares, err := h.db.ListPageShares(pageID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	responses := make([]models.ShareResponse, 0, len(shares))
+	for i := range shares {
+		responses = append(responses, shareResponseFromModel(&shares[i], ""))
+	}
+	c.JSON(http.StatusOK, gin.H{"shares": responses})
+}
+
+func (h *Handler) RevokePageShare(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid share id"})
+		return
+	}
+
+	if err := h.db.RevokePageShare(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "success"})
+}
+
+func (h *Handler) getActiveShare(c *gin.Context) (*models.PageShare, string, bool) {
+	token := c.Param("token")
+	if token == "" {
+		c.String(http.StatusNotFound, "Share not found")
+		return nil, "", false
+	}
+
+	share, err := h.db.GetActivePageShareByTokenHash(hashShareToken(token))
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Database error")
+		return nil, "", false
+	}
+	if share == nil {
+		c.String(http.StatusNotFound, "Share not found")
+		return nil, "", false
+	}
+
+	c.Header("X-Robots-Tag", "noindex, nofollow")
+	return share, token, true
+}
+
+func (h *Handler) ViewSharedPage(c *gin.Context) {
+	share, token, ok := h.getActiveShare(c)
+	if !ok {
+		return
+	}
+
+	htmlPath := filepath.Join(h.dataDir, share.HTMLPath)
+	htmlContent, err := os.ReadFile(htmlPath)
+	if err != nil {
+		c.String(http.StatusNotFound, "Snapshot file not found")
+		return
+	}
+
+	modifiedHTML := sanitizeArchivedHTML(string(htmlContent))
+	modifiedHTML = rewriteHTMLForShare(modifiedHTML, token)
+
+	nonce := generateNonce()
+	modifiedHTML = injectPublicShareHeader(modifiedHTML, share, token, nonce)
+
+	c.Header("X-Frame-Options", "SAMEORIGIN")
+	c.Header("Referrer-Policy", "no-referrer")
+	c.Header("Content-Security-Policy", fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';", nonce))
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(modifiedHTML))
+}
+
+func (h *Handler) ViewSharedPageMarkdown(c *gin.Context) {
+	share, _, ok := h.getActiveShare(c)
+	if !ok {
+		return
+	}
+	if !share.AllowMarkdown {
+		c.String(http.StatusNotFound, "Share not found")
+		return
+	}
+
+	htmlPath := filepath.Join(h.dataDir, share.HTMLPath)
+	htmlContent, err := os.ReadFile(htmlPath)
+	if err != nil {
+		c.String(http.StatusNotFound, "Snapshot file not found")
+		return
+	}
+
+	markdown := storage.ExtractMarkdown(string(htmlContent))
+	c.Header("Content-Type", "text/markdown; charset=utf-8")
+	c.String(http.StatusOK, markdown)
+}
+
+func (h *Handler) ProxySharedResource(c *gin.Context) {
+	share, _, ok := h.getActiveShare(c)
+	if !ok {
+		return
+	}
+
+	timestamp := c.Param("timestamp")
+	rawPath := c.Request.URL.RawPath
+	if rawPath == "" {
+		rawPath = c.Request.URL.Path
+	}
+
+	prefix := fmt.Sprintf("/share/%s/archive/%s/", c.Param("token"), timestamp)
+	originalURL := strings.TrimPrefix(rawPath, prefix)
+	if c.Request.URL.RawQuery != "" {
+		originalURL = originalURL + "?" + c.Request.URL.RawQuery
+	}
+
+	if strings.HasPrefix(originalURL, "resources/") {
+		resourcePath := strings.TrimPrefix(originalURL, "resources/")
+		h.serveSharedLocalResource(c, share, resourcePath)
+		return
+	}
+
+	resource, err := h.findResourceForShare(originalURL, share.TokenHash)
+	if err != nil {
+		log.Printf("[Share] Database error: %v", err)
+		c.String(http.StatusInternalServerError, "Database error")
+		return
+	}
+	if resource == nil {
+		log.Printf("[Share] Resource not found: %s", originalURL)
+		c.String(http.StatusNotFound, "Resource not found")
+		return
+	}
+
+	if resource.ResourceType == "css" {
+		h.serveRewrittenCSSWithResolver(c, resource, "/share/"+url.PathEscape(c.Param("token"))+"/", func(resourceURL string) (string, bool) {
+			cssResource, findErr := h.findResourceForShare(resourceURL, share.TokenHash)
+			if findErr != nil {
+				log.Printf("[Share] Failed to resolve CSS sub-resource %s: %v", resourceURL, findErr)
+				return "", false
+			}
+			if cssResource == nil {
+				return "", false
+			}
+			return cssResource.FilePath, true
+		})
+		return
+	}
+	if h.shouldServeArchivedHTML(c, resource) {
+		h.serveSharedArchivedHTMLResource(c, resource, c.Param("token"))
+		return
+	}
+
+	h.serveResourceFile(c, resource)
+}
+
+func (h *Handler) ServeSharedLocalResource(c *gin.Context) {
+	share, _, ok := h.getActiveShare(c)
+	if !ok {
+		return
+	}
+
+	resourcePath := strings.TrimPrefix(c.Param("filepath"), "/")
+	h.serveSharedLocalResource(c, share, resourcePath)
+}
+
+func (h *Handler) serveSharedLocalResource(c *gin.Context, share *models.PageShare, resourcePath string) {
+	resourcePath = strings.TrimPrefix(resourcePath, "/")
+	resource, err := h.db.GetShareResourceByFilePath(share.TokenHash, "resources/"+resourcePath)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Database error")
+		return
+	}
+	if resource == nil {
+		c.String(http.StatusNotFound, "Resource not found")
+		return
+	}
+
+	resourcesDir := filepath.Join(h.dataDir, "resources")
+	safePath, err := validateResourcePath(resourcesDir, resourcePath)
+	if err != nil {
+		log.Printf("[Share] Path validation failed for %s: %v", resourcePath, err)
+		c.String(http.StatusForbidden, "Invalid resource path")
+		return
+	}
+	serveFileStreaming(c, safePath)
+}
+
+func (h *Handler) serveResourceFile(c *gin.Context, resource *models.Resource) {
+	filePath := filepath.Join(h.dataDir, resource.FilePath)
+	c.Header("Content-Type", detectContentType(resource))
+	c.Header("Cache-Control", "public, max-age=31536000")
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		log.Printf("[Share] Failed to read file %s: %v", filePath, err)
+		c.String(http.StatusInternalServerError, "Failed to read file")
+		return
+	}
+	defer f.Close()
+	stat, _ := f.Stat()
+	http.ServeContent(c.Writer, c.Request, filepath.Base(filePath), stat.ModTime(), f)
+}
+
+func (h *Handler) serveSharedArchivedHTMLResource(c *gin.Context, resource *models.Resource, token string) {
+	filePath := filepath.Join(h.dataDir, resource.FilePath)
+	htmlContent, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Printf("[Share] Failed to read HTML file %s: %v", filePath, err)
+		c.String(http.StatusInternalServerError, "Failed to read file")
+		return
+	}
+
+	sanitized := sanitizeArchivedHTML(string(htmlContent))
+	sanitized = rewriteHTMLForShare(sanitized, token)
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	c.Header("Cache-Control", "public, max-age=31536000")
+	c.Header("Content-Security-Policy", "default-src 'self'; script-src 'none'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';")
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(sanitized))
+}
+
+func (h *Handler) findResourceForShare(originalURL, tokenHash string) (*models.Resource, error) {
+	resource, err := h.db.GetShareResourceByURL(tokenHash, originalURL)
+	if err != nil || resource != nil {
+		return resource, err
+	}
+
+	parsed, parseErr := url.Parse(originalURL)
+	if parseErr == nil {
+		encoded := parsed.String()
+		if encoded != originalURL {
+			resource, err = h.db.GetShareResourceByURL(tokenHash, encoded)
+			if err != nil || resource != nil {
+				return resource, err
+			}
+		}
+	}
+
+	encodedURL := strings.ReplaceAll(originalURL, " ", "%20")
+	if encodedURL != originalURL {
+		resource, err = h.db.GetShareResourceByURL(tokenHash, encodedURL)
+		if err != nil || resource != nil {
+			return resource, err
+		}
+	}
+
+	resource, err = h.db.GetShareResourceByURLPrefix(tokenHash, originalURL)
+	if err != nil || resource != nil {
+		return resource, err
+	}
+
+	urlPath := originalURL
+	if idx := strings.IndexByte(urlPath, '?'); idx != -1 {
+		urlPath = urlPath[:idx]
+	}
+
+	return h.db.GetShareResourceByURLPath(tokenHash, urlPath)
+}
+
+func rewriteHTMLForShare(html, token string) string {
+	shareArchivePrefix := "/share/" + url.PathEscape(token) + "/archive/"
+	html = shareArchivePathRe.ReplaceAllString(html, shareArchivePrefix+"$1/")
+	html = strings.ReplaceAll(html, "/archive/resources/", "/share/"+url.PathEscape(token)+"/resources/")
+	return html
+}
+
+func injectPublicShareHeader(html string, share *models.PageShare, token, nonce string) string {
+	markdownLink := ""
+	if share.AllowMarkdown {
+		markdownLink = fmt.Sprintf(`<a href="%s" style="color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:4px;font-size:12px;background:rgba(255,255,255,0.1);white-space:nowrap;">Markdown</a>`, escapeHTML(shareMarkdownPath(token)))
+	}
+
+	archiveHeader := fmt.Sprintf(`
+<div id="wayback-archive-header" style="
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 48px;
+	background: linear-gradient(135deg, #334155 0%%, #0f766e 100%%);
+	color: white;
+	padding: 0 20px;
+	box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+	z-index: 999999;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	font-size: 13px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	overflow: hidden;
+">
+	<div style="display:flex;align-items:center;gap:12px;min-width:0;flex:1;overflow:hidden;">
+		<span style="background:rgba(255,255,255,0.2);padding:3px 10px;border-radius:4px;font-size:11px;font-weight:600;letter-spacing:0.5px;white-space:nowrap;">PUBLIC SNAPSHOT</span>
+		<a href="%s" style="color:white;text-decoration:none;font-family:monospace;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;opacity:0.95;" title="%s">%s</a>
+		<span style="font-size:11px;opacity:0.7;white-space:nowrap;">%s</span>
+	</div>
+	<div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">%s</div>
+</div>
+<style>
+	:root { --wayback-header-height: 48px; }
+	body { margin-top: var(--wayback-header-height) !important; padding-top: 0 !important; }
+	[style*="position: fixed"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position:fixed"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position: fixed"][style*="top:0"]:not(#wayback-archive-header),
+	[style*="position:fixed"][style*="top:0"]:not(#wayback-archive-header),
+	[style*="position: sticky"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position:sticky"][style*="top: 0"]:not(#wayback-archive-header),
+	[style*="position: sticky"][style*="top:0"]:not(#wayback-archive-header),
+	[style*="position:sticky"][style*="top:0"]:not(#wayback-archive-header) {
+		top: var(--wayback-header-height) !important;
+	}
+	html, body, #app, #root, #__next, #__nuxt {
+		height: auto !important;
+		min-height: 100%% !important;
+		overflow: visible !important;
+	}
+	* {
+		user-select: text !important;
+		-webkit-user-select: text !important;
+	}
+</style>
+<script nonce="%s">
+(function() {
+	'use strict';
+	document.querySelectorAll('.wayback-local-time').forEach(function(el) {
+		const isoTime = el.getAttribute('datetime');
+		if (!isoTime) return;
+		const date = new Date(isoTime);
+		if (Number.isNaN(date.getTime())) return;
+		el.textContent = date.toLocaleString('zh-CN', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit'
+		});
+	});
+})();
+</script>
+	`, escapeHTML(share.URL), escapeHTML(share.URL), escapeHTML(share.URL), archiveTimeElement(share.CapturedAt, "full"), markdownLink, nonce)
+
+	if bodyTagRe.MatchString(html) {
+		return bodyTagRe.ReplaceAllString(html, "$1"+archiveHeader)
+	}
+	return archiveHeader + html
+}

--- a/server/internal/api/share_handler_test.go
+++ b/server/internal/api/share_handler_test.go
@@ -1,0 +1,260 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"wayback/internal/config"
+	"wayback/internal/database"
+	"wayback/internal/models"
+	"wayback/internal/storage"
+)
+
+func setupSQLiteShareTestHandler(t *testing.T) (*Handler, func()) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "wayback.db")
+	db, err := database.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLite failed: %v", err)
+	}
+
+	dataDir := t.TempDir()
+	fs := storage.NewFileStorage(dataDir)
+	dedup := storage.NewDeduplicator(db, fs, config.ResourceConfig{
+		Workers:         2,
+		MetadataCacheMB: 16,
+		DownloadTimeout: 30,
+	})
+	handler := NewHandler(dedup, db, dataDir, nil)
+	cleanup := func() {
+		dedup.WaitForBackgroundTasks()
+		_ = db.Close()
+	}
+	return handler, cleanup
+}
+
+func setupShareRouter(handler *Handler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/api/pages/:id/shares", handler.CreatePageShare)
+	r.GET("/api/pages/:id/shares", handler.ListPageShares)
+	r.DELETE("/api/shares/:id", handler.RevokePageShare)
+	r.GET("/share/:token", handler.ViewSharedPage)
+	r.GET("/share/:token/md", handler.ViewSharedPageMarkdown)
+	r.GET("/share/:token/archive/:timestamp/*resource_path", handler.ProxySharedResource)
+	r.GET("/share/:token/resources/*filepath", handler.ServeSharedLocalResource)
+	return r
+}
+
+func writeShareTestFile(t *testing.T, baseDir, relPath, content string) {
+	t.Helper()
+	fullPath := filepath.Join(baseDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+}
+
+func createShareTestPage(t *testing.T, handler *Handler) int64 {
+	t.Helper()
+
+	htmlPath := "html/test/public-share.html"
+	writeShareTestFile(t, handler.dataDir, htmlPath, `<html><body><h1>Shared Title</h1><link rel="stylesheet" href="/archive/1/20260410120000mp_/https://cdn.example.com/app.css"><img src="/archive/1/20260410120000mp_/https://cdn.example.com/logo.png"></body></html>`)
+	writeShareTestFile(t, handler.dataDir, "resources/aa/bb/app.css", `.hero{background:url("../img/logo.png")}`)
+	writeShareTestFile(t, handler.dataDir, "resources/cc/dd/logo.img", "shared-image")
+	writeShareTestFile(t, handler.dataDir, "resources/ee/ff/private.img", "private-image")
+
+	pageID, err := handler.db.CreatePage(
+		"https://share-test.example.com/page",
+		"Share Test",
+		htmlPath,
+		strings.Repeat("a", 64),
+		time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	if err := handler.db.FinalizePageCreate(pageID, nil); err != nil {
+		t.Fatalf("FinalizePageCreate failed: %v", err)
+	}
+
+	cssID, err := handler.db.CreateResource("https://cdn.example.com/app.css", strings.Repeat("b", 64), "css", "resources/aa/bb/app.css", 32)
+	if err != nil {
+		t.Fatalf("CreateResource css failed: %v", err)
+	}
+	imgID, err := handler.db.CreateResource("https://cdn.example.com/img/logo.png", strings.Repeat("c", 64), "image", "resources/cc/dd/logo.img", 12)
+	if err != nil {
+		t.Fatalf("CreateResource image failed: %v", err)
+	}
+	privateID, err := handler.db.CreateResource("https://cdn.example.com/private.png", strings.Repeat("d", 64), "image", "resources/ee/ff/private.img", 13)
+	if err != nil {
+		t.Fatalf("CreateResource private failed: %v", err)
+	}
+	if err := handler.db.LinkPageResource(pageID, cssID); err != nil {
+		t.Fatalf("LinkPageResource css failed: %v", err)
+	}
+	if err := handler.db.LinkPageResource(pageID, imgID); err != nil {
+		t.Fatalf("LinkPageResource image failed: %v", err)
+	}
+	_ = privateID
+
+	return pageID
+}
+
+func createShareViaAPI(t *testing.T, router *gin.Engine, pageID int64) models.ShareResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/pages/"+strconv.FormatInt(pageID, 10)+"/shares", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create share status = %d, body: %s", w.Code, w.Body.String())
+	}
+	var resp models.ShareResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Unmarshal share response failed: %v", err)
+	}
+	if resp.Token == "" || resp.SnapshotURL == "" || resp.MarkdownURL == "" {
+		t.Fatalf("share response missing public URLs: %+v", resp)
+	}
+	return resp
+}
+
+func TestPublicShare_ViewMarkdownAndResources(t *testing.T) {
+	handler, cleanup := setupSQLiteShareTestHandler(t)
+	defer cleanup()
+
+	pageID := createShareTestPage(t, handler)
+	router := setupShareRouter(handler)
+	share := createShareViaAPI(t, router, pageID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, share.SnapshotURL, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("shared page status = %d, body: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "PUBLIC SNAPSHOT") {
+		t.Fatalf("shared page missing public header: %s", body)
+	}
+	if !strings.Contains(body, "/share/"+share.Token+"/archive/20260410120000mp_/https://cdn.example.com/app.css") {
+		t.Fatalf("archive resource URL was not rewritten to share path: %s", body)
+	}
+	if strings.Contains(body, `href="/"`) || strings.Contains(body, "/timeline?") {
+		t.Fatalf("public share should not expose private UI navigation: %s", body)
+	}
+	if got := w.Header().Get("X-Robots-Tag"); got != "noindex, nofollow" {
+		t.Fatalf("X-Robots-Tag = %q", got)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, share.MarkdownURL, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("markdown status = %d, body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "# Shared Title") {
+		t.Fatalf("unexpected markdown: %s", w.Body.String())
+	}
+
+	cssURL := "/share/" + share.Token + "/archive/20260410120000mp_/https://cdn.example.com/app.css"
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, cssURL, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("css status = %d, body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `/share/`+share.Token+`/resources/cc/dd/logo.img`) {
+		t.Fatalf("CSS subresource was not rewritten to share resource path: %s", w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/share/"+share.Token+"/resources/cc/dd/logo.img", nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || w.Body.String() != "shared-image" {
+		t.Fatalf("shared local resource status = %d body = %q", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/share/"+share.Token+"/resources/ee/ff/private.img", nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unshared local resource status = %d, want 404", w.Code)
+	}
+}
+
+func TestPublicShare_RevokeDisablesAccess(t *testing.T) {
+	handler, cleanup := setupSQLiteShareTestHandler(t)
+	defer cleanup()
+
+	pageID := createShareTestPage(t, handler)
+	router := setupShareRouter(handler)
+	share := createShareViaAPI(t, router, pageID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/shares/"+strconv.FormatInt(share.ID, 10), nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, share.SnapshotURL, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("revoked share status = %d, want 404", w.Code)
+	}
+}
+
+func TestPublicShare_BypassesBasicAuthButManagementDoesNot(t *testing.T) {
+	handler, cleanup := setupSQLiteShareTestHandler(t)
+	defer cleanup()
+
+	pageID := createShareTestPage(t, handler)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	SetupRoutes(router, handler, &config.AuthConfig{Password: "secret"}, &config.ServerConfig{}, "test", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/pages/"+strconv.FormatInt(pageID, 10)+"/shares", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("management API without auth status = %d, want 401", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/pages/"+strconv.FormatInt(pageID, 10)+"/shares", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth("wayback", "secret")
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("management API with auth status = %d, body: %s", w.Code, w.Body.String())
+	}
+	var share models.ShareResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &share); err != nil {
+		t.Fatalf("Unmarshal share response failed: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, share.SnapshotURL, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("public share without auth status = %d, body: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/api/share_handler_test.go
+++ b/server/internal/api/share_handler_test.go
@@ -161,6 +161,9 @@ func TestPublicShare_ViewMarkdownAndResources(t *testing.T) {
 	if got := w.Header().Get("X-Robots-Tag"); got != "noindex, nofollow" {
 		t.Fatalf("X-Robots-Tag = %q", got)
 	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("shared page Cache-Control = %q, want no-store", got)
+	}
 
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, share.MarkdownURL, nil)
@@ -170,6 +173,9 @@ func TestPublicShare_ViewMarkdownAndResources(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "# Shared Title") {
 		t.Fatalf("unexpected markdown: %s", w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("shared markdown Cache-Control = %q, want no-store", got)
 	}
 
 	cssURL := "/share/" + share.Token + "/archive/20260410120000mp_/https://cdn.example.com/app.css"
@@ -182,12 +188,18 @@ func TestPublicShare_ViewMarkdownAndResources(t *testing.T) {
 	if !strings.Contains(w.Body.String(), `/share/`+share.Token+`/resources/cc/dd/logo.img`) {
 		t.Fatalf("CSS subresource was not rewritten to share resource path: %s", w.Body.String())
 	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("shared css Cache-Control = %q, want no-store", got)
+	}
 
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/share/"+share.Token+"/resources/cc/dd/logo.img", nil)
 	router.ServeHTTP(w, req)
 	if w.Code != http.StatusOK || w.Body.String() != "shared-image" {
 		t.Fatalf("shared local resource status = %d body = %q", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("shared local resource Cache-Control = %q, want no-store", got)
 	}
 
 	w = httptest.NewRecorder()

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -243,15 +243,7 @@ func (h *Handler) ProxyResource(c *gin.Context) {
 }
 
 func (h *Handler) serveRewrittenCSS(c *gin.Context, pageID int64, resource *models.Resource) {
-	filePath := filepath.Join(h.dataDir, resource.FilePath)
-	cssContent, err := os.ReadFile(filePath)
-	if err != nil {
-		log.Printf("[Proxy] Failed to read CSS file %s: %v", filePath, err)
-		c.String(http.StatusInternalServerError, "Failed to read file")
-		return
-	}
-
-	rewritten := rewriteCSSForPage(h.cssParser(), string(cssContent), resource.URL, func(resourceURL string) (string, bool) {
+	h.serveRewrittenCSSWithResolver(c, resource, "/archive/", func(resourceURL string) (string, bool) {
 		cssResource, findErr := h.findResourceForPageOnly(resourceURL, pageID)
 		if findErr != nil {
 			log.Printf("[Proxy] Failed to resolve CSS sub-resource %s: %v", resourceURL, findErr)
@@ -262,6 +254,18 @@ func (h *Handler) serveRewrittenCSS(c *gin.Context, pageID int64, resource *mode
 		}
 		return cssResource.FilePath, true
 	})
+}
+
+func (h *Handler) serveRewrittenCSSWithResolver(c *gin.Context, resource *models.Resource, urlPrefix string, resolveFilePath func(string) (string, bool)) {
+	filePath := filepath.Join(h.dataDir, resource.FilePath)
+	cssContent, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Printf("[Proxy] Failed to read CSS file %s: %v", filePath, err)
+		c.String(http.StatusInternalServerError, "Failed to read file")
+		return
+	}
+
+	rewritten := rewriteCSSForPageWithPrefix(h.cssParser(), string(cssContent), resource.URL, urlPrefix, resolveFilePath)
 
 	c.Header("Content-Type", "text/css; charset=utf-8")
 	c.Header("Cache-Control", "public, max-age=31536000")
@@ -394,6 +398,13 @@ func rewriteCSSForPage(parser interface {
 	ExtractResources(string) []string
 	RewriteCSS(string, map[string]string) string
 }, cssContent, cssURL string, resolveFilePath func(string) (string, bool)) string {
+	return rewriteCSSForPageWithPrefix(parser, cssContent, cssURL, "/archive/", resolveFilePath)
+}
+
+func rewriteCSSForPageWithPrefix(parser interface {
+	ExtractResources(string) []string
+	RewriteCSS(string, map[string]string) string
+}, cssContent, cssURL, urlPrefix string, resolveFilePath func(string) (string, bool)) string {
 	cssResources := parser.ExtractResources(cssContent)
 	if len(cssResources) == 0 {
 		return cssContent
@@ -414,6 +425,12 @@ func rewriteCSSForPage(parser interface {
 
 	if len(urlMapping) == 0 {
 		return cssContent
+	}
+
+	if prefixedParser, ok := parser.(interface {
+		RewriteCSSWithPrefix(string, map[string]string, string) string
+	}); ok {
+		return prefixedParser.RewriteCSSWithPrefix(cssContent, urlMapping, urlPrefix)
 	}
 
 	return parser.RewriteCSS(cssContent, urlMapping)

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -257,6 +257,10 @@ func (h *Handler) serveRewrittenCSS(c *gin.Context, pageID int64, resource *mode
 }
 
 func (h *Handler) serveRewrittenCSSWithResolver(c *gin.Context, resource *models.Resource, urlPrefix string, resolveFilePath func(string) (string, bool)) {
+	h.serveRewrittenCSSWithResolverAndCache(c, resource, urlPrefix, "public, max-age=31536000", resolveFilePath)
+}
+
+func (h *Handler) serveRewrittenCSSWithResolverAndCache(c *gin.Context, resource *models.Resource, urlPrefix, cacheControl string, resolveFilePath func(string) (string, bool)) {
 	filePath := filepath.Join(h.dataDir, resource.FilePath)
 	cssContent, err := os.ReadFile(filePath)
 	if err != nil {
@@ -268,7 +272,7 @@ func (h *Handler) serveRewrittenCSSWithResolver(c *gin.Context, resource *models
 	rewritten := rewriteCSSForPageWithPrefix(h.cssParser(), string(cssContent), resource.URL, urlPrefix, resolveFilePath)
 
 	c.Header("Content-Type", "text/css; charset=utf-8")
-	c.Header("Cache-Control", "public, max-age=31536000")
+	c.Header("Cache-Control", cacheControl)
 	c.Data(http.StatusOK, "text/css; charset=utf-8", []byte(rewritten))
 }
 
@@ -691,6 +695,10 @@ func (h *Handler) ServeLocalResource(c *gin.Context) {
 
 // serveFileStreaming 流式提供文件，避免将整个文件加载到内存
 func serveFileStreaming(c *gin.Context, filePath string) {
+	serveFileStreamingWithCacheControl(c, filePath, "public, max-age=31536000")
+}
+
+func serveFileStreamingWithCacheControl(c *gin.Context, filePath, cacheControl string) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		c.String(http.StatusNotFound, "Resource not found")
@@ -706,7 +714,7 @@ func serveFileStreaming(c *gin.Context, filePath string) {
 
 	contentType := detectContentTypeByPath(filePath)
 	c.Header("Content-Type", contentType)
-	c.Header("Cache-Control", "public, max-age=31536000")
+	c.Header("Cache-Control", cacheControl)
 	http.ServeContent(c.Writer, c.Request, filepath.Base(filePath), stat.ModTime(), f)
 }
 

--- a/server/internal/database/common.go
+++ b/server/internal/database/common.go
@@ -14,12 +14,18 @@ const pageSearchSelectColumns = pageSelectColumns + ", COALESCE(body_text, '')"
 
 const resourceSelectColumns = "id, url, content_hash, resource_type, file_path, file_size, first_seen, last_seen, is_quarantined, quarantine_reason"
 
+const shareSelectColumns = "id, token_hash, page_id, url, title, html_path, content_hash, captured_at, created_at, expires_at, revoked_at, allow_markdown"
+
 // pageScanner 定义可以扫描数据库行的接口
 type pageScanner interface {
 	Scan(dest ...any) error
 }
 
 type resourceScanner interface {
+	Scan(dest ...any) error
+}
+
+type shareScanner interface {
 	Scan(dest ...any) error
 }
 
@@ -44,6 +50,23 @@ func scanResource(scanner resourceScanner, resource *models.Resource) error {
 		&resource.LastSeen,
 		&resource.IsQuarantined,
 		&resource.QuarantineReason,
+	)
+}
+
+func scanShare(scanner shareScanner, share *models.PageShare) error {
+	return scanner.Scan(
+		&share.ID,
+		&share.TokenHash,
+		&share.PageID,
+		&share.URL,
+		&share.Title,
+		&share.HTMLPath,
+		&share.ContentHash,
+		&share.CapturedAt,
+		&share.CreatedAt,
+		&share.ExpiresAt,
+		&share.RevokedAt,
+		&share.AllowMarkdown,
 	)
 }
 

--- a/server/internal/database/interface.go
+++ b/server/internal/database/interface.go
@@ -52,4 +52,15 @@ type Database interface {
 	LinkPageResource(pageID, resourceID int64) error
 	LinkPageResources(pageID int64, resourceIDs []int64) error
 	DeletePageResources(pageID int64) error
+
+	// 公开分享
+	CreatePageShare(tokenHash string, page *models.Page, resourceIDs []int64, expiresAt *time.Time, allowMarkdown bool) (*models.PageShare, error)
+	GetActivePageShareByTokenHash(tokenHash string) (*models.PageShare, error)
+	ListPageShares(pageID int64) ([]models.PageShare, error)
+	RevokePageShare(id int64) error
+	GetShareResourceByURL(tokenHash, url string) (*models.Resource, error)
+	GetShareResourceByURLPrefix(tokenHash, urlPrefix string) (*models.Resource, error)
+	GetShareResourceByURLPath(tokenHash, urlPath string) (*models.Resource, error)
+	GetShareResourceByFilePath(tokenHash, filePath string) (*models.Resource, error)
+	HasActiveShareForHTMLPath(htmlPath string) (bool, error)
 }

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -85,6 +85,9 @@ func (db *PostgresDB) ensurePostgresMigrations() error {
 		if err := db.ensureResourceQuarantineColumns(); err != nil {
 			return fmt.Errorf("failed to ensure resource quarantine columns: %w", err)
 		}
+		if err := db.ensurePageShareTables(); err != nil {
+			return fmt.Errorf("failed to ensure page share tables: %w", err)
+		}
 		searchTextTrigramReady, err := db.ensureSearchIndexes()
 		if err != nil {
 			return fmt.Errorf("failed to ensure search indexes: %w", err)
@@ -341,6 +344,34 @@ func (db *PostgresDB) ensureResourceQuarantineColumns() error {
 		return err
 	}
 	return nil
+}
+
+func (db *PostgresDB) ensurePageShareTables() error {
+	_, err := db.conn.Exec(`
+CREATE TABLE IF NOT EXISTS page_shares (
+    id BIGSERIAL PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    page_id BIGINT REFERENCES pages(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    title TEXT,
+    html_path TEXT NOT NULL,
+    content_hash CHAR(64),
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE,
+    revoked_at TIMESTAMP WITH TIME ZONE,
+    allow_markdown BOOLEAN NOT NULL DEFAULT TRUE
+);
+CREATE INDEX IF NOT EXISTS idx_page_shares_page ON page_shares(page_id);
+CREATE INDEX IF NOT EXISTS idx_page_shares_html_path ON page_shares(html_path);
+CREATE TABLE IF NOT EXISTS page_share_resources (
+    token_hash TEXT NOT NULL REFERENCES page_shares(token_hash) ON DELETE CASCADE,
+    resource_id BIGINT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    PRIMARY KEY (token_hash, resource_id)
+);
+CREATE INDEX IF NOT EXISTS idx_page_share_resources_resource ON page_share_resources(resource_id);
+`)
+	return err
 }
 
 func (db *PostgresDB) Close() error {
@@ -1130,4 +1161,170 @@ func (db *PostgresDB) DeletePage(id int64) error {
 	}
 
 	return tx.Commit()
+}
+
+func (db *PostgresDB) CreatePageShare(tokenHash string, page *models.Page, resourceIDs []int64, expiresAt *time.Time, allowMarkdown bool) (*models.PageShare, error) {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	createdAt := time.Now().UTC()
+	var shareID int64
+	err = tx.QueryRow(
+		`INSERT INTO page_shares (token_hash, page_id, url, title, html_path, content_hash, captured_at, created_at, expires_at, allow_markdown)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		 RETURNING id`,
+		tokenHash,
+		page.ID,
+		page.URL,
+		page.Title,
+		page.HTMLPath,
+		page.ContentHash,
+		page.CapturedAt.UTC(),
+		createdAt,
+		expiresAt,
+		allowMarkdown,
+	).Scan(&shareID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resourceID := range resourceIDs {
+		if _, err := tx.Exec(
+			"INSERT INTO page_share_resources (token_hash, resource_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+			tokenHash,
+			resourceID,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &models.PageShare{
+		ID:            shareID,
+		TokenHash:     tokenHash,
+		PageID:        page.ID,
+		URL:           page.URL,
+		Title:         page.Title,
+		HTMLPath:      page.HTMLPath,
+		ContentHash:   page.ContentHash,
+		CapturedAt:    page.CapturedAt,
+		CreatedAt:     createdAt,
+		ExpiresAt:     expiresAt,
+		AllowMarkdown: allowMarkdown,
+	}, nil
+}
+
+func (db *PostgresDB) GetActivePageShareByTokenHash(tokenHash string) (*models.PageShare, error) {
+	var share models.PageShare
+	err := scanShare(db.conn.QueryRow(
+		"SELECT "+shareSelectColumns+" FROM page_shares WHERE token_hash = $1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > $2) LIMIT 1",
+		tokenHash,
+		time.Now().UTC(),
+	), &share)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &share, nil
+}
+
+func (db *PostgresDB) ListPageShares(pageID int64) ([]models.PageShare, error) {
+	rows, err := db.conn.Query(
+		"SELECT "+shareSelectColumns+" FROM page_shares WHERE page_id = $1 ORDER BY created_at DESC, id DESC",
+		pageID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	shares := []models.PageShare{}
+	for rows.Next() {
+		var share models.PageShare
+		if err := scanShare(rows, &share); err != nil {
+			return nil, err
+		}
+		shares = append(shares, share)
+	}
+	return shares, rows.Err()
+}
+
+func (db *PostgresDB) RevokePageShare(id int64) error {
+	_, err := db.conn.Exec("UPDATE page_shares SET revoked_at = $1 WHERE id = $2", time.Now().UTC(), id)
+	return err
+}
+
+func (db *PostgresDB) GetShareResourceByURL(tokenHash, url string) (*models.Resource, error) {
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = $1 AND r.url = $2
+		LIMIT 1
+	`, tokenHash, url)
+}
+
+func (db *PostgresDB) GetShareResourceByURLPrefix(tokenHash, urlPrefix string) (*models.Resource, error) {
+	escapedPrefix := escapeLikePattern(urlPrefix)
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = $1 AND (r.url LIKE $2 ESCAPE '\' OR r.url LIKE $3 ESCAPE '\')
+		ORDER BY r.last_seen DESC, r.id DESC
+		LIMIT 1
+	`, tokenHash, escapedPrefix+"#%", escapedPrefix+"%23%")
+}
+
+func (db *PostgresDB) GetShareResourceByURLPath(tokenHash, urlPath string) (*models.Resource, error) {
+	escapedPath := escapeLikePattern(urlPath)
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = $1 AND (r.url = $2 OR r.url LIKE $3 ESCAPE '\')
+		ORDER BY CASE WHEN r.url = $2 THEN 0 ELSE 1 END, r.last_seen DESC, r.id DESC
+		LIMIT 1
+	`, tokenHash, urlPath, escapedPath+"?%")
+}
+
+func (db *PostgresDB) GetShareResourceByFilePath(tokenHash, filePath string) (*models.Resource, error) {
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = $1 AND r.file_path = $2
+		LIMIT 1
+	`, tokenHash, filePath)
+}
+
+func (db *PostgresDB) getShareResourceByQuery(query string, args ...any) (*models.Resource, error) {
+	var r models.Resource
+	err := scanResource(db.conn.QueryRow(query, args...), &r)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (db *PostgresDB) HasActiveShareForHTMLPath(htmlPath string) (bool, error) {
+	var count int
+	err := db.conn.QueryRow(
+		"SELECT COUNT(*) FROM page_shares WHERE html_path = $1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > $2)",
+		htmlPath,
+		time.Now().UTC(),
+	).Scan(&count)
+	return count > 0, err
 }

--- a/server/internal/database/postgres.go
+++ b/server/internal/database/postgres.go
@@ -241,6 +241,20 @@ func isOptionalTrigramExtensionError(err error) bool {
 	}
 }
 
+func isOptionalPostgresIndexError(err error) bool {
+	var pqErr *pq.Error
+	if !errors.As(err, &pqErr) {
+		return false
+	}
+
+	switch pqErr.Code {
+	case "42501":
+		return true
+	default:
+		return false
+	}
+}
+
 func (db *PostgresDB) ensureSchema() error {
 	if err := db.ensureTrigramExtension(); err != nil {
 		return err
@@ -283,6 +297,28 @@ func (db *PostgresDB) hasPostgresExtension(name string) (bool, error) {
 	var exists bool
 	err := db.conn.QueryRow(`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = $1)`, name).Scan(&exists)
 	return exists, err
+}
+
+func (db *PostgresDB) postgresRelationExists(qualifiedName string) (bool, error) {
+	var exists bool
+	err := db.conn.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, qualifiedName).Scan(&exists)
+	return exists, err
+}
+
+func (db *PostgresDB) ensureOptionalIndex(indexName, createSQL string) error {
+	exists, err := db.postgresRelationExists("public." + indexName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	_, err = db.conn.Exec(createSQL)
+	if err == nil || isOptionalPostgresIndexError(err) {
+		return nil
+	}
+	return err
 }
 
 func (db *PostgresDB) dropLegacySearchTrigramIndexes() error {
@@ -347,7 +383,7 @@ func (db *PostgresDB) ensureResourceQuarantineColumns() error {
 }
 
 func (db *PostgresDB) ensurePageShareTables() error {
-	_, err := db.conn.Exec(`
+	if _, err := db.conn.Exec(`
 CREATE TABLE IF NOT EXISTS page_shares (
     id BIGSERIAL PRIMARY KEY,
     token_hash TEXT NOT NULL UNIQUE,
@@ -362,16 +398,25 @@ CREATE TABLE IF NOT EXISTS page_shares (
     revoked_at TIMESTAMP WITH TIME ZONE,
     allow_markdown BOOLEAN NOT NULL DEFAULT TRUE
 );
-CREATE INDEX IF NOT EXISTS idx_page_shares_page ON page_shares(page_id);
-CREATE INDEX IF NOT EXISTS idx_page_shares_html_path ON page_shares(html_path);
 CREATE TABLE IF NOT EXISTS page_share_resources (
     token_hash TEXT NOT NULL REFERENCES page_shares(token_hash) ON DELETE CASCADE,
     resource_id BIGINT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
     PRIMARY KEY (token_hash, resource_id)
 );
-CREATE INDEX IF NOT EXISTS idx_page_share_resources_resource ON page_share_resources(resource_id);
-`)
-	return err
+`); err != nil {
+		return err
+	}
+
+	if err := db.ensureOptionalIndex("idx_page_shares_page", `CREATE INDEX idx_page_shares_page ON page_shares(page_id)`); err != nil {
+		return err
+	}
+	if err := db.ensureOptionalIndex("idx_page_shares_html_path", `CREATE INDEX idx_page_shares_html_path ON page_shares(html_path)`); err != nil {
+		return err
+	}
+	if err := db.ensureOptionalIndex("idx_page_share_resources_resource", `CREATE INDEX idx_page_share_resources_resource ON page_share_resources(resource_id)`); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (db *PostgresDB) Close() error {

--- a/server/internal/database/postgres_test.go
+++ b/server/internal/database/postgres_test.go
@@ -64,6 +64,8 @@ func TestPostgresErrorHelpers(t *testing.T) {
 		{name: "duplicate database", err: &pq.Error{Code: "42P04"}, check: isDuplicateDatabaseError, want: true},
 		{name: "optional extension insufficient privilege", err: &pq.Error{Code: "42501"}, check: isOptionalTrigramExtensionError, want: true},
 		{name: "optional extension missing control file", err: &pq.Error{Code: "58P01"}, check: isOptionalTrigramExtensionError, want: true},
+		{name: "optional index insufficient privilege", err: &pq.Error{Code: "42501"}, check: isOptionalPostgresIndexError, want: true},
+		{name: "optional index unrelated error", err: &pq.Error{Code: "42601"}, check: isOptionalPostgresIndexError, want: false},
 		{name: "wrapped missing database", err: fmt.Errorf("wrapped: %w", &pq.Error{Code: "3D000"}), check: isMissingDatabaseError, want: true},
 		{name: "unrelated error", err: errors.New("boom"), check: isMissingDatabaseError, want: false},
 	}
@@ -233,7 +235,8 @@ func TestGetPagesByURL(t *testing.T) {
 	defer db.Close()
 
 	now := time.Now()
-	testURL := "http://test-get-pages-by-url.example.com"
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	testURL := "http://test-get-pages-by-url.example.com/" + suffix
 
 	// Create 3 snapshots with different content hashes
 	hash1 := "1111111111111111111111111111111111111111111111111111111111111111"
@@ -782,7 +785,8 @@ func TestGetSnapshotNeighbors(t *testing.T) {
 	defer db.Close()
 
 	now := time.Now()
-	testURL := "http://test-snapshot-neighbors.example.com"
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	testURL := "http://test-snapshot-neighbors.example.com/" + suffix
 
 	hash1 := "aaaa111111111111111111111111111111111111111111111111111111111111"
 	hash2 := "aaaa222222222222222222222222222222222222222222222222222222222222"

--- a/server/internal/database/schema/init_postgres.sql
+++ b/server/internal/database/schema/init_postgres.sql
@@ -72,13 +72,24 @@ CREATE TABLE IF NOT EXISTS page_shares (
     allow_markdown BOOLEAN NOT NULL DEFAULT TRUE
 );
 
-CREATE INDEX IF NOT EXISTS idx_page_shares_page ON page_shares(page_id);
-CREATE INDEX IF NOT EXISTS idx_page_shares_html_path ON page_shares(html_path);
-
 CREATE TABLE IF NOT EXISTS page_share_resources (
     token_hash TEXT NOT NULL REFERENCES page_shares(token_hash) ON DELETE CASCADE,
     resource_id BIGINT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
     PRIMARY KEY (token_hash, resource_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_page_share_resources_resource ON page_share_resources(resource_id);
+DO $$
+BEGIN
+    IF to_regclass('public.idx_page_shares_page') IS NULL THEN
+        EXECUTE 'CREATE INDEX idx_page_shares_page ON page_shares(page_id)';
+    END IF;
+    IF to_regclass('public.idx_page_shares_html_path') IS NULL THEN
+        EXECUTE 'CREATE INDEX idx_page_shares_html_path ON page_shares(html_path)';
+    END IF;
+    IF to_regclass('public.idx_page_share_resources_resource') IS NULL THEN
+        EXECUTE 'CREATE INDEX idx_page_share_resources_resource ON page_share_resources(resource_id)';
+    END IF;
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Skipping optional page share indexes because current user does not own page_shares';
+END $$;

--- a/server/internal/database/schema/init_postgres.sql
+++ b/server/internal/database/schema/init_postgres.sql
@@ -55,3 +55,30 @@ CREATE TABLE IF NOT EXISTS page_resources (
 );
 
 CREATE INDEX IF NOT EXISTS idx_page_resources_page ON page_resources(page_id);
+
+-- 公开分享表（token_hash 存储 token 的哈希，不保存 token 明文）
+CREATE TABLE IF NOT EXISTS page_shares (
+    id BIGSERIAL PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    page_id BIGINT REFERENCES pages(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    title TEXT,
+    html_path TEXT NOT NULL,
+    content_hash CHAR(64),
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE,
+    revoked_at TIMESTAMP WITH TIME ZONE,
+    allow_markdown BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_shares_page ON page_shares(page_id);
+CREATE INDEX IF NOT EXISTS idx_page_shares_html_path ON page_shares(html_path);
+
+CREATE TABLE IF NOT EXISTS page_share_resources (
+    token_hash TEXT NOT NULL REFERENCES page_shares(token_hash) ON DELETE CASCADE,
+    resource_id BIGINT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    PRIMARY KEY (token_hash, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_share_resources_resource ON page_share_resources(resource_id);

--- a/server/internal/database/schema/init_sqlite.sql
+++ b/server/internal/database/schema/init_sqlite.sql
@@ -69,3 +69,30 @@ CREATE TABLE IF NOT EXISTS page_resources (
 );
 
 CREATE INDEX IF NOT EXISTS idx_page_resources_page ON page_resources(page_id);
+
+-- 公开分享表（token_hash 存储 token 的哈希，不保存 token 明文）
+CREATE TABLE IF NOT EXISTS page_shares (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_hash TEXT NOT NULL UNIQUE,
+    page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    title TEXT,
+    html_path TEXT NOT NULL,
+    content_hash CHAR(64),
+    captured_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME,
+    revoked_at DATETIME,
+    allow_markdown BOOLEAN NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_shares_page ON page_shares(page_id);
+CREATE INDEX IF NOT EXISTS idx_page_shares_html_path ON page_shares(html_path);
+
+CREATE TABLE IF NOT EXISTS page_share_resources (
+    token_hash TEXT NOT NULL REFERENCES page_shares(token_hash) ON DELETE CASCADE,
+    resource_id INTEGER NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    PRIMARY KEY (token_hash, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_share_resources_resource ON page_share_resources(resource_id);

--- a/server/internal/database/sqlite.go
+++ b/server/internal/database/sqlite.go
@@ -31,7 +31,8 @@ const (
 	sqliteMigrationVersionTimestampNormalization = 3
 	sqliteMigrationVersionTimestampFixedWidth    = 4
 	sqliteMigrationVersionResourceQuarantine     = 5
-	sqliteMigrationVersionCurrent                = sqliteMigrationVersionResourceQuarantine
+	sqliteMigrationVersionPageShares             = 6
+	sqliteMigrationVersionCurrent                = sqliteMigrationVersionPageShares
 )
 
 func formatSQLiteTimestamp(t time.Time) string {
@@ -155,11 +156,11 @@ func (db *SQLiteDB) ensureMigrations() error {
 		}
 
 		// ensureNormalizedTimestamps 现在直接产出最终的固定宽度 UTC 文本，
-		// 旧库首次升级时可直接推进到当前版本，避免同一轮启动里再做一次全表重写。
-		if err := db.setSQLiteUserVersion(sqliteMigrationVersionCurrent); err != nil {
+		// 可跳过 timestamp fixed-width 迁移，但仍要继续执行后续非时间戳迁移。
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionTimestampFixedWidth); err != nil {
 			return err
 		}
-		version = sqliteMigrationVersionCurrent
+		version = sqliteMigrationVersionTimestampFixedWidth
 	}
 
 	if version < sqliteMigrationVersionTimestampFixedWidth {
@@ -179,6 +180,17 @@ func (db *SQLiteDB) ensureMigrations() error {
 		}
 
 		if err := db.setSQLiteUserVersion(sqliteMigrationVersionResourceQuarantine); err != nil {
+			return err
+		}
+		version = sqliteMigrationVersionResourceQuarantine
+	}
+
+	if version < sqliteMigrationVersionPageShares {
+		if err := db.ensurePageShareTables(); err != nil {
+			return err
+		}
+
+		if err := db.setSQLiteUserVersion(sqliteMigrationVersionPageShares); err != nil {
 			return err
 		}
 	}
@@ -384,6 +396,34 @@ func (db *SQLiteDB) ensureSnapshotStateColumn() error {
 	}
 
 	return nil
+}
+
+func (db *SQLiteDB) ensurePageShareTables() error {
+	_, err := db.conn.Exec(`
+CREATE TABLE IF NOT EXISTS page_shares (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_hash TEXT NOT NULL UNIQUE,
+    page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    title TEXT,
+    html_path TEXT NOT NULL,
+    content_hash CHAR(64),
+    captured_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME,
+    revoked_at DATETIME,
+    allow_markdown BOOLEAN NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_page_shares_page ON page_shares(page_id);
+CREATE INDEX IF NOT EXISTS idx_page_shares_html_path ON page_shares(html_path);
+CREATE TABLE IF NOT EXISTS page_share_resources (
+    token_hash TEXT NOT NULL REFERENCES page_shares(token_hash) ON DELETE CASCADE,
+    resource_id INTEGER NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    PRIMARY KEY (token_hash, resource_id)
+);
+CREATE INDEX IF NOT EXISTS idx_page_share_resources_resource ON page_share_resources(resource_id);
+`)
+	return err
 }
 
 func (db *SQLiteDB) Close() error {
@@ -1088,4 +1128,177 @@ func (db *SQLiteDB) DeletePage(id int64) error {
 	}
 
 	return tx.Commit()
+}
+
+func (db *SQLiteDB) CreatePageShare(tokenHash string, page *models.Page, resourceIDs []int64, expiresAt *time.Time, allowMarkdown bool) (*models.PageShare, error) {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	createdAt := time.Now().UTC()
+	var expiresValue any
+	if expiresAt != nil {
+		expiresValue = formatSQLiteTimestamp(*expiresAt)
+	}
+
+	result, err := tx.Exec(
+		`INSERT INTO page_shares (token_hash, page_id, url, title, html_path, content_hash, captured_at, created_at, expires_at, allow_markdown)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tokenHash,
+		page.ID,
+		page.URL,
+		page.Title,
+		page.HTMLPath,
+		page.ContentHash,
+		formatSQLiteTimestamp(page.CapturedAt),
+		formatSQLiteTimestamp(createdAt),
+		expiresValue,
+		allowMarkdown,
+	)
+	if err != nil {
+		return nil, err
+	}
+	shareID, err := result.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resourceID := range resourceIDs {
+		if _, err := tx.Exec(
+			"INSERT OR IGNORE INTO page_share_resources (token_hash, resource_id) VALUES (?, ?)",
+			tokenHash,
+			resourceID,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &models.PageShare{
+		ID:            shareID,
+		TokenHash:     tokenHash,
+		PageID:        page.ID,
+		URL:           page.URL,
+		Title:         page.Title,
+		HTMLPath:      page.HTMLPath,
+		ContentHash:   page.ContentHash,
+		CapturedAt:    page.CapturedAt,
+		CreatedAt:     createdAt,
+		ExpiresAt:     expiresAt,
+		AllowMarkdown: allowMarkdown,
+	}, nil
+}
+
+func (db *SQLiteDB) GetActivePageShareByTokenHash(tokenHash string) (*models.PageShare, error) {
+	var share models.PageShare
+	err := scanShare(db.conn.QueryRow(
+		"SELECT "+shareSelectColumns+" FROM page_shares WHERE token_hash = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?) LIMIT 1",
+		tokenHash,
+		currentSQLiteTimestamp(),
+	), &share)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &share, nil
+}
+
+func (db *SQLiteDB) ListPageShares(pageID int64) ([]models.PageShare, error) {
+	rows, err := db.conn.Query(
+		"SELECT "+shareSelectColumns+" FROM page_shares WHERE page_id = ? ORDER BY created_at DESC, id DESC",
+		pageID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	shares := []models.PageShare{}
+	for rows.Next() {
+		var share models.PageShare
+		if err := scanShare(rows, &share); err != nil {
+			return nil, err
+		}
+		shares = append(shares, share)
+	}
+	return shares, rows.Err()
+}
+
+func (db *SQLiteDB) RevokePageShare(id int64) error {
+	_, err := db.conn.Exec("UPDATE page_shares SET revoked_at = ? WHERE id = ?", currentSQLiteTimestamp(), id)
+	return err
+}
+
+func (db *SQLiteDB) GetShareResourceByURL(tokenHash, url string) (*models.Resource, error) {
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = ? AND r.url = ?
+		LIMIT 1
+	`, tokenHash, url)
+}
+
+func (db *SQLiteDB) GetShareResourceByURLPrefix(tokenHash, urlPrefix string) (*models.Resource, error) {
+	escapedPrefix := escapeLikePattern(urlPrefix)
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = ? AND (r.url LIKE ? ESCAPE '\' OR r.url LIKE ? ESCAPE '\')
+		ORDER BY r.last_seen DESC, r.id DESC
+		LIMIT 1
+	`, tokenHash, escapedPrefix+"#%", escapedPrefix+"%23%")
+}
+
+func (db *SQLiteDB) GetShareResourceByURLPath(tokenHash, urlPath string) (*models.Resource, error) {
+	escapedPath := escapeLikePattern(urlPath)
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = ? AND (r.url = ? OR r.url LIKE ? ESCAPE '\')
+		ORDER BY CASE WHEN r.url = ? THEN 0 ELSE 1 END, r.last_seen DESC, r.id DESC
+		LIMIT 1
+	`, tokenHash, urlPath, escapedPath+"?%", urlPath)
+}
+
+func (db *SQLiteDB) GetShareResourceByFilePath(tokenHash, filePath string) (*models.Resource, error) {
+	return db.getShareResourceByQuery(`
+		SELECT `+resourceSelectColumns+`
+		FROM resources r
+		INNER JOIN page_share_resources psr ON r.id = psr.resource_id
+		WHERE psr.token_hash = ? AND r.file_path = ?
+		LIMIT 1
+	`, tokenHash, filePath)
+}
+
+func (db *SQLiteDB) getShareResourceByQuery(query string, args ...any) (*models.Resource, error) {
+	var r models.Resource
+	err := scanResource(db.conn.QueryRow(query, args...), &r)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (db *SQLiteDB) HasActiveShareForHTMLPath(htmlPath string) (bool, error) {
+	var count int
+	err := db.conn.QueryRow(
+		"SELECT COUNT(*) FROM page_shares WHERE html_path = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		htmlPath,
+		currentSQLiteTimestamp(),
+	).Scan(&count)
+	return count > 0, err
 }

--- a/server/internal/database/sqlite_test.go
+++ b/server/internal/database/sqlite_test.go
@@ -51,6 +51,131 @@ func TestSQLiteFTSUpdatePageBodyText(t *testing.T) {
 	}
 }
 
+func TestSQLitePageShare_ScopesResourcesAndHTMLProtection(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	now := time.Now().UTC()
+	pageID, err := db.CreatePage("https://share-scope.example.com/page", "Share Scope", "html/test/share.html", strings.Repeat("a", 64), now)
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	page, err := db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	if page == nil {
+		t.Fatal("expected page to exist")
+	}
+
+	sharedID, err := db.CreateResource("https://cdn.example.com/shared.css", strings.Repeat("b", 64), "css", "resources/aa/bb/shared.css", 12)
+	if err != nil {
+		t.Fatalf("CreateResource shared failed: %v", err)
+	}
+	unsharedID, err := db.CreateResource("https://cdn.example.com/unshared.css", strings.Repeat("c", 64), "css", "resources/cc/dd/unshared.css", 13)
+	if err != nil {
+		t.Fatalf("CreateResource unshared failed: %v", err)
+	}
+	if err := db.LinkPageResource(pageID, sharedID); err != nil {
+		t.Fatalf("LinkPageResource shared failed: %v", err)
+	}
+
+	tokenHash := strings.Repeat("f", 64)
+	share, err := db.CreatePageShare(tokenHash, page, []int64{sharedID}, nil, true)
+	if err != nil {
+		t.Fatalf("CreatePageShare failed: %v", err)
+	}
+	if share.TokenHash != tokenHash || !share.AllowMarkdown {
+		t.Fatalf("unexpected share: %+v", share)
+	}
+
+	active, err := db.GetActivePageShareByTokenHash(tokenHash)
+	if err != nil {
+		t.Fatalf("GetActivePageShareByTokenHash failed: %v", err)
+	}
+	if active == nil || active.HTMLPath != page.HTMLPath {
+		t.Fatalf("active share = %+v, want html path %q", active, page.HTMLPath)
+	}
+
+	resource, err := db.GetShareResourceByURL(tokenHash, "https://cdn.example.com/shared.css")
+	if err != nil {
+		t.Fatalf("GetShareResourceByURL shared failed: %v", err)
+	}
+	if resource == nil || resource.ID != sharedID {
+		t.Fatalf("shared resource = %+v, want %d", resource, sharedID)
+	}
+	resource, err = db.GetShareResourceByFilePath(tokenHash, "resources/cc/dd/unshared.css")
+	if err != nil {
+		t.Fatalf("GetShareResourceByFilePath unshared failed: %v", err)
+	}
+	if resource != nil {
+		t.Fatalf("unshared resource leaked through share: %+v", resource)
+	}
+
+	protected, err := db.HasActiveShareForHTMLPath(page.HTMLPath)
+	if err != nil {
+		t.Fatalf("HasActiveShareForHTMLPath failed: %v", err)
+	}
+	if !protected {
+		t.Fatal("active share should protect html path")
+	}
+
+	if err := db.RevokePageShare(share.ID); err != nil {
+		t.Fatalf("RevokePageShare failed: %v", err)
+	}
+	active, err = db.GetActivePageShareByTokenHash(tokenHash)
+	if err != nil {
+		t.Fatalf("GetActivePageShareByTokenHash after revoke failed: %v", err)
+	}
+	if active != nil {
+		t.Fatalf("revoked share should not be active: %+v", active)
+	}
+	protected, err = db.HasActiveShareForHTMLPath(page.HTMLPath)
+	if err != nil {
+		t.Fatalf("HasActiveShareForHTMLPath after revoke failed: %v", err)
+	}
+	if protected {
+		t.Fatal("revoked share should not protect html path")
+	}
+
+	_ = unsharedID
+}
+
+func TestSQLitePageShare_ExpiredShareIsInactive(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	pageID, err := db.CreatePage("https://share-expiry.example.com/page", "Share Expiry", "html/test/expiry.html", strings.Repeat("a", 64), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+	page, err := db.GetPageByID(fmt.Sprintf("%d", pageID))
+	if err != nil {
+		t.Fatalf("GetPageByID failed: %v", err)
+	}
+	expiredAt := time.Now().Add(-time.Hour)
+	share, err := db.CreatePageShare(strings.Repeat("e", 64), page, nil, &expiredAt, false)
+	if err != nil {
+		t.Fatalf("CreatePageShare failed: %v", err)
+	}
+	if share.AllowMarkdown {
+		t.Fatalf("allow_markdown should be false: %+v", share)
+	}
+
+	active, err := db.GetActivePageShareByTokenHash(share.TokenHash)
+	if err != nil {
+		t.Fatalf("GetActivePageShareByTokenHash failed: %v", err)
+	}
+	if active != nil {
+		t.Fatalf("expired share should not be active: %+v", active)
+	}
+	protected, err := db.HasActiveShareForHTMLPath(page.HTMLPath)
+	if err != nil {
+		t.Fatalf("HasActiveShareForHTMLPath failed: %v", err)
+	}
+	if protected {
+		t.Fatal("expired share should not protect html path")
+	}
+}
+
 func TestSQLiteSearchPages_MatchesURLTitleAndBodyText(t *testing.T) {
 	db := newSQLiteTestDB(t)
 

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -32,6 +32,40 @@ type Resource struct {
 	QuarantineReason string    `json:"quarantine_reason,omitempty"`
 }
 
+type PageShare struct {
+	ID            int64      `json:"id"`
+	TokenHash     string     `json:"-"`
+	PageID        int64      `json:"page_id"`
+	URL           string     `json:"url"`
+	Title         string     `json:"title"`
+	HTMLPath      string     `json:"html_path"`
+	ContentHash   string     `json:"content_hash"`
+	CapturedAt    time.Time  `json:"captured_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+	AllowMarkdown bool       `json:"allow_markdown"`
+}
+
+type CreateShareRequest struct {
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	AllowMarkdown *bool      `json:"allow_markdown,omitempty"`
+}
+
+type ShareResponse struct {
+	Status      string     `json:"status"`
+	ID          int64      `json:"id"`
+	Token       string     `json:"token,omitempty"`
+	PageID      int64      `json:"page_id"`
+	URL         string     `json:"url"`
+	Title       string     `json:"title"`
+	CapturedAt  time.Time  `json:"captured_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	SnapshotURL string     `json:"snapshot_url"`
+	MarkdownURL string     `json:"markdown_url,omitempty"`
+}
+
 type CaptureRequest struct {
 	URL     string            `json:"url" binding:"required"`
 	Title   string            `json:"title"`

--- a/server/internal/storage/css_parser.go
+++ b/server/internal/storage/css_parser.go
@@ -56,7 +56,14 @@ func (p *CSSParser) ExtractResources(cssContent string) []string {
 
 // RewriteCSS rewrites resource URLs in CSS content to point to local paths
 func (p *CSSParser) RewriteCSS(cssContent string, urlMapping map[string]string) string {
+	return p.RewriteCSSWithPrefix(cssContent, urlMapping, "/archive/")
+}
+
+func (p *CSSParser) RewriteCSSWithPrefix(cssContent string, urlMapping map[string]string, urlPrefix string) string {
 	result := cssContent
+	if urlPrefix == "" {
+		urlPrefix = "/archive/"
+	}
 
 	// Rewrite @import URLs
 	result = p.importPattern.ReplaceAllStringFunc(result, func(match string) string {
@@ -64,7 +71,7 @@ func (p *CSSParser) RewriteCSS(cssContent string, urlMapping map[string]string) 
 		if len(submatch) > 1 {
 			originalURL := strings.TrimSpace(submatch[1])
 			if localPath, ok := urlMapping[originalURL]; ok {
-				localURL := "/archive/" + localPath
+				localURL := urlPrefix + localPath
 				// Preserve the original format
 				if strings.Contains(match, "url(") {
 					return strings.Replace(match, originalURL, localURL, 1)
@@ -81,7 +88,7 @@ func (p *CSSParser) RewriteCSS(cssContent string, urlMapping map[string]string) 
 		if len(submatch) > 1 {
 			originalURL := strings.TrimSpace(submatch[1])
 			if localPath, ok := urlMapping[originalURL]; ok {
-				localURL := "/archive/" + localPath
+				localURL := urlPrefix + localPath
 				// Preserve quotes if present
 				if strings.Contains(match, `"`) {
 					return `url("` + localURL + `")`

--- a/server/internal/storage/deduplicator.go
+++ b/server/internal/storage/deduplicator.go
@@ -1368,7 +1368,9 @@ func (d *Deduplicator) CleanupOldHTML(retentionDays int) error {
 		return fmt.Errorf("retention days must be positive")
 	}
 
-	deletedCount, err := d.deletionQueue.ProcessDeletions(d.storage.baseDir, retentionDays)
+	deletedCount, err := d.deletionQueue.ProcessDeletionsWithProtection(d.storage.baseDir, retentionDays, func(record DeletionRecord) (bool, error) {
+		return d.db.HasActiveShareForHTMLPath(record.HTMLPath)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to process deletion queue: %w", err)
 	}

--- a/server/internal/storage/deletion_queue.go
+++ b/server/internal/storage/deletion_queue.go
@@ -12,9 +12,9 @@ import (
 
 // DeletionRecord 记录待删除的 HTML 文件信息
 type DeletionRecord struct {
-	HTMLPath  string    `json:"html_path"`  // 相对路径，如 "html/2026/03/14/120000_abc123.html"
-	Timestamp time.Time `json:"timestamp"`  // 记录时间
-	PageID    int64     `json:"page_id"`    // 关联的页面 ID（用于日志）
+	HTMLPath  string    `json:"html_path"` // 相对路径，如 "html/2026/03/14/120000_abc123.html"
+	Timestamp time.Time `json:"timestamp"` // 记录时间
+	PageID    int64     `json:"page_id"`   // 关联的页面 ID（用于日志）
 }
 
 // DeletionQueue 管理待删除的 HTML 文件队列
@@ -22,6 +22,8 @@ type DeletionQueue struct {
 	queueFile string
 	mu        sync.Mutex
 }
+
+type DeletionProtectFunc func(record DeletionRecord) (bool, error)
 
 // NewDeletionQueue 创建删除队列管理器
 func NewDeletionQueue(dataDir string) *DeletionQueue {
@@ -61,6 +63,10 @@ func (q *DeletionQueue) Add(htmlPath string, pageID int64) error {
 // 记录按时间顺序追加，遇到第一个未过期的记录即可停止，剩余部分直接保留
 // 返回删除的文件数量和错误
 func (q *DeletionQueue) ProcessDeletions(baseDir string, retentionDays int) (int, error) {
+	return q.ProcessDeletionsWithProtection(baseDir, retentionDays, nil)
+}
+
+func (q *DeletionQueue) ProcessDeletionsWithProtection(baseDir string, retentionDays int, protect DeletionProtectFunc) (int, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -82,6 +88,24 @@ func (q *DeletionQueue) ProcessDeletions(baseDir string, retentionDays int) (int
 			// 记录按时间有序，后续全部未过期，直接截断
 			firstRemaining = i
 			break
+		}
+
+		if protect != nil {
+			protected, err := protect(record)
+			if err != nil {
+				if firstRemaining == -1 {
+					firstRemaining = i
+				}
+				fmt.Printf("Failed to check deletion protection for %s: %v\n", record.HTMLPath, err)
+				break
+			}
+			if protected {
+				if firstRemaining == -1 {
+					firstRemaining = i
+				}
+				fmt.Printf("Skipped shared HTML: %s (page_id: %d)\n", record.HTMLPath, record.PageID)
+				break
+			}
 		}
 
 		fullPath := filepath.Join(baseDir, record.HTMLPath)

--- a/server/internal/storage/deletion_queue.go
+++ b/server/internal/storage/deletion_queue.go
@@ -81,30 +81,26 @@ func (q *DeletionQueue) ProcessDeletionsWithProtection(baseDir string, retention
 
 	cutoffTime := time.Now().AddDate(0, 0, -retentionDays)
 	deletedCount := 0
-	firstRemaining := -1
+	remaining := make([]DeletionRecord, 0, len(records))
 
 	for i, record := range records {
 		if !record.Timestamp.Before(cutoffTime) {
 			// 记录按时间有序，后续全部未过期，直接截断
-			firstRemaining = i
+			remaining = append(remaining, records[i:]...)
 			break
 		}
 
 		if protect != nil {
 			protected, err := protect(record)
 			if err != nil {
-				if firstRemaining == -1 {
-					firstRemaining = i
-				}
 				fmt.Printf("Failed to check deletion protection for %s: %v\n", record.HTMLPath, err)
+				remaining = append(remaining, records[i:]...)
 				break
 			}
 			if protected {
-				if firstRemaining == -1 {
-					firstRemaining = i
-				}
 				fmt.Printf("Skipped shared HTML: %s (page_id: %d)\n", record.HTMLPath, record.PageID)
-				break
+				remaining = append(remaining, record)
+				continue
 			}
 		}
 
@@ -112,10 +108,8 @@ func (q *DeletionQueue) ProcessDeletionsWithProtection(baseDir string, retention
 		if err := os.Remove(fullPath); err != nil {
 			if !os.IsNotExist(err) {
 				// 删除失败（权限等问题），保留这条记录
-				if firstRemaining == -1 {
-					firstRemaining = i
-				}
 				fmt.Printf("Failed to delete %s: %v\n", record.HTMLPath, err)
+				remaining = append(remaining, records[i:]...)
 				break // 后续记录也保留
 			}
 			// 文件不存在，视为已删除
@@ -124,12 +118,6 @@ func (q *DeletionQueue) ProcessDeletionsWithProtection(baseDir string, retention
 			fmt.Printf("Deleted superseded HTML: %s (page_id: %d, age: %v)\n",
 				record.HTMLPath, record.PageID, time.Since(record.Timestamp))
 		}
-	}
-
-	// 保留未处理的记录
-	var remaining []DeletionRecord
-	if firstRemaining >= 0 {
-		remaining = records[firstRemaining:]
 	}
 
 	if err := q.writeRecords(remaining); err != nil {

--- a/server/internal/storage/deletion_queue_test.go
+++ b/server/internal/storage/deletion_queue_test.go
@@ -178,6 +178,50 @@ func TestDeletionQueue_ProcessDeletions_MixedExpiry(t *testing.T) {
 	}
 }
 
+func TestDeletionQueue_ProcessDeletions_ProtectedExpiredFileDoesNotBlockLaterDeletes(t *testing.T) {
+	q, dir := newTestQueue(t)
+	baseDir := filepath.Join(dir, "data")
+
+	createHTMLFile(t, baseDir, "html/shared.html")
+	createHTMLFile(t, baseDir, "html/old.html")
+	createHTMLFile(t, baseDir, "html/recent.html")
+
+	f, _ := os.Create(q.queueFile)
+	enc := json.NewEncoder(f)
+	enc.Encode(DeletionRecord{HTMLPath: "html/shared.html", Timestamp: time.Now().AddDate(0, 0, -12), PageID: 1})
+	enc.Encode(DeletionRecord{HTMLPath: "html/old.html", Timestamp: time.Now().AddDate(0, 0, -10), PageID: 2})
+	enc.Encode(DeletionRecord{HTMLPath: "html/recent.html", Timestamp: time.Now().AddDate(0, 0, -2), PageID: 3})
+	f.Close()
+
+	deleted, err := q.ProcessDeletionsWithProtection(baseDir, 7, func(record DeletionRecord) (bool, error) {
+		return record.HTMLPath == "html/shared.html", nil
+	})
+	if err != nil {
+		t.Fatalf("ProcessDeletionsWithProtection: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+
+	if _, err := os.Stat(filepath.Join(baseDir, "html/shared.html")); err != nil {
+		t.Fatalf("shared.html should remain: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(baseDir, "html/old.html")); !os.IsNotExist(err) {
+		t.Fatal("old.html should have been deleted")
+	}
+	if _, err := os.Stat(filepath.Join(baseDir, "html/recent.html")); err != nil {
+		t.Fatalf("recent.html should remain: %v", err)
+	}
+
+	records := readQueueFile(t, q.queueFile)
+	if len(records) != 2 {
+		t.Fatalf("queue should have 2 records, got %d", len(records))
+	}
+	if records[0].HTMLPath != "html/shared.html" || records[1].HTMLPath != "html/recent.html" {
+		t.Fatalf("remaining records = %+v, want shared then recent", records)
+	}
+}
+
 func TestDeletionQueue_ProcessDeletions_FileAlreadyGone(t *testing.T) {
 	q, dir := newTestQueue(t)
 	baseDir := filepath.Join(dir, "data")

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -363,7 +363,10 @@
             gap: 8px;
         }
 
-        .timeline-btn {
+        .timeline-btn,
+        .share-btn,
+        .share-md-btn,
+        .share-revoke-btn {
             background: transparent;
             border: 1px solid var(--color-border);
             color: var(--color-text-dim);
@@ -379,6 +382,20 @@
             border-color: var(--color-cyan);
             color: var(--color-cyan);
             background: rgba(0, 217, 255, 0.1);
+        }
+
+        .share-btn:hover,
+        .share-btn.is-active,
+        .share-md-btn:hover {
+            border-color: var(--color-accent);
+            color: var(--color-accent);
+            background: rgba(0, 255, 136, 0.1);
+        }
+
+        .share-revoke-btn:hover {
+            border-color: #ff4444;
+            color: #ff4444;
+            background: rgba(255, 68, 68, 0.1);
         }
 
         .delete-btn {
@@ -620,6 +637,7 @@
         let domainTimer = null;
         let activeRequestController = null;
         let latestRequestSeq = 0;
+        const pageShareState = new Map();
 
         function normalizePageNumber(page) {
             const parsed = Number.parseInt(page, 10);
@@ -906,6 +924,15 @@
                 timelineBtn.textContent = 'Timeline';
                 timelineBtn.addEventListener('click', (event) => openTimeline(event, page.url));
 
+                const shareBtn = document.createElement('button');
+                shareBtn.className = 'share-btn';
+                shareBtn.type = 'button';
+                shareBtn.textContent = 'Share';
+                if (pageShareState.has(page.id)) {
+                    shareBtn.classList.add('is-active');
+                }
+                shareBtn.addEventListener('click', (event) => createShare(event, page.id, shareBtn, actions));
+
                 const deleteBtn = document.createElement('button');
                 deleteBtn.className = 'delete-btn';
                 deleteBtn.type = 'button';
@@ -926,6 +953,8 @@
                 titleGroup.appendChild(pageId);
 
                 actions.appendChild(timelineBtn);
+                actions.appendChild(shareBtn);
+                renderShareStateActions(actions, page.id);
                 actions.appendChild(deleteBtn);
 
                 header.appendChild(titleGroup);
@@ -942,7 +971,7 @@
                 item.appendChild(meta);
 
                 item.addEventListener('click', (e) => {
-                    if (e.target.closest('.page-url') || e.target.closest('.delete-btn') || e.target.closest('.timeline-btn')) {
+                    if (e.target.closest('.page-url') || e.target.closest('.delete-btn') || e.target.closest('.timeline-btn') || e.target.closest('.share-btn') || e.target.closest('.share-md-btn') || e.target.closest('.share-revoke-btn')) {
                         return;
                     }
                     window.open(`/view/${page.id}`, '_blank');
@@ -957,6 +986,122 @@
         function openTimeline(event, pageUrl) {
             event.stopPropagation();
             window.open(`/timeline?url=${encodeURIComponent(pageUrl)}`, '_blank');
+        }
+
+        function absoluteURL(path) {
+            return new URL(path, window.location.origin).toString();
+        }
+
+        async function copyText(text) {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                return;
+            }
+
+            const textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.setAttribute('readonly', '');
+            textarea.style.position = 'fixed';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
+        }
+
+        function setButtonTextTemporarily(button, text) {
+            const original = button.textContent;
+            button.textContent = text;
+            setTimeout(() => {
+                button.textContent = original;
+            }, 1600);
+        }
+
+        function renderShareStateActions(actions, pageId) {
+            const state = pageShareState.get(pageId);
+            if (!state || !state.id) {
+                return;
+            }
+
+            if (state.markdown_url) {
+                const mdBtn = document.createElement('button');
+                mdBtn.className = 'share-md-btn';
+                mdBtn.type = 'button';
+                mdBtn.textContent = 'Copy MD';
+                mdBtn.addEventListener('click', async (event) => {
+                    event.stopPropagation();
+                    try {
+                        await copyText(absoluteURL(state.markdown_url));
+                        setButtonTextTemporarily(mdBtn, 'Copied');
+                    } catch (error) {
+                        alert('复制失败: ' + error.message);
+                    }
+                });
+                actions.appendChild(mdBtn);
+            }
+
+            const revokeBtn = document.createElement('button');
+            revokeBtn.className = 'share-revoke-btn';
+            revokeBtn.type = 'button';
+            revokeBtn.textContent = 'Revoke';
+            revokeBtn.addEventListener('click', async (event) => {
+                event.stopPropagation();
+                if (!confirm('确定要撤销这个公开分享吗？')) {
+                    return;
+                }
+                try {
+                    const response = await fetch(`/api/shares/${state.id}`, {method: 'DELETE'});
+                    if (!response.ok) {
+                        const data = await response.json().catch(() => ({}));
+                        throw new Error(data.error || `HTTP ${response.status}`);
+                    }
+                    pageShareState.delete(pageId);
+                    actions.querySelectorAll('.share-md-btn, .share-revoke-btn').forEach((el) => el.remove());
+                    const shareBtn = actions.querySelector('.share-btn');
+                    if (shareBtn) {
+                        shareBtn.classList.remove('is-active');
+                        shareBtn.textContent = 'Share';
+                    }
+                } catch (error) {
+                    alert('撤销失败: ' + error.message);
+                }
+            });
+            actions.appendChild(revokeBtn);
+        }
+
+        async function createShare(event, pageId, button, actions) {
+            event.stopPropagation();
+            button.disabled = true;
+            const originalText = button.textContent;
+            button.textContent = 'Sharing';
+
+            try {
+                const response = await fetch(`/api/pages/${pageId}/shares`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: '{}'
+                });
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    throw new Error(data.error || `HTTP ${response.status}`);
+                }
+
+                pageShareState.set(pageId, data);
+                await copyText(absoluteURL(data.snapshot_url));
+                button.classList.add('is-active');
+                button.textContent = 'Copied';
+
+                actions.querySelectorAll('.share-md-btn, .share-revoke-btn').forEach((el) => el.remove());
+                renderShareStateActions(actions, pageId);
+                setTimeout(() => {
+                    button.textContent = 'Share';
+                }, 1600);
+            } catch (error) {
+                alert('分享失败: ' + error.message);
+                button.textContent = originalText;
+            } finally {
+                button.disabled = false;
+            }
         }
 
         async function deletePage(event, pageId) {

--- a/server/web/robots.txt
+++ b/server/web/robots.txt
@@ -36,3 +36,4 @@ Disallow: /
 
 User-agent: *
 Allow: /
+Disallow: /share/

--- a/skill.md
+++ b/skill.md
@@ -134,6 +134,16 @@ Returns the page body as clean Markdown (strips scripts, nav, footer, etc.). Ide
 curl "http://localhost:8080/view/$PAGE_ID/md"
 ```
 
+#### Create Public Share Link
+
+Creates an unauthenticated link for one fixed snapshot. The returned token is only shown once.
+
+```bash
+curl -X POST "http://localhost:8080/api/pages/$PAGE_ID/shares" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 #### Get Timeline for URL
 
 ```bash


### PR DESCRIPTION
## Summary
- add token-based public share records for fixed snapshots and Markdown output
- expose unauthenticated /share/:token routes with scoped resource proxying
- add UI controls to create/copy/revoke shares and protect shared HTML from cleanup
- document the new share APIs

## Tests
- make test
- make server
- smoke tested /api/version and share 404 responses with the rebuilt server

Note: local PostgreSQL integration tests that depend on the existing test database skip because page_shares is owned by a different DB owner; SQLite and new share tests pass.