### PR TITLE
feat(logs): add progressive log loading

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -205,8 +205,8 @@ export https_proxy=http://127.0.0.1:7897
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | 按 URL、标题或正文分页搜索 |
 | `GET` | `/api/pages/timeline?url=URL` | 获取同一 URL 的所有快照（时间线视图） |
 | `GET` | `/api/logs` | 列出可用日志文件 |
-| `GET` | `/api/logs/latest` | 获取最新日志文件内容（支持 `?tail=N&grep=关键词`，也支持 `?limit=字节数&before=offset` / `?limit=字节数&after=offset` 渐进读取） |
-| `GET` | `/api/logs/:filename` | 获取日志文件内容（支持 `?tail=N&grep=关键词`，也支持 `?limit=字节数&before=offset` / `?limit=字节数&after=offset` 渐进读取） |
+| `GET` | `/api/logs/latest` | 获取最新日志文件内容（支持 `?tail=N&grep=关键词`，也支持 `?limit=字节数` 读取最新文件尾部） |
+| `GET` | `/api/logs/:filename` | 获取日志文件内容（支持 `?tail=N&grep=关键词`，也支持 `?limit=字节数&before=offset` / `?limit=字节数&after=offset` 渐进读取；默认分块大小为 128 KiB） |
 | `GET` | `/view/:id` | 还原归档页面 |
 | `GET` | `/view/:id/md` | 获取归档页面正文的 Markdown 格式（方便 AI/LLM 读取） |
 | `GET` | `/share/:token` | 无鉴权访问特定公开快照 |

--- a/README-zh.md
+++ b/README-zh.md
@@ -205,8 +205,8 @@ export https_proxy=http://127.0.0.1:7897
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | 按 URL、标题或正文分页搜索 |
 | `GET` | `/api/pages/timeline?url=URL` | 获取同一 URL 的所有快照（时间线视图） |
 | `GET` | `/api/logs` | 列出可用日志文件 |
-| `GET` | `/api/logs/latest` | 获取最新日志文件内容（支持 `?tail=N&grep=关键词`） |
-| `GET` | `/api/logs/:filename` | 获取日志文件内容（支持 `?tail=N&grep=关键词`） |
+| `GET` | `/api/logs/latest` | 获取最新日志文件内容（支持 `?tail=N&grep=关键词`，也支持 `?limit=字节数&before=offset` / `?limit=字节数&after=offset` 渐进读取） |
+| `GET` | `/api/logs/:filename` | 获取日志文件内容（支持 `?tail=N&grep=关键词`，也支持 `?limit=字节数&before=offset` / `?limit=字节数&after=offset` 渐进读取） |
 | `GET` | `/view/:id` | 还原归档页面 |
 | `GET` | `/view/:id/md` | 获取归档页面正文的 Markdown 格式（方便 AI/LLM 读取） |
 | `GET` | `/share/:token` | 无鉴权访问特定公开快照 |

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | Search pages by URL, title, or body text with pagination |
 | `GET` | `/api/pages/timeline?url=URL` | Get all snapshots of a URL (timeline view) |
 | `GET` | `/api/logs` | List available log files |
-| `GET` | `/api/logs/latest` | Get latest log file content (supports `?tail=N&grep=keyword`) |
-| `GET` | `/api/logs/:filename` | Get log file content (supports `?tail=N&grep=keyword`) |
+| `GET` | `/api/logs/latest` | Get latest log file content (supports `?tail=N&grep=keyword`, or progressive reads with `?limit=bytes&before=offset` / `?limit=bytes&after=offset`) |
+| `GET` | `/api/logs/:filename` | Get log file content (supports `?tail=N&grep=keyword`, or progressive reads with `?limit=bytes&before=offset` / `?limit=bytes&after=offset`) |
 | `GET` | `/view/:id` | Replay an archived page |
 | `GET` | `/view/:id/md` | Get archived page content as Markdown (for AI/LLM consumption) |
 | `GET` | `/share/:token` | Public unauthenticated access to a specific shared snapshot |

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ ENABLE_COMPRESSION: true  # Enable upload compression for remote deployment
 | `GET` | `/api/search?q=keyword&limit=50&offset=0` | Search pages by URL, title, or body text with pagination |
 | `GET` | `/api/pages/timeline?url=URL` | Get all snapshots of a URL (timeline view) |
 | `GET` | `/api/logs` | List available log files |
-| `GET` | `/api/logs/latest` | Get latest log file content (supports `?tail=N&grep=keyword`, or progressive reads with `?limit=bytes&before=offset` / `?limit=bytes&after=offset`) |
-| `GET` | `/api/logs/:filename` | Get log file content (supports `?tail=N&grep=keyword`, or progressive reads with `?limit=bytes&before=offset` / `?limit=bytes&after=offset`) |
+| `GET` | `/api/logs/latest` | Get latest log file content (supports `?tail=N&grep=keyword`, or initial progressive read with `?limit=bytes`) |
+| `GET` | `/api/logs/:filename` | Get log file content (supports `?tail=N&grep=keyword`, or progressive reads with `?limit=bytes&before=offset` / `?limit=bytes&after=offset`; default chunk size is 128 KiB) |
 | `GET` | `/view/:id` | Replay an archived page |
 | `GET` | `/view/:id/md` | Get archived page content as Markdown (for AI/LLM consumption) |
 | `GET` | `/share/:token` | Public unauthenticated access to a specific shared snapshot |

