### PR TITLE
feat: move share action to snapshot header

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -227,7 +227,7 @@ export https_proxy=http://127.0.0.1:7897
 
 ### 公开分享
 
-`POST /api/pages/:id/shares` 会为当前快照创建不可枚举公开 token，返回 `{ token, snapshot_url, markdown_url }`。公开入口不需要 Basic Auth，但只暴露该分享创建时固定的 HTML 文件和资源集合；后续页面更新不会改变已创建分享指向的特定快照。撤销分享后 `/share/:token` 和 `/share/:token/md` 返回 `404`。
+`POST /api/pages/:id/shares` 会为当前快照创建不可枚举公开 token，返回 `{ token, snapshot_url, markdown_url }`。也可以在 `/view/:id` 快照页顶部点击 `Share` 创建并复制公开链接；创建成功后顶部栏会显示 `Revoke`，用于撤销本次分享。公开入口不需要 Basic Auth，但只暴露该分享创建时固定的 HTML 文件和资源集合；后续页面更新不会改变已创建分享指向的特定快照。撤销分享后 `/share/:token` 和 `/share/:token/md` 返回 `404`。
 
 ## 项目结构
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The request body `url` must exactly match the existing page URL for `:id`; other
 
 ### Public Sharing
 
-`POST /api/pages/:id/shares` creates an unguessable public token for the current snapshot and returns `{ token, snapshot_url, markdown_url }`. Public share routes do not require Basic Auth, but they only expose the HTML file and resource set fixed at share creation time. Later page updates do not change the shared snapshot. Revoked shares return `404` from `/share/:token` and `/share/:token/md`.
+`POST /api/pages/:id/shares` creates an unguessable public token for the current snapshot and returns `{ token, snapshot_url, markdown_url }`. Use the `Share` button in the `/view/:id` snapshot header to create and copy the public URL; after creation the header also exposes `Revoke` for that share. Public share routes do not require Basic Auth, but they only expose the HTML file and resource set fixed at share creation time. Later page updates do not change the shared snapshot. Revoked shares return `404` from `/share/:token` and `/share/:token/md`.
 
 ## Project Structure
 

--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -39,7 +39,8 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		</div>`, prevLink, timelineLink, nextLink)
 	}
 
-	shareButton := fmt.Sprintf(`<button type="button" id="wayback-share-button" data-page-id="%d" style="color:white;text-decoration:none;padding:4px 12px;border:1px solid rgba(255,255,255,0.3);border-radius:4px;font-size:12px;background:rgba(255,255,255,0.1);white-space:nowrap;cursor:pointer;font-family:inherit;">Share</button>`, page.ID)
+	shareControls := fmt.Sprintf(`<button type="button" data-wayback-share-action="snapshot" data-page-id="%d" style="color:white;text-decoration:none;padding:4px 12px;border:1px solid rgba(255,255,255,0.3);border-radius:4px;font-size:12px;background:rgba(255,255,255,0.1);white-space:nowrap;cursor:pointer;font-family:inherit;">Share</button>
+		<button type="button" data-wayback-share-action="revoke" style="display:none;color:white;text-decoration:none;padding:4px 10px;border:1px solid rgba(255,255,255,0.3);border-radius:4px;font-size:12px;background:rgba(255,255,255,0.1);white-space:nowrap;cursor:pointer;font-family:inherit;">Revoke</button>`, page.ID)
 
 	// 归档信息栏 HTML
 	archiveHeader := fmt.Sprintf(`
@@ -260,66 +261,137 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		document.body.removeChild(textarea);
 	}
 