--- a/server/internal/api/log_handler.go
+++ b/server/internal/api/log_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -22,6 +23,38 @@ func parseTailQuery(c *gin.Context) (int, bool) {
 	return tail, true
 }
 
+func parseOptionalInt64Query(c *gin.Context, name string) (int64, bool, bool) {
+	raw := c.Query(name)
+	if raw == "" {
+		return 0, false, true
+	}
+
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid %s", name)})
+		return 0, false, false
+	}
+	return v, true, true
+}
+
+func parseLogRangeLimitQuery(c *gin.Context) (int64, bool) {
+	raw := c.Query("limit")
+	if raw == "" {
+		return 0, true
+	}
+
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid limit"})
+		return 0, false
+	}
+	return v, true
+}
+
+func isLogRangeRequest(c *gin.Context) bool {
+	return c.Query("before") != "" || c.Query("after") != "" || c.Query("limit") != ""
+}
+
 func logReadStatus(err error) int {
 	if err == nil {
 		return http.StatusOK
@@ -38,6 +71,66 @@ func logReadStatus(err error) int {
 	}
 }
 
+func (h *Handler) getLogRange(c *gin.Context, filename string) {
+	before, hasBefore, ok := parseOptionalInt64Query(c, "before")
+	if !ok {
+		return
+	}
+	after, hasAfter, ok := parseOptionalInt64Query(c, "after")
+	if !ok {
+		return
+	}
+	if hasBefore && hasAfter {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "before and after cannot be used together"})
+		return
+	}
+	limit, ok := parseLogRangeLimitQuery(c)
+	if !ok {
+		return
+	}
+
+	var beforePtr, afterPtr *int64
+	if hasBefore {
+		beforePtr = &before
+	}
+	if hasAfter {
+		afterPtr = &after
+	}
+
+	result, err := h.logger.ReadLogRange(filename, beforePtr, afterPtr, limit)
+	if err != nil {
+		c.JSON(logReadStatus(err), gin.H{"error": err.Error()})
+		return
+	}
+
+	content := result.Content
+	if grep := c.Query("grep"); grep != "" {
+		content = filterLogContent(content, grep)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"content":         content,
+		"filename":        filename,
+		"start_offset":    result.StartOffset,
+		"end_offset":      result.EndOffset,
+		"file_size":       result.FileSize,
+		"has_more_before": result.HasMoreBefore,
+		"has_more_after":  result.HasMoreAfter,
+	})
+}
+
+func filterLogContent(content, grep string) string {
+	lines := strings.Split(content, "\n")
+	var filtered []string
+	lowerGrep := strings.ToLower(grep)
+	for _, line := range lines {
+		if strings.Contains(strings.ToLower(line), lowerGrep) {
+			filtered = append(filtered, line)
+		}
+	}
+	return strings.Join(filtered, "\n")
+}
+
 // ListLogs returns available log files.
 func (h *Handler) ListLogs(c *gin.Context) {
 	files, err := h.logger.ListLogFiles()
@@ -51,6 +144,11 @@ func (h *Handler) ListLogs(c *gin.Context) {
 // GetLog returns the content of a specific log file.
 func (h *Handler) GetLog(c *gin.Context) {
 	filename := c.Param("filename")
+	if isLogRangeRequest(c) {
+		h.getLogRange(c, filename)
+		return
+	}
+
 	tail, ok := parseTailQuery(c)
 	if !ok {
 		return
@@ -64,15 +162,7 @@ func (h *Handler) GetLog(c *gin.Context) {
 
 	// Server-side grep filtering
 	if grep := c.Query("grep"); grep != "" {
-		lines := strings.Split(content, "\n")
-		var filtered []string
-		lowerGrep := strings.ToLower(grep)
-		for _, line := range lines {
-			if strings.Contains(strings.ToLower(line), lowerGrep) {
-				filtered = append(filtered, line)
-			}
-		}
-		content = strings.Join(filtered, "\n")
+		content = filterLogContent(content, grep)
 	}
 
 	c.JSON(http.StatusOK, gin.H{"content": content, "filename": filename})
@@ -89,6 +179,11 @@ func (h *Handler) GetLatestLog(c *gin.Context) {
 	// files are sorted newest first
 	latest := files[0].Name
 
+	if isLogRangeRequest(c) {
+		h.getLogRange(c, latest)
+		return
+	}
+
 	tail, ok := parseTailQuery(c)
 	if !ok {
 		return
@@ -102,15 +197,7 @@ func (h *Handler) GetLatestLog(c *gin.Context) {
 
 	// Server-side grep filtering
 	if grep := c.Query("grep"); grep != "" {
-		lines := strings.Split(content, "\n")
-		var filtered []string
-		lowerGrep := strings.ToLower(grep)
-		for _, line := range lines {
-			if strings.Contains(strings.ToLower(line), lowerGrep) {
-				filtered = append(filtered, line)
-			}
-		}
-		content = strings.Join(filtered, "\n")
+		content = filterLogContent(content, grep)
 	}
 
 	c.JSON(http.StatusOK, gin.H{"content": content, "filename": latest})

--- a/server/internal/api/log_handler.go
+++ b/server/internal/api/log_handler.go
@@ -180,6 +180,10 @@ func (h *Handler) GetLatestLog(c *gin.Context) {
 	latest := files[0].Name
 
 	if isLogRangeRequest(c) {
+		if c.Query("before") != "" || c.Query("after") != "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "before/after offsets require an explicit log filename"})
+			return
+		}
 		h.getLogRange(c, latest)
 		return
 	}

--- a/server/internal/api/log_handler_test.go
+++ b/server/internal/api/log_handler_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -85,5 +86,80 @@ func TestGetLog_SymlinkReturnsInternalServerError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500 for symlink log file, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetLogRange_ReturnsOffsets(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	filename := "wayback-2099-04-15.001.log"
+	content := "one\ntwo\nthree\nfour\n"
+	path := filepath.Join(handler.logger.Dir(), filename)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/"+filename+"?limit=11", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Content       string `json:"content"`
+		Filename      string `json:"filename"`
+		StartOffset   int64  `json:"start_offset"`
+		EndOffset     int64  `json:"end_offset"`
+		FileSize      int64  `json:"file_size"`
+		HasMoreBefore bool   `json:"has_more_before"`
+		HasMoreAfter  bool   `json:"has_more_after"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if body.Filename != filename {
+		t.Fatalf("unexpected filename: %s", body.Filename)
+	}
+	if body.Content != "three\nfour\n" {
+		t.Fatalf("unexpected content: %q", body.Content)
+	}
+	if body.StartOffset != int64(len("one\ntwo\n")) || body.EndOffset != int64(len(content)) || body.FileSize != int64(len(content)) {
+		t.Fatalf("unexpected offsets: start=%d end=%d size=%d", body.StartOffset, body.EndOffset, body.FileSize)
+	}
+	if !body.HasMoreBefore || body.HasMoreAfter {
+		t.Fatalf("unexpected more flags: before=%v after=%v", body.HasMoreBefore, body.HasMoreAfter)
+	}
+}
+
+func TestGetLogRange_InvalidBeforeReturnsBadRequest(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/latest?before=-1&limit=1024", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid before, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetLogRange_BeforeAndAfterReturnsBadRequest(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/latest?before=10&after=20&limit=1024", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for before and after, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/server/internal/api/log_handler_test.go
+++ b/server/internal/api/log_handler_test.go
@@ -163,3 +163,17 @@ func TestGetLogRange_BeforeAndAfterReturnsBadRequest(t *testing.T) {
 		t.Fatalf("expected 400 for before and after, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestGetLatestLogRange_OffsetRequiresExplicitFilename(t *testing.T) {
+	handler, cleanup := setupLogTestHandler(t)
+	defer cleanup()
+
+	router := setupLogRouter(handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/latest?after=10&limit=1024", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for latest offset range, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/logging/logger.go
+++ b/server/internal/logging/logger.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -23,16 +24,22 @@ const (
 	maxLogSize    = 10 * 1024 * 1024 // 10MB per file
 )
 
+const (
+	defaultLogRangeLimit = 256 * 1024
+	maxLogRangeLimit     = 1024 * 1024
+	maxReadSize          = 50 * 1024 * 1024
+)
+
 // Logger manages log file rotation and cleanup.
 type Logger struct {
-	dir      string
-	mu       sync.Mutex
-	file     *os.File
-	curDate  string
-	curSeq   int
-	curSize  atomic.Int64
-	stopCh   chan struct{}
-	writer   io.Writer
+	dir     string
+	mu      sync.Mutex
+	file    *os.File
+	curDate string
+	curSeq  int
+	curSize atomic.Int64
+	stopCh  chan struct{}
+	writer  io.Writer
 }
 
 // Setup initializes the logging system: creates log dir, opens today's
@@ -245,6 +252,15 @@ type LogFileInfo struct {
 	Date string `json:"date"`
 }
 
+type LogRangeResult struct {
+	Content       string `json:"content"`
+	StartOffset   int64  `json:"start_offset"`
+	EndOffset     int64  `json:"end_offset"`
+	FileSize      int64  `json:"file_size"`
+	HasMoreBefore bool   `json:"has_more_before"`
+	HasMoreAfter  bool   `json:"has_more_after"`
+}
+
 func (l *Logger) ListLogFiles() ([]LogFileInfo, error) {
 	entries, err := os.ReadDir(l.dir)
 	if err != nil {
@@ -283,29 +299,9 @@ func (l *Logger) ListLogFiles() ([]LogFileInfo, error) {
 
 // ReadLogFile reads the last N lines of a log file.
 func (l *Logger) ReadLogFile(filename string, tail int) (string, error) {
-	// Sanitize filename to prevent path traversal
-	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
-		return "", fmt.Errorf("invalid filename")
-	}
-	if !strings.HasPrefix(filename, filePrefix) || !strings.HasSuffix(filename, fileSuffix) {
-		return "", fmt.Errorf("invalid log filename")
-	}
-
-	path := filepath.Join(l.dir, filename)
-
-	// Check for symlink to prevent symlink attacks
-	info, err := os.Lstat(path)
+	path, _, err := l.checkedLogFile(filename)
 	if err != nil {
 		return "", err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return "", fmt.Errorf("symlink not allowed")
-	}
-
-	// Limit file size to prevent OOM attacks (now per-file limit is 10MB, so this is extra safety)
-	const maxReadSize = 50 * 1024 * 1024 // 50MB
-	if info.Size() > maxReadSize {
-		return "", fmt.Errorf("log file too large")
 	}
 
 	data, err := os.ReadFile(path)
@@ -326,4 +322,149 @@ func (l *Logger) ReadLogFile(filename string, tail int) (string, error) {
 		lines = lines[len(lines)-tail:]
 	}
 	return strings.Join(lines, "\n"), nil
+}
+
+// ReadLogRange reads a bounded byte range for progressive log viewing.
+// If after is set, it reads forward from that byte offset.
+// Otherwise it reads backward before the provided offset, or from EOF when before is nil.
+func (l *Logger) ReadLogRange(filename string, before, after *int64, limit int64) (*LogRangeResult, error) {
+	if before != nil && after != nil {
+		return nil, fmt.Errorf("before and after cannot be used together")
+	}
+	if before != nil && *before < 0 {
+		return nil, fmt.Errorf("invalid before")
+	}
+	if after != nil && *after < 0 {
+		return nil, fmt.Errorf("invalid after")
+	}
+	if limit <= 0 {
+		limit = defaultLogRangeLimit
+	}
+	if limit > maxLogRangeLimit {
+		limit = maxLogRangeLimit
+	}
+
+	path, info, err := l.checkedLogFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	size := info.Size()
+	start, end := rangeBounds(size, before, after, limit)
+	if end <= start {
+		return &LogRangeResult{
+			Content:       "",
+			StartOffset:   start,
+			EndOffset:     end,
+			FileSize:      size,
+			HasMoreBefore: start > 0,
+			HasMoreAfter:  end < size,
+		}, nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	data := make([]byte, end-start)
+	n, err := f.ReadAt(data, start)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	data = data[:n]
+	end = start + int64(n)
+
+	// Backward chunks should begin at a line boundary when possible, so prepending
+	// older logs does not duplicate or display chopped lines between chunks.
+	if after == nil && start > 0 && len(data) > 0 {
+		lineBoundary, err := isLineBoundary(f, start)
+		if err != nil {
+			return nil, err
+		}
+		if !lineBoundary {
+			if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+				drop := idx + 1
+				if drop < len(data) {
+					data = data[drop:]
+					start += int64(drop)
+				}
+			}
+		}
+	}
+
+	return &LogRangeResult{
+		Content:       string(data),
+		StartOffset:   start,
+		EndOffset:     end,
+		FileSize:      size,
+		HasMoreBefore: start > 0,
+		HasMoreAfter:  end < size,
+	}, nil
+}
+
+func (l *Logger) checkedLogFile(filename string) (string, os.FileInfo, error) {
+	// Sanitize filename to prevent path traversal.
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+		return "", nil, fmt.Errorf("invalid filename")
+	}
+	if !strings.HasPrefix(filename, filePrefix) || !strings.HasSuffix(filename, fileSuffix) {
+		return "", nil, fmt.Errorf("invalid log filename")
+	}
+
+	path := filepath.Join(l.dir, filename)
+
+	// Check for symlink to prevent symlink attacks.
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", nil, fmt.Errorf("symlink not allowed")
+	}
+
+	// Per-file rotation is 10MB; keep a larger guard for unexpected files.
+	if info.Size() > maxReadSize {
+		return "", nil, fmt.Errorf("log file too large")
+	}
+
+	return path, info, nil
+}
+
+func rangeBounds(size int64, before, after *int64, limit int64) (int64, int64) {
+	if after != nil {
+		start := *after
+		if start > size {
+			start = size
+		}
+		end := start + limit
+		if end > size {
+			end = size
+		}
+		return start, end
+	}
+
+	end := size
+	if before != nil && *before < end {
+		end = *before
+	}
+	start := end - limit
+	if start < 0 {
+		start = 0
+	}
+	return start, end
+}
+
+func isLineBoundary(f *os.File, offset int64) (bool, error) {
+	if offset <= 0 {
+		return true, nil
+	}
+
+	var prev [1]byte
+	_, err := f.ReadAt(prev[:], offset-1)
+	if err != nil {
+		return false, err
+	}
+	return prev[0] == '\n', nil
 }

--- a/server/internal/logging/logger.go
+++ b/server/internal/logging/logger.go
@@ -25,7 +25,7 @@ const (
 )
 
 const (
-	defaultLogRangeLimit = 256 * 1024
+	defaultLogRangeLimit = 128 * 1024
 	maxLogRangeLimit     = 1024 * 1024
 	maxReadSize          = 50 * 1024 * 1024
 )
@@ -376,9 +376,21 @@ func (l *Logger) ReadLogRange(filename string, before, after *int64, limit int64
 	data = data[:n]
 	end = start + int64(n)
 
-	// Backward chunks should begin at a line boundary when possible, so prepending
-	// older logs does not duplicate or display chopped lines between chunks.
-	if after == nil && start > 0 && len(data) > 0 {
+	if after != nil {
+		// Forward chunks should end at a line boundary when possible, so polling
+		// newly appended logs does not split ordinary log lines across requests.
+		if end < size {
+			if idx := bytes.LastIndexByte(data, '\n'); idx >= 0 {
+				keep := idx + 1
+				if keep > 0 {
+					data = data[:keep]
+					end = start + int64(keep)
+				}
+			}
+		}
+	} else if start > 0 && len(data) > 0 {
+		// Backward chunks should begin at a line boundary when possible, so prepending
+		// older logs does not duplicate or display chopped lines between chunks.
 		lineBoundary, err := isLineBoundary(f, start)
 		if err != nil {
 			return nil, err

--- a/server/internal/logging/logger_test.go
+++ b/server/internal/logging/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -273,6 +274,109 @@ func TestRepeatedSizeRotationNoEmptyFiles(t *testing.T) {
 	}
 }
 
+func TestReadLogRangeBackwardChunks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logger, err := Setup(tmpDir)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+	defer logger.Close()
+
+	content := "line-1\nline-2\nline-3\nline-4\n"
+	if _, err := logger.writer.Write([]byte(content)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	filename := filepath.Base(logger.file.Name())
+	latest, err := logger.ReadLogRange(filename, nil, nil, 14)
+	if err != nil {
+		t.Fatalf("ReadLogRange latest failed: %v", err)
+	}
+	if latest.Content != "line-3\nline-4\n" {
+		t.Fatalf("unexpected latest content: %q", latest.Content)
+	}
+	if latest.StartOffset != 14 || latest.EndOffset != int64(len(content)) {
+		t.Fatalf("unexpected latest offsets: start=%d end=%d", latest.StartOffset, latest.EndOffset)
+	}
+	if !latest.HasMoreBefore || latest.HasMoreAfter {
+		t.Fatalf("unexpected latest more flags: before=%v after=%v", latest.HasMoreBefore, latest.HasMoreAfter)
+	}
+
+	before := latest.StartOffset
+	older, err := logger.ReadLogRange(filename, &before, nil, 14)
+	if err != nil {
+		t.Fatalf("ReadLogRange older failed: %v", err)
+	}
+	if older.Content+latest.Content != content {
+		t.Fatalf("chunks did not reconstruct content: %q + %q", older.Content, latest.Content)
+	}
+	if older.StartOffset != 0 || older.EndOffset != before {
+		t.Fatalf("unexpected older offsets: start=%d end=%d", older.StartOffset, older.EndOffset)
+	}
+	if older.HasMoreBefore || !older.HasMoreAfter {
+		t.Fatalf("unexpected older more flags: before=%v after=%v", older.HasMoreBefore, older.HasMoreAfter)
+	}
+}
+
+func TestReadLogRangeAfterOffset(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logger, err := Setup(tmpDir)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+	defer logger.Close()
+
+	content := "line-1\nline-2\nline-3\n"
+	if _, err := logger.writer.Write([]byte(content)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	filename := filepath.Base(logger.file.Name())
+	after := int64(len("line-1\n"))
+	result, err := logger.ReadLogRange(filename, nil, &after, int64(len("line-2\n")))
+	if err != nil {
+		t.Fatalf("ReadLogRange after failed: %v", err)
+	}
+	if result.Content != "line-2\n" {
+		t.Fatalf("unexpected content after offset: %q", result.Content)
+	}
+	if result.StartOffset != after || result.EndOffset != after+int64(len("line-2\n")) {
+		t.Fatalf("unexpected offsets: start=%d end=%d", result.StartOffset, result.EndOffset)
+	}
+	if !result.HasMoreBefore || !result.HasMoreAfter {
+		t.Fatalf("unexpected more flags: before=%v after=%v", result.HasMoreBefore, result.HasMoreAfter)
+	}
+}
+
+func TestReadLogRangeSkipsPartialFirstLineWhenPossible(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logger, err := Setup(tmpDir)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+	defer logger.Close()
+
+	content := "aaa\nbbb\nccc\n"
+	if _, err := logger.writer.Write([]byte(content)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	filename := filepath.Base(logger.file.Name())
+	result, err := logger.ReadLogRange(filename, nil, nil, 7)
+	if err != nil {
+		t.Fatalf("ReadLogRange failed: %v", err)
+	}
+	if result.Content != "ccc\n" {
+		t.Fatalf("expected partial first line to be skipped, got %q", result.Content)
+	}
+	if result.StartOffset != int64(len("aaa\nbbb\n")) {
+		t.Fatalf("unexpected start offset: %d", result.StartOffset)
+	}
+}
+
 // TestNoDeadlock_ConcurrentLogAndRotate 模拟午夜死锁场景：
 // rotate() 持有 l.mu 并调用 log.SetOutput()，与此同时 log.Printf 通过
 // sizeTrackingWriter.Write 尝试获取 l.mu → 使用 atomic 前会死锁。
@@ -327,4 +431,3 @@ func TestNoDeadlock_ConcurrentLogAndRotate(t *testing.T) {
 		t.Fatal("DEADLOCK detected: concurrent log.Printf and rotate() blocked for 5 seconds")
 	}
 }
-

--- a/server/internal/logging/logger_test.go
+++ b/server/internal/logging/logger_test.go
@@ -350,6 +350,37 @@ func TestReadLogRangeAfterOffset(t *testing.T) {
 	}
 }
 
+func TestReadLogRangeAfterStopsAtLineBoundary(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logger, err := Setup(tmpDir)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+	defer logger.Close()
+
+	content := "line-1\nline-2\nline-3\n"
+	if _, err := logger.writer.Write([]byte(content)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	filename := filepath.Base(logger.file.Name())
+	after := int64(len("line-1\n"))
+	result, err := logger.ReadLogRange(filename, nil, &after, int64(len("line-2\nlin")))
+	if err != nil {
+		t.Fatalf("ReadLogRange after failed: %v", err)
+	}
+	if result.Content != "line-2\n" {
+		t.Fatalf("expected forward chunk to stop at line boundary, got %q", result.Content)
+	}
+	if result.StartOffset != after || result.EndOffset != after+int64(len("line-2\n")) {
+		t.Fatalf("unexpected offsets: start=%d end=%d", result.StartOffset, result.EndOffset)
+	}
+	if !result.HasMoreBefore || !result.HasMoreAfter {
+		t.Fatalf("unexpected more flags: before=%v after=%v", result.HasMoreBefore, result.HasMoreAfter)
+	}
+}
+
 func TestReadLogRangeSkipsPartialFirstLineWhenPossible(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/server/web/logs.html
+++ b/server/web/logs.html
@@ -155,11 +155,25 @@
         </div>
     </div>
     <script>
+        const LOG_CHUNK_LIMIT = 256 * 1024;
+        const TOP_LOAD_THRESHOLD = 48;
+
         let currentFile = null;
         let autoScroll = true;
         let filterText = '';
         let refreshTimer = null;
         let userScrolling = false;
+        let logRequestSeq = 0;
+        let loadingBefore = false;
+        let loadingAfter = false;
+        let logLines = [];
+        let logState = {
+            startOffset: 0,
+            endOffset: 0,
+            fileSize: 0,
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        };
 
         async function loadFileList() {
             try {
@@ -204,25 +218,67 @@
         }
 
         async function selectFile(filename) {
+            stopAutoRefresh();
             currentFile = filename;
+            logRequestSeq++;
+            resetLogState();
             document.querySelectorAll('.file-item').forEach(el => el.classList.remove('active'));
             document.querySelectorAll('.file-item').forEach(el => {
                 if (el.getAttribute('data-filename') === filename) {
                     el.classList.add('active');
                 }
             });
-            await loadLogContent();
+            await loadInitialLog();
             if (autoScroll) startAutoRefresh();
         }
 
-        async function loadLogContent() {
+        function resetLogState() {
+            loadingBefore = false;
+            loadingAfter = false;
+            logLines = [];
+            logState = {
+                startOffset: 0,
+                endOffset: 0,
+                fileSize: 0,
+                hasMoreBefore: false,
+                hasMoreAfter: false
+            };
+        }
+
+        async function fetchLogRange(params = {}) {
+            const query = new URLSearchParams();
+            query.set('limit', String(LOG_CHUNK_LIMIT));
+            if (params.before !== undefined) query.set('before', String(params.before));
+            if (params.after !== undefined) query.set('after', String(params.after));
+
+            const res = await fetch(`/api/logs/${encodeURIComponent(currentFile)}?${query.toString()}`);
+            if (!res.ok) throw new Error(`load log failed: ${res.status}`);
+            return res.json();
+        }
+
+        async function loadInitialLog() {
             if (!currentFile) return;
+            const requestSeq = logRequestSeq;
+            const viewer = document.getElementById('logViewer');
+            viewer.innerHTML = '<div class="empty-state">Loading...</div>';
+
             try {
-                const res = await fetch(`/api/logs/${encodeURIComponent(currentFile)}?tail=2000`);
-                const data = await res.json();
-                renderLog(data.content || '');
+                const data = await fetchLogRange();
+                if (requestSeq !== logRequestSeq) return;
+
+                logState.startOffset = Number(data.start_offset || 0);
+                logState.endOffset = Number(data.end_offset || 0);
+                logState.fileSize = Number(data.file_size || 0);
+                logState.hasMoreBefore = Boolean(data.has_more_before);
+                logState.hasMoreAfter = Boolean(data.has_more_after);
+                logLines = parseLogLines(data.content || '');
+
+                renderLoadedLines();
+                scrollToBottom();
             } catch (e) {
-                document.getElementById('logViewer').innerHTML = '<div class="empty-state">Failed to load log</div>';
+                if (requestSeq === logRequestSeq) {
+                    viewer.innerHTML = '<div class="empty-state">Failed to load log</div>';
+                }
             }
         }
 
@@ -238,27 +294,180 @@
             return '';
         }
 
-        function renderLog(content) {
-            const viewer = document.getElementById('logViewer');
+        function parseLogLines(content) {
+            if (!content) return [];
             const lines = content.split('\n');
-            const filtered = filterText
-                ? lines.filter(l => l.toLowerCase().includes(filterText.toLowerCase()))
-                : lines;
+            if (lines.length > 0 && lines[lines.length - 1] === '') {
+                lines.pop();
+            }
+            return lines;
+        }
 
-            viewer.innerHTML = filtered.map(line => {
-                let html = escapeHtml(line);
-                if (filterText) {
-                    const re = new RegExp('(' + escapeRegex(filterText) + ')', 'gi');
-                    html = html.replace(re, '<span class="highlight">$1</span>');
+        function lineMatchesFilter(line) {
+            return !filterText || line.toLowerCase().includes(filterText.toLowerCase());
+        }
+
+        function createLogLine(line) {
+            const row = document.createElement('div');
+            row.className = 'log-line';
+            const cls = classifyLine(line);
+            if (cls) row.classList.add(cls);
+
+            if (!filterText) {
+                row.textContent = line;
+                return row;
+            }
+
+            appendHighlightedText(row, line, filterText);
+            return row;
+        }
+
+        function appendHighlightedText(row, line, term) {
+            const lowerLine = line.toLowerCase();
+            const lowerTerm = term.toLowerCase();
+            let pos = 0;
+
+            while (true) {
+                const idx = lowerLine.indexOf(lowerTerm, pos);
+                if (idx === -1) break;
+                if (idx > pos) {
+                    row.appendChild(document.createTextNode(line.slice(pos, idx)));
                 }
-                const cls = classifyLine(line);
-                return `<div class="log-line${cls ? ' ' + cls : ''}">${html}</div>`;
-            }).join('');
 
-            if (autoScroll) {
-                userScrolling = true;
-                viewer.scrollTop = viewer.scrollHeight;
+                const mark = document.createElement('span');
+                mark.className = 'highlight';
+                mark.textContent = line.slice(idx, idx + term.length);
+                row.appendChild(mark);
+                pos = idx + term.length;
+            }
+
+            if (pos < line.length) {
+                row.appendChild(document.createTextNode(line.slice(pos)));
+            }
+        }
+
+        function createLogFragment(lines) {
+            const fragment = document.createDocumentFragment();
+            let count = 0;
+            lines.forEach(line => {
+                if (!lineMatchesFilter(line)) return;
+                fragment.appendChild(createLogLine(line));
+                count++;
+            });
+            return { fragment, count };
+        }
+
+        function hasOnlyEmptyState(viewer) {
+            return viewer.children.length === 1 && viewer.firstElementChild.classList.contains('empty-state');
+        }
+
+        function renderLoadedLines() {
+            const viewer = document.getElementById('logViewer');
+            const { fragment, count } = createLogFragment(logLines);
+            viewer.innerHTML = '';
+            if (count === 0) {
+                const message = filterText ? 'No matching log lines in loaded range' : 'No logs';
+                viewer.innerHTML = `<div class="empty-state">${message}</div>`;
+                return;
+            }
+            viewer.appendChild(fragment);
+        }
+
+        function prependLogLines(lines) {
+            if (lines.length === 0) return;
+            logLines = lines.concat(logLines);
+
+            const viewer = document.getElementById('logViewer');
+            const { fragment, count } = createLogFragment(lines);
+            if (count === 0) return;
+
+            if (hasOnlyEmptyState(viewer)) {
+                viewer.innerHTML = '';
+                viewer.appendChild(fragment);
+                return;
+            }
+
+            const oldHeight = viewer.scrollHeight;
+            const oldTop = viewer.scrollTop;
+            viewer.prepend(fragment);
+            setProgrammaticScroll(() => {
+                viewer.scrollTop = oldTop + (viewer.scrollHeight - oldHeight);
+            });
+        }
+
+        function appendLogLines(lines) {
+            if (lines.length === 0) return;
+            logLines.push(...lines);
+
+            const viewer = document.getElementById('logViewer');
+            const { fragment, count } = createLogFragment(lines);
+            if (count === 0) return;
+
+            if (hasOnlyEmptyState(viewer)) {
+                viewer.innerHTML = '';
+            }
+            viewer.appendChild(fragment);
+            if (autoScroll) scrollToBottom();
+        }
+
+        function setProgrammaticScroll(fn) {
+            userScrolling = true;
+            fn();
+            requestAnimationFrame(() => {
                 userScrolling = false;
+            });
+        }
+
+        function scrollToBottom() {
+            const viewer = document.getElementById('logViewer');
+            setProgrammaticScroll(() => {
+                viewer.scrollTop = viewer.scrollHeight;
+            });
+        }
+
+        async function loadOlderLogs() {
+            if (!currentFile || loadingBefore || !logState.hasMoreBefore) return;
+
+            const requestSeq = logRequestSeq;
+            loadingBefore = true;
+            try {
+                const data = await fetchLogRange({ before: logState.startOffset });
+                if (requestSeq !== logRequestSeq) return;
+
+                logState.startOffset = Number(data.start_offset || 0);
+                logState.fileSize = Number(data.file_size || logState.fileSize);
+                logState.hasMoreBefore = Boolean(data.has_more_before);
+                prependLogLines(parseLogLines(data.content || ''));
+            } catch (e) {
+                // Keep the current view stable; a later scroll/refresh can retry.
+            } finally {
+                if (requestSeq === logRequestSeq) loadingBefore = false;
+            }
+        }
+
+        async function loadNewLogs() {
+            if (!currentFile || loadingAfter) return;
+
+            const requestSeq = logRequestSeq;
+            loadingAfter = true;
+            try {
+                const data = await fetchLogRange({ after: logState.endOffset });
+                if (requestSeq !== logRequestSeq) return;
+
+                const nextEnd = Number(data.end_offset || 0);
+                if (nextEnd < logState.endOffset) {
+                    await loadInitialLog();
+                    return;
+                }
+
+                logState.endOffset = nextEnd;
+                logState.fileSize = Number(data.file_size || logState.fileSize);
+                logState.hasMoreAfter = Boolean(data.has_more_after);
+                appendLogLines(parseLogLines(data.content || ''));
+            } catch (e) {
+                // Auto refresh is best-effort; keep the existing log visible.
+            } finally {
+                if (requestSeq === logRequestSeq) loadingAfter = false;
             }
         }
 
@@ -267,10 +476,7 @@
             const btn = document.getElementById('autoScrollBtn');
             btn.classList.toggle('active', autoScroll);
             if (autoScroll) {
-                const viewer = document.getElementById('logViewer');
-                userScrolling = true;
-                viewer.scrollTop = viewer.scrollHeight;
-                userScrolling = false;
+                scrollToBottom();
                 startAutoRefresh();
             } else {
                 stopAutoRefresh();
@@ -279,16 +485,18 @@
 
         function startAutoRefresh() {
             stopAutoRefresh();
-            refreshTimer = setInterval(() => loadLogContent(), 3000);
+            refreshTimer = setInterval(() => loadNewLogs(), 3000);
         }
 
         function stopAutoRefresh() {
             if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
         }
 
-        function refreshLog() {
-            loadFileList();
-            loadLogContent();
+        async function refreshLog() {
+            await loadFileList();
+            if (currentFile) {
+                await loadNewLogs();
+            }
         }
 
         // Detect user scroll: disable auto-scroll when scrolling up, re-enable when at bottom
@@ -296,6 +504,9 @@
             if (userScrolling) return; // ignore programmatic scrolls
             const viewer = document.getElementById('logViewer');
             const atBottom = viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight < 30;
+            if (viewer.scrollTop < TOP_LOAD_THRESHOLD) {
+                loadOlderLogs();
+            }
             if (atBottom && !autoScroll) {
                 autoScroll = true;
                 document.getElementById('autoScrollBtn').classList.add('active');
@@ -308,24 +519,17 @@
         });
 
         document.getElementById('filterInput').addEventListener('input', (e) => {
+            const viewer = document.getElementById('logViewer');
+            const wasAtBottom = viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight < 30;
             filterText = e.target.value;
-            loadLogContent();
+            renderLoadedLines();
+            if (wasAtBottom) scrollToBottom();
         });
 
         function formatSize(bytes) {
             if (bytes < 1024) return bytes + ' B';
             if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
             return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-        }
-
-        function escapeHtml(text) {
-            const d = document.createElement('div');
-            d.textContent = text;
-            return d.innerHTML;
-        }
-
-        function escapeRegex(str) {
-            return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         }
 
         loadFileList();

--- a/server/web/logs.html
+++ b/server/web/logs.html
@@ -155,7 +155,7 @@
         </div>
     </div>
     <script>
-        const LOG_CHUNK_LIMIT = 256 * 1024;
+        const LOG_CHUNK_LIMIT = 128 * 1024;
         const TOP_LOAD_THRESHOLD = 48;
 
         let currentFile = null;


### PR DESCRIPTION
## Summary
- add byte cursor log reads with limit/before/after while keeping tail compatible
- update the logs viewer to incrementally prepend older chunks and append new chunks without full redraw
- document the progressive log API and cover range reads with tests

## Tests
- node --check <logs.html script>
- git diff --check
- make test