-	function initShareButton() {
-		const button = document.getElementById('wayback-share-button');
-		if (!button) return;
+	let activeShare = null;
 
-		button.addEventListener('click', async function() {
-			const pageId = button.getAttribute('data-page-id');
+	function findShareControl(action) {
+		const header = document.getElementById('wayback-archive-header');
+		if (!header) return null;
+		return header.querySelector('[data-wayback-share-action="' + action + '"]');
+	}
+
+	function setShareControlBusy(button, busy) {
+		if (!button) return;
+		button.disabled = busy;
+		button.style.opacity = busy ? '0.65' : '';
+	}
+
+	function updateShareSecondaryControls() {
+		const revokeButton = findShareControl('revoke');
+		if (revokeButton) {
+			revokeButton.style.display = activeShare && activeShare.id ? '' : 'none';
+		}
+	}
+
+	async function createArchiveShare(pageId) {
+		const response = await fetch('/api/pages/' + encodeURIComponent(pageId) + '/shares', {
+			method: 'POST',
+			headers: {'Content-Type': 'application/json'},
+			credentials: 'same-origin',
+			body: '{}'
+		});
+		const data = await response.json().catch(function() { return {}; });
+		if (!response.ok) {
+			throw new Error(data.error || ('HTTP ' + response.status));
+		}
+		if (!data.snapshot_url) {
+			throw new Error('missing snapshot_url');
+		}
+		return data;
+	}
+
+	async function copyShareURL(path, promptMessage) {
+		const shareURL = absoluteArchiveURL(path);
+		try {
+			await copyArchiveText(shareURL);
+			return 'copied';
+		} catch (copyError) {
+			window.prompt(promptMessage, shareURL);
+			return 'prompted';
+		}
+	}
+
+	function stopShareEvent(event) {
+		event.preventDefault();
+		event.stopPropagation();
+	}
+
+	function initShareControls() {
+		const shareButton = findShareControl('snapshot');
+		const revokeButton = findShareControl('revoke');
+		if (!shareButton) return;
+
+		shareButton.addEventListener('click', async function(event) {
+			stopShareEvent(event);
+			const pageId = shareButton.getAttribute('data-page-id');
 			if (!pageId) return;
 
-			const originalText = button.textContent;
-			button.disabled = true;
-			button.style.opacity = '0.65';
-			button.textContent = 'Sharing';
+			setShareControlBusy(shareButton, true);
+			shareButton.textContent = activeShare ? 'Copying' : 'Sharing';
 
 			try {
-				const response = await fetch('/api/pages/' + encodeURIComponent(pageId) + '/shares', {
-					method: 'POST',
-					headers: {'Content-Type': 'application/json'},
-					credentials: 'same-origin',
-					body: '{}'
-				});
-				const data = await response.json().catch(function() { return {}; });
-				if (!response.ok) {
-					throw new Error(data.error || ('HTTP ' + response.status));
-				}
-				if (!data.snapshot_url) {
-					throw new Error('missing snapshot_url');
+				if (!activeShare) {
+					activeShare = await createArchiveShare(pageId);
+					updateShareSecondaryControls();
 				}
 
-				const shareURL = absoluteArchiveURL(data.snapshot_url);
-				try {
-					await copyArchiveText(shareURL);
-					button.textContent = 'Copied';
-				} catch (copyError) {
-					button.textContent = 'Created';
-					window.prompt('分享已创建，请复制链接', shareURL);
-				}
-
+				const copyResult = await copyShareURL(activeShare.snapshot_url, '分享已创建，请复制链接');
+				shareButton.textContent = copyResult === 'copied' ? 'Copied' : 'Created';
 				setTimeout(function() {
-					button.textContent = originalText;
+					shareButton.textContent = 'Share';
 				}, 1600);
 			} catch (error) {
 				alert('分享失败: ' + error.message);
-				button.textContent = originalText;
+				shareButton.textContent = 'Share';
 			} finally {
-				button.disabled = false;
-				button.style.opacity = '';
+				setShareControlBusy(shareButton, false);
 			}
 		});
+
+		if (revokeButton) {
+			revokeButton.addEventListener('click', async function(event) {
+				stopShareEvent(event);
+				if (!activeShare || !activeShare.id) return;
+				if (!confirm('确定要撤销这个公开分享吗？')) return;
+
+				setShareControlBusy(revokeButton, true);
+				const originalText = revokeButton.textContent;
+				revokeButton.textContent = 'Revoking';
+
+				try {
+					const response = await fetch('/api/shares/' + encodeURIComponent(activeShare.id), {
+						method: 'DELETE',
+						credentials: 'same-origin'
+					});
+					const data = await response.json().catch(function() { return {}; });
+					if (!response.ok) {
+						throw new Error(data.error || ('HTTP ' + response.status));
+					}
+					activeShare = null;
+					updateShareSecondaryControls();
+					shareButton.textContent = 'Share';
+					revokeButton.textContent = originalText;
+				} catch (error) {
+					alert('撤销失败: ' + error.message);
+					revokeButton.textContent = originalText;
+				} finally {
+					setShareControlBusy(revokeButton, false);
+				}
+			});
+		}
+
+		updateShareSecondaryControls();
 	}
 
 	// 页面加载完成后执行
 	if (document.readyState === 'loading') {
 		document.addEventListener('DOMContentLoaded', function() {
-			initShareButton();
+			initShareControls();
 			localizeArchiveTimes();
 			fixPositionedElements();
 			forceEnableInteraction();
 		});
 	} else {
-		initShareButton();
+		initShareControls();
 		localizeArchiveTimes();
 		fixPositionedElements();
 		forceEnableInteraction();
@@ -336,7 +408,7 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 
 })();
 </script>
-	`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, shareButton, nonce)
+	`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, shareControls, nonce)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {

--- a/server/internal/api/injector.go
+++ b/server/internal/api/injector.go
@@ -39,6 +39,8 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		</div>`, prevLink, timelineLink, nextLink)
 	}
 
+	shareButton := fmt.Sprintf(`<button type="button" id="wayback-share-button" data-page-id="%d" style="color:white;text-decoration:none;padding:4px 12px;border:1px solid rgba(255,255,255,0.3);border-radius:4px;font-size:12px;background:rgba(255,255,255,0.1);white-space:nowrap;cursor:pointer;font-family:inherit;">Share</button>`, page.ID)
+
 	// 归档信息栏 HTML
 	archiveHeader := fmt.Sprintf(`
 <div id="wayback-archive-header" style="
@@ -66,6 +68,7 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		<span style="font-size:11px;opacity:0.7;white-space:nowrap;">%s</span>
 	</div>
 	<div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">
+		%s
 		%s
 		<a href="/" style="color:white;text-decoration:none;padding:4px 12px;border:1px solid rgba(255,255,255,0.3);border-radius:4px;font-size:12px;background:rgba(255,255,255,0.1);white-space:nowrap;">← Archives</a>
 	</div>
@@ -236,14 +239,87 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 		console.log('[Wayback] Text selection enabled for', allElements.length, 'elements');
 	}
 
+	function absoluteArchiveURL(path) {
+		return new URL(path, window.location.origin).toString();
+	}
+
+	async function copyArchiveText(text) {
+		if (navigator.clipboard && window.isSecureContext) {
+			await navigator.clipboard.writeText(text);
+			return;
+		}
+
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.setAttribute('readonly', '');
+		textarea.style.position = 'fixed';
+		textarea.style.left = '-9999px';
+		document.body.appendChild(textarea);
+		textarea.select();
+		document.execCommand('copy');
+		document.body.removeChild(textarea);
+	}
+
+	function initShareButton() {
+		const button = document.getElementById('wayback-share-button');
+		if (!button) return;
+
+		button.addEventListener('click', async function() {
+			const pageId = button.getAttribute('data-page-id');
+			if (!pageId) return;
+
+			const originalText = button.textContent;
+			button.disabled = true;
+			button.style.opacity = '0.65';
+			button.textContent = 'Sharing';
+
+			try {
+				const response = await fetch('/api/pages/' + encodeURIComponent(pageId) + '/shares', {
+					method: 'POST',
+					headers: {'Content-Type': 'application/json'},
+					credentials: 'same-origin',
+					body: '{}'
+				});
+				const data = await response.json().catch(function() { return {}; });
+				if (!response.ok) {
+					throw new Error(data.error || ('HTTP ' + response.status));
+				}
+				if (!data.snapshot_url) {
+					throw new Error('missing snapshot_url');
+				}
+
+				const shareURL = absoluteArchiveURL(data.snapshot_url);
+				try {
+					await copyArchiveText(shareURL);
+					button.textContent = 'Copied';
+				} catch (copyError) {
+					button.textContent = 'Created';
+					window.prompt('分享已创建，请复制链接', shareURL);
+				}
+
+				setTimeout(function() {
+					button.textContent = originalText;
+				}, 1600);
+			} catch (error) {
+				alert('分享失败: ' + error.message);
+				button.textContent = originalText;
+			} finally {
+				button.disabled = false;
+				button.style.opacity = '';
+			}
+		});
+	}
+
 	// 页面加载完成后执行
 	if (document.readyState === 'loading') {
 		document.addEventListener('DOMContentLoaded', function() {
+			initShareButton();
 			localizeArchiveTimes();
 			fixPositionedElements();
 			forceEnableInteraction();
 		});
 	} else {
+		initShareButton();
 		localizeArchiveTimes();
 		fixPositionedElements();
 		forceEnableInteraction();
@@ -260,7 +336,7 @@ func injectArchiveHeader(html string, page *models.Page, prev *models.Page, next
 
 })();
 </script>
-	`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, nonce)
+	`, escapeHTML(page.URL), escapeHTML(page.URL), escapeHTML(page.URL), archiveTimeElement(page.CapturedAt, "full"), navHTML, shareButton, nonce)
 
 	// 在 <body> 标签后注入
 	if bodyTagRe.MatchString(html) {

--- a/server/internal/api/injector_test.go
+++ b/server/internal/api/injector_test.go
@@ -51,6 +51,35 @@ func TestInjectArchiveHeader_LocalizesSnapshotTimesInBrowser(t *testing.T) {
 	}
 }
 
+func TestInjectArchiveHeader_IncludesShareButtonInSnapshotHeader(t *testing.T) {
+	page := &models.Page{
+		ID:         42,
+		URL:        "https://example.com/page",
+		CapturedAt: time.Date(2026, 4, 15, 12, 34, 56, 0, time.UTC),
+	}
+
+	got := injectArchiveHeader(`<html><body><main>hello</main></body></html>`, page, nil, nil, 1, "nonce")
+
+	for _, want := range []string{
+		`id="wayback-share-button"`,
+		`data-page-id="42"`,
+		`<script nonce="nonce">`,
+		`function initShareButton()`,
+		`button.addEventListener('click'`,
+		`fetch('/api/pages/' + encodeURIComponent(pageId) + '/shares'`,
+		`credentials: 'same-origin'`,
+		`navigator.clipboard.writeText`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing share header marker %q in %s", want, got)
+		}
+	}
+
+	if strings.Contains(got, `onclick=`) {
+		t.Fatalf("share button should not use inline event handlers: %s", got)
+	}
+}
+
 func TestInjectArchiveHeader_DoesNotIncludeCollapsedFixedLayoutRepair(t *testing.T) {
 	page := &models.Page{
 		ID:         1,

--- a/server/internal/api/injector_test.go
+++ b/server/internal/api/injector_test.go
@@ -61,12 +61,18 @@ func TestInjectArchiveHeader_IncludesShareButtonInSnapshotHeader(t *testing.T) {
 	got := injectArchiveHeader(`<html><body><main>hello</main></body></html>`, page, nil, nil, 1, "nonce")
 
 	for _, want := range []string{
-		`id="wayback-share-button"`,
+		`data-wayback-share-action="snapshot"`,
+		`data-wayback-share-action="revoke"`,
 		`data-page-id="42"`,
+		`Revoke`,
 		`<script nonce="nonce">`,
-		`function initShareButton()`,
-		`button.addEventListener('click'`,
+		`let activeShare = null`,
+		`function initShareControls()`,
+		`function updateShareSecondaryControls()`,
+		`shareButton.addEventListener('click'`,
+		`revokeButton.addEventListener('click'`,
 		`fetch('/api/pages/' + encodeURIComponent(pageId) + '/shares'`,
+		`fetch('/api/shares/' + encodeURIComponent(activeShare.id)`,
 		`credentials: 'same-origin'`,
 		`navigator.clipboard.writeText`,
 	} {
@@ -77,6 +83,10 @@ func TestInjectArchiveHeader_IncludesShareButtonInSnapshotHeader(t *testing.T) {
 
 	if strings.Contains(got, `onclick=`) {
 		t.Fatalf("share button should not use inline event handlers: %s", got)
+	}
+
+	if strings.Contains(got, `Copy MD`) || strings.Contains(got, `data-wayback-share-action="markdown"`) {
+		t.Fatalf("snapshot header should not include markdown copy controls: %s", got)
 	}
 }
 

--- a/server/internal/api/view_handler.go
+++ b/server/internal/api/view_handler.go
@@ -112,12 +112,16 @@ func (h *Handler) ViewPage(c *gin.Context) {
 	nonce := generateNonce()
 	modifiedHTML = injectArchiveHeader(modifiedHTML, page, prev, next, snapshotTotal, nonce)
 
-	// 设置安全响应头（允许带 nonce 的内联脚本，用于修复定位问题）
+	// 设置安全响应头（允许带 nonce 的内联脚本，用于修复定位和顶部栏分享）
 	c.Header("X-Frame-Options", "SAMEORIGIN")
 	c.Header("Referrer-Policy", "no-referrer")
-	c.Header("Content-Security-Policy", fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'none'; frame-src 'self'; object-src 'none';", nonce))
+	c.Header("Content-Security-Policy", viewPageContentSecurityPolicy(nonce))
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(modifiedHTML))
+}
+
+func viewPageContentSecurityPolicy(nonce string) string {
+	return fmt.Sprintf("default-src 'self'; script-src 'nonce-%s'; img-src * data: blob:; style-src 'self' 'unsafe-inline'; font-src * data:; connect-src 'self'; frame-src 'self'; object-src 'none';", nonce)
 }
 
 // ViewPageMarkdown 返回归档页面正文的 Markdown 格式（精简版，方便 AI 读取）

--- a/server/internal/api/view_page_handler_test.go
+++ b/server/internal/api/view_page_handler_test.go
@@ -51,6 +51,31 @@ func TestViewPage_DatabaseErrorReturnsInternalServerError(t *testing.T) {
 	}
 }
 
+func TestViewPageContentSecurityPolicy_AllowsOnlyNonceScriptAndSelfConnect(t *testing.T) {
+	got := viewPageContentSecurityPolicy("test-nonce")
+
+	for _, want := range []string{
+		`script-src 'nonce-test-nonce'`,
+		`connect-src 'self'`,
+		`object-src 'none'`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("CSP missing %q: %s", want, got)
+		}
+	}
+
+	for _, unwanted := range []string{
+		`script-src 'unsafe-inline'`,
+		`connect-src *`,
+		`connect-src http:`,
+		`connect-src https:`,
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("CSP contains unsafe directive %q: %s", unwanted, got)
+		}
+	}
+}
+
 func TestViewPageMarkdown_InvalidID(t *testing.T) {
 	handler, cleanup := setupTestHandler(t)
 	defer cleanup()

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -363,10 +363,7 @@
             gap: 8px;
         }
 
-        .timeline-btn,
-        .share-btn,
-        .share-md-btn,
-        .share-revoke-btn {
+        .timeline-btn {
             background: transparent;
             border: 1px solid var(--color-border);
             color: var(--color-text-dim);
@@ -382,20 +379,6 @@
             border-color: var(--color-cyan);
             color: var(--color-cyan);
             background: rgba(0, 217, 255, 0.1);
-        }
-
-        .share-btn:hover,
-        .share-btn.is-active,
-        .share-md-btn:hover {
-            border-color: var(--color-accent);
-            color: var(--color-accent);
-            background: rgba(0, 255, 136, 0.1);
-        }
-
-        .share-revoke-btn:hover {
-            border-color: #ff4444;
-            color: #ff4444;
-            background: rgba(255, 68, 68, 0.1);
         }
 
         .delete-btn {
@@ -637,7 +620,6 @@
         let domainTimer = null;
         let activeRequestController = null;
         let latestRequestSeq = 0;
-        const pageShareState = new Map();
 
         function normalizePageNumber(page) {
             const parsed = Number.parseInt(page, 10);
@@ -924,15 +906,6 @@
                 timelineBtn.textContent = 'Timeline';
                 timelineBtn.addEventListener('click', (event) => openTimeline(event, page.url));
 
-                const shareBtn = document.createElement('button');
-                shareBtn.className = 'share-btn';
-                shareBtn.type = 'button';
-                shareBtn.textContent = 'Share';
-                if (pageShareState.has(page.id)) {
-                    shareBtn.classList.add('is-active');
-                }
-                shareBtn.addEventListener('click', (event) => createShare(event, page.id, shareBtn, actions));
-
                 const deleteBtn = document.createElement('button');
                 deleteBtn.className = 'delete-btn';
                 deleteBtn.type = 'button';
@@ -953,8 +926,6 @@
                 titleGroup.appendChild(pageId);
 
                 actions.appendChild(timelineBtn);
-                actions.appendChild(shareBtn);
-                renderShareStateActions(actions, page.id);
                 actions.appendChild(deleteBtn);
 
                 header.appendChild(titleGroup);
@@ -971,7 +942,7 @@
                 item.appendChild(meta);
 
                 item.addEventListener('click', (e) => {
-                    if (e.target.closest('.page-url') || e.target.closest('.delete-btn') || e.target.closest('.timeline-btn') || e.target.closest('.share-btn') || e.target.closest('.share-md-btn') || e.target.closest('.share-revoke-btn')) {
+                    if (e.target.closest('.page-url') || e.target.closest('.delete-btn') || e.target.closest('.timeline-btn')) {
                         return;
                     }
                     window.open(`/view/${page.id}`, '_blank');
@@ -986,122 +957,6 @@
         function openTimeline(event, pageUrl) {
             event.stopPropagation();
             window.open(`/timeline?url=${encodeURIComponent(pageUrl)}`, '_blank');
-        }
-
-        function absoluteURL(path) {
-            return new URL(path, window.location.origin).toString();
-        }
-
-        async function copyText(text) {
-            if (navigator.clipboard && window.isSecureContext) {
-                await navigator.clipboard.writeText(text);
-                return;
-            }
-
-            const textarea = document.createElement('textarea');
-            textarea.value = text;
-            textarea.setAttribute('readonly', '');
-            textarea.style.position = 'fixed';
-            textarea.style.left = '-9999px';
-            document.body.appendChild(textarea);
-            textarea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textarea);
-        }
-
-        function setButtonTextTemporarily(button, text) {
-            const original = button.textContent;
-            button.textContent = text;
-            setTimeout(() => {
-                button.textContent = original;
-            }, 1600);
-        }
-
-        function renderShareStateActions(actions, pageId) {
-            const state = pageShareState.get(pageId);
-            if (!state || !state.id) {
-                return;
-            }
-
-            if (state.markdown_url) {
-                const mdBtn = document.createElement('button');
-                mdBtn.className = 'share-md-btn';
-                mdBtn.type = 'button';
-                mdBtn.textContent = 'Copy MD';
-                mdBtn.addEventListener('click', async (event) => {
-                    event.stopPropagation();
-                    try {
-                        await copyText(absoluteURL(state.markdown_url));
-                        setButtonTextTemporarily(mdBtn, 'Copied');
-                    } catch (error) {
-                        alert('复制失败: ' + error.message);
-                    }
-                });
-                actions.appendChild(mdBtn);
-            }
-
-            const revokeBtn = document.createElement('button');
-            revokeBtn.className = 'share-revoke-btn';
-            revokeBtn.type = 'button';
-            revokeBtn.textContent = 'Revoke';
-            revokeBtn.addEventListener('click', async (event) => {
-                event.stopPropagation();
-                if (!confirm('确定要撤销这个公开分享吗？')) {
-                    return;
-                }
-                try {
-                    const response = await fetch(`/api/shares/${state.id}`, {method: 'DELETE'});
-                    if (!response.ok) {
-                        const data = await response.json().catch(() => ({}));
-                        throw new Error(data.error || `HTTP ${response.status}`);
-                    }
-                    pageShareState.delete(pageId);
-                    actions.querySelectorAll('.share-md-btn, .share-revoke-btn').forEach((el) => el.remove());
-                    const shareBtn = actions.querySelector('.share-btn');
-                    if (shareBtn) {
-                        shareBtn.classList.remove('is-active');
-                        shareBtn.textContent = 'Share';
-                    }
-                } catch (error) {
-                    alert('撤销失败: ' + error.message);
-                }
-            });
-            actions.appendChild(revokeBtn);
-        }
-
-        async function createShare(event, pageId, button, actions) {
-            event.stopPropagation();
-            button.disabled = true;
-            const originalText = button.textContent;
-            button.textContent = 'Sharing';
-
-            try {
-                const response = await fetch(`/api/pages/${pageId}/shares`, {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: '{}'
-                });
-                const data = await response.json().catch(() => ({}));
-                if (!response.ok) {
-                    throw new Error(data.error || `HTTP ${response.status}`);
-                }
-
-                pageShareState.set(pageId, data);
-                await copyText(absoluteURL(data.snapshot_url));
-                button.classList.add('is-active');
-                button.textContent = 'Copied';
-
-                actions.querySelectorAll('.share-md-btn, .share-revoke-btn').forEach((el) => el.remove());
-                renderShareStateActions(actions, pageId);
-                setTimeout(() => {
-                    button.textContent = 'Share';
-                }, 1600);
-            } catch (error) {
-                alert('分享失败: ' + error.message);
-                button.textContent = originalText;
-            } finally {
-                button.disabled = false;
-            }
         }
 
         async function deletePage(event, pageId) {

--- a/skill.md
+++ b/skill.md
@@ -137,6 +137,7 @@ curl "http://localhost:8080/view/$PAGE_ID/md"
 #### Create Public Share Link
 
 Creates an unauthenticated link for one fixed snapshot. The returned token is only shown once.
+The `/view/:id` snapshot header also has a Share button that creates and copies the public URL, then exposes Revoke for that share.
 
 ```bash
 curl -X POST "http://localhost:8080/api/pages/$PAGE_ID/shares" \


### PR DESCRIPTION
## Summary
- move the Share action from the archive list into the injected snapshot header
- keep the snapshot header share flow focused on public page links: Share creates/copies the link, then Revoke appears for that created share
- avoid repeatedly creating new share tokens on subsequent Share clicks in the same snapshot page
- allow the nonce header script to call same-origin share APIs while keeping archived page scripts disabled
- update docs and focused injector coverage; Copy MD is intentionally not shown in the snapshot header

## Tests
- go test -tags fts5 ./internal/api
- make test